### PR TITLE
docs(agents): flujo GitFlow-lite en AGENTS.md + CLAUDE.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@
 > **Estado (v0.3): Hitos 0–6 + 1.5 construidos y tanda de remediación R1–R5 COMPLETA** tras el
 > red-team de la Nota 06 y el modelo nuevo (ADR 0022/0023; el producto **no usa IA generativa** —
 > el desarrollo SÍ es asistido por IA, pero el scent es bibliométrico determinista). **Próximo:
-> Hito 7 (dedup fuzzy).** Ver `docs/ROADMAP.md` y "Estado actual" abajo. El diseño objetivo vive en
+> Hito 7 (dedup fuzzy).** Ver `docs/ROADMAP/` y "Estado actual" abajo. El diseño objetivo vive en
 > `docs/ARCHITECTURE.md`; los contratos
 > públicos en `docs/API.md`; el producto en `docs/PRD.md`; las reglas que motivan este código en
 > `docs/Notas/01-lecciones-v0.md`. Las decisiones vigentes tras **el giro** son los ADR
@@ -40,10 +40,10 @@
   transversal en `status`; **R4** — **scent bibliométrico vía proyectores**, **el producto NO usa
   IA generativa** (se eliminaron `foraging/explain.py`, `explain_candidate`, el extra `[llm]` y la
   "máquina de tensiones"); **R5** — robustez (bulk-load, UTF-8 en la frontera, retry, footguns).
-  Ver `docs/ROADMAP.md` (Hitos R1–R5). **PRÓXIMO: Hito 7** (dedup fuzzy `[dedup]`). El entorno se
+  Ver `docs/ROADMAP/` (Hitos R1–R5). **PRÓXIMO: Hito 7** (dedup fuzzy `[dedup]`). El entorno se
   levanta con `uv sync`.
 - Toda la información del producto, la arquitectura, los contratos y la secuencia de
-  construcción está en `docs/`. **Leer `docs/ROADMAP.md` antes de tocar nada**: cada hito declara
+  construcción está en `docs/`. **Leer `docs/ROADMAP/` antes de tocar nada**: cada hito declara
   qué historias del PRD §7 cumple, sus criterios de aceptación (DoD) y los tests TDD que se
   escriben. El orden es deliberado (núcleo puro → costura local DuckDB → costura red OpenAlex →
   forrajeo → CLI → opcionales).
@@ -59,6 +59,41 @@
   BibTeX es `Source` secundaria. El enricher S2 ya **no es estructural**.
 - **El CLI es la API para LLM/agentes** (Hito 6). Subprocess + JSON stdout, exit codes
   claros, sin estado entre invocaciones (el estado vive en DuckDB).
+
+## Flujo de trabajo (ramas dev/main) — LEER ANTES DE TOCAR GIT
+
+Modelo **GitFlow-lite** con dos ramas protegidas (PR + CI verde obligatorios; nunca
+pushear directo). Detalle en [`CONTRIBUTING.md`](CONTRIBUTING.md) §Modelo de ramas.
+
+- **`dev`** — rama de **integración** y **default del repo**. Acá se **acumula** el trabajo.
+  Protección no-estricta.
+- **`main`** — rama **estable / de release**. Solo recibe `dev` al liberar y el PR de release.
+  Protección **estricta** (la rama del PR debe estar actualizada con `main` antes de mergear).
+
+Flujo de un cambio (agente o humano):
+
+```
+git checkout dev && git pull
+git checkout -b feat/lo-que-sea        # ramear SIEMPRE desde dev
+# ...commits Conventional Commits...
+git push -u origin feat/lo-que-sea
+gh pr create --base dev                # PR a dev (NO a main)
+# CI verde (lint + test 3.11/3.12) → es el gate
+gh pr merge --squash --delete-branch   # 1 commit conventional limpio por idea
+```
+
+**Dos tipos de PR, no confundir:**
+1. **PR de trabajo** (`feat/...` → `dev`): lo abrís vos/el agente a mano. Squash al mergear.
+2. **PR de release** (`chore(main): release X.Y.Z`): lo crea **`release-please` solo**; no se
+   crea a mano. Ver §Comandos de release.
+
+**Liberar** (cuando hay varias cosas en `dev`, no por cada cambio): PR `dev → main` con
+**merge commit** (NO squash, para que release-please vea los `feat`/`fix`) → release-please
+abre su PR de release → mergearlo crea el tag + GitHub Release.
+
+**Reglas para agentes:** ramear desde `dev`; nunca commitear directo a `dev`/`main`; un PR =
+una idea; el commit/PR sigue Conventional Commits (abajo); no bumpear versión ni editar
+`CHANGELOG.md` a mano (lo hace release-please).
 
 ## Comandos de build / lint / test
 
@@ -79,34 +114,35 @@ El proyecto se gestiona con **uv** (entorno + lockfile + versión de Python). **
 - **Por marcador:** `uv run pytest -m unit` / `uv run pytest -m integration` (los tests que
   toquen red o Neo4j se marcan `integration` y usan Testcontainers o mocks; el núcleo va en
   `unit`).
-- **Lint:** `uv run ruff check src tests` y `uv run ruff format --check src tests`
+- **Lint:** `uv run ruff check .` y `uv run ruff format --check .` (así lo corre el CI; `exploracion/` excluido)
 - **Tipos:** `uv run mypy src`
-- **Todo en uno (gate de CI):** `uv run ruff check src tests && uv run mypy src && uv run pytest`
+- **Todo en uno (gate de CI):** `uv run ruff check . && uv run ruff format --check . && uv run mypy src && uv run pytest`
 
 Regla de Hito 0: el **tooling LOCAL** —uv, linter (`ruff`), tipos (`mypy`), tests
 (`pytest`), hooks (`pre-commit`) y **commitizen** (linter de Conventional Commits +
 `cz bump --dry-run` para previsualizar el bump)— quedó configurado desde el día uno
-(ADR 0006/0010). El gate de calidad corre en local (`ruff` + `mypy` + `pytest`). En
-cambio, **la automatización de releases (release-please + CI/PyPI) está DISEÑADA pero
-AÚN NO conectada**: no existe `.github/` ni CI/GitHub Actions (ver §Comandos de release).
-La versión de Python la fija `.python-version` (3.12; `requires-python >=3.11`).
+(ADR 0006/0010). El mismo gate (`ruff` + `mypy` + `pytest`) corre **en CI** en cada push
+a `main`/`dev` y en cada PR (`.github/workflows/ci.yml`). La **automatización de releases
+(`release-please`) YA está conectada** (`.github/workflows/release-please.yml`); falta solo
+la publicación a PyPI (ver §Comandos de release). La versión de Python la fija
+`.python-version` (3.12; `requires-python >=3.11`).
 
 ## Comandos de release
 
-El **mecanismo de release DISEÑADO es `release-please`** (PR de release → bump +
-`CHANGELOG.md` → tag + publicación a PyPI; ver [`VERSIONING.md`](VERSIONING.md) y
-[ADR 0006](docs/decisiones/0006-tabla-canonica-y-networkspec.md)). **Pero AÚN NO está
-conectado**: no existe `.github/` ni CI. Hasta conectarlo, el versionado/tag se hace
-**manual/local**. `commitizen` **no** es el publicador de releases: es (a) el linter de
-Conventional Commits (hook de `pre-commit`) y (b) la herramienta para **previsualizar**
-el bump localmente con `cz bump --dry-run`.
+`release-please` **YA está conectado** (`.github/workflows/release-please.yml`): vigila
+`main` y, cuando llegan commits liberables (vía el merge `dev → main`), abre/actualiza
+**un** PR `chore(main): release X.Y.Z` con el `CHANGELOG.md` + bump de `pyproject.toml`;
+al mergearlo crea el tag `vX.Y.Z` y el **GitHub Release**. Pre-1.0: `feat`→minor,
+`fix`→patch, breaking→minor. **No publica a PyPI** (decisión del PO: solo GitHub Releases
+por ahora). `commitizen` **no** es el publicador: es (a) el linter de Conventional Commits
+(hook de `pre-commit`) y (b) preview del bump con `cz bump --dry-run`.
 
 - **Hacer un commit conventional:** `uv run cz commit` (interactivo, recomendado).
 - **Previsualizar qué versión saldría:** `uv run cz bump --dry-run` (solo preview, no publica).
-- **Tags actuales (locales, anotados, sin push):** `v0.1.0` (cierre Hitos 1–4) y `v0.2.0`
-  (Hitos 5–6), creados a mano. El **`v0.3.0`** (remediación R1–R5) está **por taguearse** sobre
-  HEAD. El **release publicado** (push de tags + artefactos a PyPI) queda **pendiente de conectar
-  `release-please` + CI**.
+- **No bumpear/taggear a mano:** lo hace release-please al mergear su PR de release.
+- **Tags publicados en `origin`:** `v0.1.0`, `v0.2.0`, `v0.3.0`, `v0.3.1` (GitHub Releases).
+- **Caveat:** el PR de release **no dispara CI** (los commits del `GITHUB_TOKEN` no disparan
+  workflows); se mergea con **bypass de admin** hasta que exista el secret `RELEASE_PLEASE_TOKEN`.
 
 Detalle en [`CONTRIBUTING.md`](CONTRIBUTING.md) y [`VERSIONING.md`](VERSIONING.md).
 
@@ -271,7 +307,7 @@ dominio** y los **contratos de `docs/API.md`**.
 > **TDD selectivo.** En el núcleo, el test va **antes** del código. Pero **no se testea cada
 > cosa**: se testea donde hay lógica, un contrato o riesgo de regresión; no wrappers finos,
 > plumbing de Click, ni el cliente HTTP de terceros. La disciplina completa (qué SÍ / qué NO) y
-> los tests concretos por hito están en `docs/ROADMAP.md` (§"Disciplina de tests" + cada hito).
+> los tests concretos por hito están en `docs/ROADMAP/` (§"Disciplina de tests" + cada hito).
 
 - **El núcleo se testea primero, sin red ni servidores** (Hitos 1 y 2). Tests sobre
   `Corpus`, proyectores y analizadores con datos sintéticos pequeños y **resultados
@@ -324,21 +360,20 @@ release), `ci` (no release), `style` (no release). Alcance sugerido:
 **SemVer estricto** (`MAJOR.MINOR.PATCH`). Mientras la mayor sea `0`, la API
 se considera inestable: cualquier cambio visible al usuario (no bugfix) bumpa
 MINOR. El congelamiento en `1.0.0` requiere API pública estable, cobertura de
-tests razonable y un caso real validado (estudio de semiconductores
-reproducido). Detalle y tabla de ejemplos en
-[`VERSIONING.md`](VERSIONING.md).
+tests razonable y un caso real validado (el caso **IED** reproducido; ver PRD §10).
+Detalle y tabla de ejemplos en [`VERSIONING.md`](VERSIONING.md).
 
 ## Changelog
 
-**Keep a Changelog**. Cuando se conecte `release-please` (mecanismo diseñado, ADR 0006 /
-[`VERSIONING.md`](VERSIONING.md)), el PR de release actualizará el `CHANGELOG.md` desde los
-Conventional Commits. Como ese tooling **aún no está conectado** (no hay `.github/`/CI), por
-ahora las secciones se mantienen **a mano** antes de cada tag (con `cz bump --dry-run` como
-ayuda de preview local). Plantilla en [`docs/RELEASE_TEMPLATE.md`](docs/RELEASE_TEMPLATE.md).
+**Keep a Changelog**. El `CHANGELOG.md` lo **gestiona `release-please`** (ya conectado): su
+PR de release agrega la sección nueva desde los Conventional Commits que llegan a `main`. Las
+secciones por debajo de `[0.3.0]` son el historial previo a la conexión (mantenido a mano); de
+ahí en adelante las gestiona el bot. `cz bump --dry-run` sigue sirviendo como preview local.
+Plantilla en [`docs/RELEASE_TEMPLATE.md`](docs/RELEASE_TEMPLATE.md).
 
 ## Dónde mirar primero según la tarea
 
-- Empezar cualquier hito → `docs/ROADMAP.md`: historias (PRD §7), criterios de
+- Empezar cualquier hito → `docs/ROADMAP/`: historias (PRD §7), criterios de
   aceptación (DoD) y los tests TDD a escribir.
 - Tocar el modelo de datos → `docs/API.md` §1, `docs/ARCHITECTURE.md` §3,
   [ADR 0006](docs/decisiones/0006-tabla-canonica-y-networkspec.md).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,28 @@
+# CLAUDE.md
+
+Guía para agentes (Claude Code y otros). La **fuente canónica** —estado del proyecto,
+comandos, convenciones de código, estructura de paquetes, tests— es **[`AGENTS.md`](AGENTS.md)**:
+leéla antes de tocar nada. Este archivo solo fija lo mínimo imprescindible para no duplicar
+(evitar drift); el detalle vive en `AGENTS.md` y `CONTRIBUTING.md`.
+
+## Flujo de trabajo básico (NO te lo saltes)
+
+Modelo **GitFlow-lite** — detalle en [`AGENTS.md`](AGENTS.md) §Flujo de trabajo y
+[`CONTRIBUTING.md`](CONTRIBUTING.md):
+
+- **`dev`** = rama de integración y default del repo (acá se acumula el trabajo).
+  **`main`** = estable/release. **Ambas protegidas**: PR + CI verde obligatorios, nunca pushear directo.
+- **Un cambio:** ramear desde `dev` → commits Conventional Commits → `gh pr create --base dev`
+  → CI verde → `gh pr merge --squash`.
+- **Liberar** (cuando hay varias cosas en `dev`): PR `dev → main` con **merge commit** →
+  `release-please` abre el PR de release → mergearlo crea tag + GitHub Release. **No** bumpees
+  versión ni edites `CHANGELOG.md` a mano.
+- **Dos tipos de PR:** el de trabajo (manual, a `dev`) y el de release (lo crea release-please solo).
+
+## Reglas que no se negocian
+
+- **uv** para todo (`uv sync`, `uv run …`); no `pip`, no editar `[project.dependencies]` a mano.
+- **Conventional Commits** estricto. Un PR = una idea, con sus tests.
+- Gate antes de PR: `uv run ruff check . && uv run ruff format --check . && uv run mypy src && uv run pytest`.
+- **Leer `docs/ROADMAP/` antes de empezar un hito** (historias del PRD §7, DoD, tests TDD).
+- Cambios a contratos públicos (`docs/API.md`) → ADR nuevo en `docs/decisiones/` antes de mergear.


### PR DESCRIPTION
Documenta el **flujo básico de trabajo** en las guías de agentes (faltaba).

- **AGENTS.md**: nueva sección "Flujo de trabajo (ramas dev/main)" (modelo, flujo de un cambio, dos tipos de PR, cómo liberar). Actualizadas release/changelog/versionado (release-please **ya conectado**, tags publicados, caso 1.0 = IED), comandos `ruff` como los corre el CI, y `docs/ROADMAP.md` → `docs/ROADMAP/`.
- **CLAUDE.md** (nuevo): conciso, apunta a AGENTS.md como fuente canónica (anti-drift) con el flujo básico + reglas no negociables al frente.

Primer PR bajo el flujo nuevo (base `dev`). 0 enlaces markdown rotos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)