### PR TITLE
feat(enrichers): costura Enricher + resolución references→DOI (Hito 8a)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,8 +27,8 @@
   (`DuckDBStore`), `sources/` (`OpenAlexSource`, `BibtexSource`), `foraging/` (`Forager`,
   scent bibliométrico), `preprocessors/` (normalize + thesaurus), `filters/` (PRISMA),
   `networks/` (proyectores, analyzer, spec, facade), `exporters/` (GraphML, CSV) y `cli/`.
-  El **CLI `b2g` es real** —paquete `cli/` con 12 subcomandos en `cli/commands/`, no un
-  placeholder—. **327 tests verdes** (mypy/ruff limpios; el núcleo importa sin `duckdb`).
+  El **CLI `b2g` es real** —paquete `cli/` con 13 subcomandos en `cli/commands/`, no un
+  placeholder—. **341 tests verdes** (mypy/ruff limpios; el núcleo importa sin `duckdb`).
 - **Tanda de remediación R1–R5 COMPLETA** (v0.3, 2026-06-16). Tras el red-team del AS-BUILT
   ([`docs/Notas/06-critica-as-built-v0.2.md`](docs/Notas/06-critica-as-built-v0.2.md)) el PO bloqueó
   un **modelo nuevo** (ADR [0022](docs/decisiones/0022-producto-sin-ia-generativa.md)/
@@ -211,14 +211,15 @@ src/bib2graph/
   preprocessors/       # normalize + thesaurus multilingüe DETERMINISTA, sin fallback LLM (núcleo);
                        # dedup fuzzy DETERMINISTA en [dedup]
   filters/             # filtros de inclusión/exclusión con conteo PRISMA (núcleo)
-  enrichers/           # FUTURO (Hito 8): OpenAlexEnricher opt-in (refs→DOI, 2º nivel); S2 ([s2])
+  enrichers/           # OpenAlexEnricher opt-in, NÚCLEO (refs→DOI = Ciclo 8a ✅; cited_by_id/2º nivel = 8b);
+                       # Enricher Protocol; S2 ([s2]) reservado para señal adicional, NO el Enricher (ADR 0025)
   networks/            # Projector, Analyzer, NetworkSpec, NetworkArtifact, Networks
   exporters/           # GraphML, CSV
   stores/              # DuckDBStore (núcleo, por defecto: biblioteca viva);
                        # ParquetStore (export); ZoteroStore ([zotero], V1.1);
                        # Neo4jStore ([neo4j], post-V1)
   cli/                 # paquete de 3 capas (Click → run_<cmd>() núcleo → envelope/errores);
-                       # cli/commands/ = 12 subcomandos (incl. monitor, FSM→MONITORED). CLI = API
+                       # cli/commands/ = 13 subcomandos (incl. monitor FSM→MONITORED, enrich refs→DOI). CLI = API
                        # para LLM y agentes (Hito 6, ARCHITECTURE.md §6.3). No es un cli.py plano.
 tests/
   unit/                # tests puros, sin red ni I/O (default)

--- a/docs/API.md
+++ b/docs/API.md
@@ -49,6 +49,12 @@
 > [0021](decisiones/0021-cli-agente-native-contrato.md)). **Con el Hito 6, las capacidades de v0.2
 > (Hitos 5–6) quedan completas** (ver [`ROADMAP.md`](ROADMAP/README.md)). *(El 12° subcomando `monitor`
 > —AS-BUILT del cleanup pre-v0.3— cierra el paso 8 del ciclo: `MONITORED` ahora es alcanzable.)*
+>
+> **Sincronizado con el Ciclo 8a (2026-06-16):** la costura **`Enricher`** está **construida** (§3) y
+> suma el **13° subcomando `enrich`** (refs→DOI sobre OpenAlex, núcleo; **NO** transiciona el
+> `CycleState`). El Enricher vive en el **núcleo sobre OpenAlex**, no en `[s2]` (ADR
+> [0025](decisiones/0025-enricher-cocitacion-openalex.md)). La **co-citación end-to-end** (poblar
+> `cited_by_id`) queda para el **Ciclo 8b** (pendiente).
 
 ## Convenciones
 
@@ -67,9 +73,10 @@ subcomando lleva `--json` (envelope estable/versionado) y exit codes (`0` éxito
 datos · `3` dependencia · `4` red · `5` store/snapshot corrupto o bloqueado). **Sin estado entre
 invocaciones:** el estado vive en el archivo `.duckdb` (opción global `--store`).
 
-**Set de 12 subcomandos** (decisión del PO, ADR 0021 §A — **amplía** este doc, que antes listaba 9
+**Set de 13 subcomandos** (decisión del PO, ADR 0021 §A — **amplía** este doc, que antes listaba 9
 y dejaba `accept`/`reject` como "solo programático"; el 12° `monitor` se agregó en el cleanup
-pre-v0.3):
+pre-v0.3; el 13° `enrich` en el Ciclo 8a, ADR
+[0025](decisiones/0025-enricher-cocitacion-openalex.md)):
 
 - `seed`, `chain`, **`filter`** (filtros PRISMA deterministas: año/tipo/idioma/citas **con conteo
   en cada paso**), `build`, `export`, `snapshot`, **`status`** (expone el ciclo: estado actual,
@@ -90,6 +97,13 @@ pre-v0.3):
   fijo, que **siempre** tiene `fetch_citing` (asimetría deliberada con `chain`, que acepta
   `--direction` variable y sí pre-chequea). Errores accionables: sin corpus/estado previo →
   `DataError` (exit 2). Con `monitor`, **`MONITORED` deja de ser inalcanzable**.
+- **`enrich`** (Ciclo 8a, ADR [0025](decisiones/0025-enricher-cocitacion-openalex.md)): corre el
+  `OpenAlexEnricher` (§3) sobre la biblioteca viva. **8a (hecho):** resuelve `references_id`→
+  `references_doi` (batching por OR) y registra el `EnricherRef` en el `Manifest` (idempotente).
+  Flags: `--email` (polite pool), `--api-key` (opcional), `--json`. `data` =
+  `{enriched, references_resolved, ...}`. **NO transiciona el `CycleState`** (ortogonal al lazo):
+  se puede enriquecer en cualquier estado sin perturbar el FSM. `build` sigue puro/sin red. La
+  co-citación end-to-end (poblar `cited_by_id`, 2º nivel) es el **Ciclo 8b (pendiente)**.
 
 **`--store` global (obligatoria).** Va en el grupo `b2g`, **antes** del subcomando:
 `b2g --store mi.duckdb seed --equation "..."`. Una investigación = un archivo `.duckdb` (ADR
@@ -102,7 +116,8 @@ transición).
 
 **Transiciones automáticas del ciclo** (ADR 0021 §F; AS-BUILT R3): `seed`→`SEEDED`, `chain`→`FORAGED`,
 `filter`→`FILTERED`, `build`→`BUILT`, **`monitor`→`MONITORED`** (cleanup pre-v0.3);
-`accept`/`reject`/`export`/`snapshot`/`status`/`inspect`/`validate` **no transicionan**. El estado
+`accept`/`reject`/`export`/`snapshot`/`status`/`inspect`/`validate`/**`enrich`** **no transicionan**
+(`enrich` es ortogonal al lazo, ADR 0025). El estado
 destino lo dicta `bib2graph.cycle.apply_transition`
 (fuente única de verdad; los comandos no hardcodean el destino). `seed` con **estado previo** se trata
 como **`reseed`** (loop-back a `SEEDED`, ronda++, acumula sobre lo curado).
@@ -465,19 +480,23 @@ en v0.1 (función pura sobre `pa.Table`), sin cablearse vacío (lección 5).
 
 Con OpenAlex como backbone, refs y citantes **ya vienen en el corpus** (ADR 0007). El `Enricher`
 deja de ser el camino para co-citación; queda opt-in para **resolver `references` a DOI** y el
-**segundo nivel de fetch** (citantes con sus citas).
+**segundo nivel de fetch** (citantes con sus citas ≡ `cited_by_id` compartido — ver decisión F en
+ADR [0025](decisiones/0025-enricher-cocitacion-openalex.md)). El `Enricher` vive en el **núcleo,
+sobre OpenAlex** (ADR 0025, decisión B), **no** en el extra `[s2]` (ese DoD pre-giro queda superado;
+`[s2]` se reserva para un futuro `SemanticScholarEnricher` de señal adicional).
 
 ```python
+@runtime_checkable
 class Enricher(Protocol):
     """Config (API keys) INYECTADA, nunca embebida. Sin ramas muertas. Rate limit/reintentos
-    sin perder papers. Idempotente."""
+    sin perder papers. Idempotente. NO transiciona el CycleState (ortogonal al lazo, ADR 0025)."""
     def enrich(self, corpus: Corpus) -> Corpus: ...
 ```
 
 | Implementación | Estado | Aporta |
 |----------------|--------|--------|
-| `OpenAlexEnricher` | **v1, opt-in** | resuelve `references_id`→`references_doi`; 2º nivel de citantes → habilita co-citación completa |
-| `SemanticScholarEnricher` | futuro | señal de citas adicional |
+| `OpenAlexEnricher` | **v1, opt-in (Ciclo 8a construido)** | **refs→DOI hecho:** reúne los `references_id` únicos, los resuelve **batcheando por OR** (lotes ≤100, `openalex_id:W1\|W2\|...`, `select=id,doi`) y rellena `references_doi` por lookup; registra `EnricherRef(name="openalex_references_doi", …)` en el `Manifest` (idempotente: reemplaza por nombre, no duplica). **`cited_by_id` / co-citación end-to-end = Ciclo 8b pendiente** (poblará solo `cited_by_id`, sin crecer el corpus; decisión A) |
+| `SemanticScholarEnricher` | futuro | señal de citas adicional (reserva del `[s2]`, no estructural) |
 | `CrossRefEnricher` / `ScopusEnricher` | futuro | No implementados. |
 
 ---
@@ -758,9 +777,11 @@ completo** (crítica #2). La **co-citación** es la más cara (segundo nivel de 
 - **Tipo de nodo** (D2): co-autoría / instituciones / co-word → la **entidad** es el nodo
   (`authors_id` / `institutions_id` / `keywords_id`); acoplamiento / co-citación → el **paper**
   (`id`) es el nodo.
-- **Co-citación en Hito 2:** el `CoCitationProjector` proyecta desde `cited_by_id` con scope
-  `seeds_only`; es válido para los citantes ya presentes en el corpus, pero la co-citación
-  **completa** requiere el 2º nivel de fetch del `OpenAlexEnricher` (Hito 8, ADR 0007).
+- **Co-citación en Hito 2:** el `CoCitationProjector` **no cambia** (decisión F, ADR 0025): cuenta
+  **`cited_by_id` compartido** = los **citantes compartidos** de la metodología (la frase "citantes
+  con sus citas" ≡ `cited_by_id` compartido). Proyecta con scope `seeds_only`; es válido para los
+  citantes ya presentes en el corpus, pero la co-citación **completa** requiere el 2º nivel de fetch
+  del `OpenAlexEnricher` (poblar `cited_by_id`), que es el **Ciclo 8b** (ADR 0007/0025).
 
 ---
 
@@ -875,7 +896,8 @@ versionable.
 
 - **`Networks.quick` arma 4 redes** (coupling `full`, co-autoría, institución, co-word) y **omite
   la co-citación**, avisándolo por log (D3): la co-citación completa requiere el 2º nivel de fetch
-  del `OpenAlexEnricher` (Hito 8). El `CoCitationProjector` queda disponible vía
+  del `OpenAlexEnricher` (poblar `cited_by_id`, **Ciclo 8b**; ADR 0025). El `CoCitationProjector`
+  queda disponible vía
   `Networks.build(corpus, NetworkSpec(kind="cocitation"))`.
 - **`NetworkSpec` es un hook mínimo en v1** (modelo Pydantic ya consumido por `build`/`quick`); la
   carga desde YAML y la validación avanzada son del Hito 9. El símbolo público re-exportado desde

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -260,13 +260,17 @@ exige un pre-procesador). SciELO/Redalyc/La Referencia, RIS/CSV: futuras, no pub
 **reporte de cobertura/calidad** por seed/source (concreto v0.2+, ADR 0018) mide qué tan completa
 es la fuente y alimenta el juicio de cuándo cambiar de `Source`.
 
-### 4.2 `Enricher` — señal extra (opt-in)
+### 4.2 `Enricher` — señal extra (opt-in, núcleo sobre OpenAlex)
 
-Con OpenAlex como backbone, **deja de ser estructural** (ADR 0007). Queda opt-in para:
-**resolver `references` a DOI canónico** (OpenAlex las da como URLs internas — T8 del sandbox) y
-el **segundo nivel de fetch** (citantes con sus citas) que habilita la co-citación. S2/CrossRef/
-Scopus: futuras. Reglas: config inyectada (nunca embebida), sin ramas muertas, rate limit y
-reintentos sin perder papers.
+Con OpenAlex como backbone, **deja de ser estructural** (ADR 0007). Vive en el **núcleo sobre
+OpenAlex** (no en `[s2]`; ADR [0025](decisiones/0025-enricher-cocitacion-openalex.md)). Queda opt-in
+para: **resolver `references_id` a DOI canónico** (OpenAlex las da como URLs internas — T8 del
+sandbox; **Ciclo 8a ✅ construido**, batching por OR, idempotente vía `EnricherRef` en el `Manifest`)
+y el **segundo nivel de fetch** (citantes con sus citas ≡ `cited_by_id` compartido) que habilita la
+co-citación (**Ciclo 8b pendiente**: puebla solo `cited_by_id`, sin crecer el corpus). El subcomando
+`b2g enrich` es propio y **no transiciona el `CycleState`**. S2/CrossRef/Scopus: futuras (`[s2]`
+reservado para señal adicional). Reglas: config inyectada (nunca embebida), sin ramas muertas, rate
+limit y reintentos sin perder papers.
 
 ### 4.3 `Store` / backend de persistencia (biblioteca viva)
 
@@ -415,11 +419,14 @@ trabajo posterior, pero la API se **diseña con estos principios desde el hito 1
    faltante"); la capacidad-de-source-faltante se convierte en `DependencyError` mediante un
    **pre-check `hasattr` en el borde** (p. ej. `chain.py` antes del `Forager`). Ver ADR 0021 §D.
 
-Son **12 subcomandos** (`seed`, `chain`, `filter`, `build`, `export`, `snapshot`, `status`,
-`inspect`, `validate`, `accept`, `reject`, **`monitor`**); `build`/`export` están **separados** y el
-`CycleState` transiciona automáticamente por comando (ADR 0021). El 12° **`monitor`** (cleanup
-pre-v0.3) re-chequea citantes nuevos del corpus (forward chaining) y transiciona a `MONITORED`. El
-error de uso (p. ej. falta `--store`) sale **sin envelope** (Click aborta el parseo: stderr + exit 1).
+Son **13 subcomandos** (`seed`, `chain`, `filter`, `build`, `export`, `snapshot`, `status`,
+`inspect`, `validate`, `accept`, `reject`, **`monitor`**, **`enrich`**); `build`/`export` están
+**separados** y el `CycleState` transiciona automáticamente por comando (ADR 0021). El 12°
+**`monitor`** (cleanup pre-v0.3) re-chequea citantes nuevos del corpus (forward chaining) y
+transiciona a `MONITORED`. El 13° **`enrich`** (Ciclo 8a, ADR
+[0025](decisiones/0025-enricher-cocitacion-openalex.md)) corre el `OpenAlexEnricher` (refs→DOI) y
+**no transiciona** el ciclo (ortogonal al lazo). El error de uso (p. ej. falta `--store`) sale **sin
+envelope** (Click aborta el parseo: stderr + exit 1).
 
 **AS-BUILT R5 — UTF-8 en la frontera (Nota 06 RAÍZ 3):** `main()` llama `_force_utf8()` (reconfigura
 `sys.stdout`/`stderr` a UTF-8, con guarda por si la stream no es reconfigurable) **antes de que Click
@@ -435,7 +442,8 @@ el `.duckdb` ante un typo en `--store` (falla accionable); los comandos de escri
 core         pyarrow, pydantic, networkx, click, tqdm,
              duckdb, <cliente OpenAlex>                 (siempre; biblioteca viva + backbone)
 [zotero]     pyzotero                                   ─┐
-[s2]         (cliente Semantic Scholar)                  │ costuras / capacidades opcionales
+[s2]         (cliente Semantic Scholar; reservado para   │ costuras / capacidades opcionales
+              señal adicional, NO el Enricher —ADR 0025)  │
 [neo4j]      neomodel / driver oficial                   │ (futuras marcadas como no
 [viz]        matplotlib, seaborn                          │ implementadas)
 [dedup]      rapidfuzz / splink (fuzzy DETERMINISTA)    ─┘

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -392,7 +392,8 @@ Esta reconciliación ya está reflejada en `ARCHITECTURE.md` (§3.1, §4.3, §6.
 3. ✅ Implementación por hitos en curso (coder): **Hitos 0–6 + 1.5 terminados** (núcleo del corpus
    stateful sobre `TabularBackend`, proyectores/analizadores/export, biblioteca viva en DuckDB,
    fuentes OpenAlex/BibTeX, forrajeo + `Preprocessor` + filtros PRISMA, y el **CLI agente-native
-   `b2g`** — 12 subcomandos, ADR [0021](decisiones/0021-cli-agente-native-contrato.md)). Con ello
+   `b2g`** — 13 subcomandos, ADR [0021](decisiones/0021-cli-agente-native-contrato.md) +
+   [0025](decisiones/0025-enricher-cocitacion-openalex.md) (`enrich`, Ciclo 8a)). Con ello
    v0.2 alcanza las capacidades del **flujo** `seed → … → export`. **El red-team de la
    [Nota 06](Notas/06-critica-as-built-v0.2.md) corrige el claim "capacidades completas":** falta la
    **tanda de remediación R1–R5** (modelo sin IA, identidad-vs-procedencia reproducible, FSM cíclico,

--- a/docs/ROADMAP/04-lo-que-viene.md
+++ b/docs/ROADMAP/04-lo-que-viene.md
@@ -29,13 +29,22 @@
 
 ---
 
-## Hito 8 — `Enricher` opt-in: resolución de refs + co-citación (extra `[s2]`)
+## Hito 8 — `Enricher` opt-in: resolución de refs + co-citación (núcleo OpenAlex)
+
+> **Partición (ADR [0025](../decisiones/0025-enricher-cocitacion-openalex.md), 2026-06-16):** el hito
+> se hace en **2 ciclos**. **8a ✅ (hecho):** costura `Enricher` + refs→DOI + subcomando `b2g enrich`.
+> **8b (pendiente):** co-citación end-to-end (poblar `cited_by_id`), **solo seeds aceptadas + tope
+> configurable**. El Enricher vive en el **núcleo sobre OpenAlex**, **no** en el extra `[s2]`: ese
+> `[s2]` era residuo pre-giro (ADR [0007](../decisiones/0007-openalex-backbone.md): S2 ya no es
+> estructural) y queda **reservado** para un futuro `SemanticScholarEnricher` de señal adicional.
 
 **Alcance**
 
-- `Enricher` (ya **no estructural**; ADR 0007, API.md §3): **resolver `references_id` a DOI
-  canónico** (T8) y el **segundo nivel de fetch** (citantes con sus citas) que habilita la
-  **co-citación** completa.
+- `Enricher` (ya **no estructural**; ADR 0007/0025, API.md §3): **resolver `references_id` a DOI
+  canónico** (T8, **8a ✅**) y el **segundo nivel de fetch** (citantes con sus citas ≡ `cited_by_id`
+  compartido) que habilita la **co-citación** completa (**8b**). El 2º nivel **solo puebla
+  `cited_by_id`**; los citantes NO se materializan como filas del corpus (eso es del `Forager` +
+  curación; decisión A).
 - **Batching-por-OR de `fetch_citing`** (seguimiento heredado de R5, encuadrado acá por el arquitecto
   2026-06-16): R5 entregó **retry/backoff** pero **difirió** el batching (agrupar varios `cites:` en
   una query `cites:W1|W2|...` para matar el N+1 de requests). El **2º nivel de fetch de este hito** es
@@ -48,11 +57,18 @@ interoperabilidad de referencias cross-source (OpenAlex ↔ `.bib`).
 
 **Criterios de aceptación (DoD)**
 
-- `enrich` es **idempotente** y no pierde papers ante rate limit/reintentos.
-- Resuelve `references_id` → `references_doi`; el 2º nivel habilita `CoCitationProjector` completo.
-- **`fetch_citing` batchea por OR** (`cites:W1|W2|...`) en el 2º nivel de fetch: el N+1 de R5 deja de
-  hacer una request por paper (mejora de performance; el retry/backoff de R5 se conserva).
-- Config/keys **inyectadas**, sin ramas muertas. **Sin red en CI** (mock).
+- **8a ✅** `enrich` es **idempotente** (reemplaza el `EnricherRef` por nombre, no duplica) y no pierde
+  papers ante rate limit/reintentos. Subcomando `b2g enrich` propio; **NO** transiciona el `CycleState`
+  (ortogonal al lazo, decisión C). `build` sigue puro/sin red.
+- **8a ✅** Resuelve `references_id` → `references_doi` **batcheando por OR** (lotes ≤100,
+  `openalex_id:W1|W2|...`, `select=id,doi`).
+- **8b** El 2º nivel habilita `CoCitationProjector` completo poblando `cited_by_id` (el projector
+  **no cambia**: cuenta `cited_by_id` compartido = citantes compartidos; decisión F). Solo seeds
+  aceptadas + tope configurable.
+- **8b** **`fetch_citing` batchea por OR** (`cites:W1|W2|...`) en el 2º nivel de fetch: el N+1 de R5
+  deja de hacer una request por paper (mejora de performance; el retry/backoff de R5 se conserva).
+- Config/keys **inyectadas**, sin ramas muertas. **Sin red en CI** (mock). Núcleo sin importar
+  `duckdb`; sin red al importar.
 
 **Tests (TDD — los justos)**
 

--- a/docs/ROADMAP/README.md
+++ b/docs/ROADMAP/README.md
@@ -87,11 +87,13 @@ OIDC), no el push de tags. Cortes acordados:
 - **v0.2 — forrajeo + CLI agente-native (Hitos 5–6) · ✅ CAPACIDADES COMPLETAS (2026-06-15):**
   chaining rankeado, `Preprocessor`, filtros PRISMA (comando **`filter`**), `b2g status`
   (`LoopState`) y el CLI `b2g` con `--json`. **El forrajeo, el `Preprocessor` y los filtros (Hito 5)
-  y el CLI agente-native (Hito 6) están construidos.** El CLI expone **12 subcomandos** (`seed`,
+  y el CLI agente-native (Hito 6) están construidos.** El CLI expone **13 subcomandos** (`seed`,
   `chain`, `filter`, `build`, `export`, `snapshot`, `status`, `inspect`, `validate`, `accept`,
-  `reject`, **`monitor`**) con envelope `--json` versionado y exit codes 0–5 (ADR
+  `reject`, **`monitor`**, **`enrich`**) con envelope `--json` versionado y exit codes 0–5 (ADR
   [0021](../decisiones/0021-cli-agente-native-contrato.md)). El 12° **`monitor`** (cleanup pre-v0.3)
-  re-chequea citantes nuevos del corpus y transiciona a `MONITORED`. El `accept`/`reject` programático
+  re-chequea citantes nuevos del corpus y transiciona a `MONITORED`; el 13° **`enrich`** (Ciclo 8a,
+  ADR [0025](../decisiones/0025-enricher-cocitacion-openalex.md)) resuelve refs→DOI y **no
+  transiciona** el ciclo. El `accept`/`reject` programático
   sobrevive (ahora como subcomando CLI); la curación interactiva rica (`curate`) y la GUI son
   futuro. Acá se cumple el criterio "V1 hecha" del PRD §9 a nivel de *capacidades* (el número de
   versión sigue en 0.y). **Tag `v0.2.0`** creado el 2026-06-15, **publicado en `origin`**.
@@ -199,5 +201,5 @@ limpio y actual; el cuerpo de cada hito vive en su archivo:
 | D3 asortatividad + composición + proxy | 2 | |
 | D4 export GraphML/CSV | 2 | |
 | E1 snapshot reproducible | 1 + 6 ✅ | `Corpus.snapshot` + `b2g snapshot` |
-| E2 CLI `--json` + exit codes | 0 (principios) + 6 ✅ (CLI) + cleanup pre-v0.3 ✅ (`monitor`) | `b2g` **12 subcomandos** (Hito 6 entregó 11; `monitor` se sumó en el cleanup pre-v0.3 → `MONITORED`), envelope `--json` versionado, exit 0–5 (ADR 0021) |
+| E2 CLI `--json` + exit codes | 0 (principios) + 6 ✅ (CLI) + cleanup pre-v0.3 ✅ (`monitor`) + 8a ✅ (`enrich`) | `b2g` **13 subcomandos** (Hito 6 entregó 11; `monitor` se sumó en el cleanup pre-v0.3 → `MONITORED`; `enrich` en el Ciclo 8a, ADR 0025, sin transición), envelope `--json` versionado, exit 0–5 (ADR 0021) |
 

--- a/docs/decisiones/0025-enricher-cocitacion-openalex.md
+++ b/docs/decisiones/0025-enricher-cocitacion-openalex.md
@@ -1,0 +1,85 @@
+# 0025 — `Enricher` opt-in sobre OpenAlex (núcleo): refs→DOI + co-citación
+
+- **Estado:** Aceptada · **AS-BUILT parcial (2026-06-16)** (Ciclo **8a** implementado en esta rama;
+  **8b** pendiente)
+- **Fecha:** 2026-06-16
+- **Relacionada con:** [0007](0007-openalex-backbone.md) (OpenAlex backbone; el Enricher deja de ser
+  estructural y S2 se demota), [0004](0004-enriquecimiento-opcional.md) (principio de enriquecimiento
+  opt-in, nunca obligatorio, keys inyectadas), [0014](0014-proyeccion-redes-pesos-asortatividad.md)
+  (semántica del `CoCitationProjector`), [0021](0021-cli-agente-native-contrato.md) (set de
+  subcomandos del CLI), [`metodología.md`](../metodología.md) (co-citación = citantes compartidos)
+
+## Contexto
+
+El Hito 8 ([ROADMAP/04](../ROADMAP/04-lo-que-viene.md)) materializa la costura `Enricher` opt-in
+para resolver `references_id`→`references_doi` y habilitar la **co-citación** end-to-end. El DoD
+original del hito lo encuadraba sobre el extra **`[s2]`** (Semantic Scholar), residuo del diseño
+**pre-giro** previo al [ADR 0007](0007-openalex-backbone.md): cuando la entrada era BibTeX, el único
+camino a las listas de referencias era un enricher S2 **estructural**. Tras el ADR 0007, OpenAlex ya
+trae referencias y citantes, así que ese encuadre `[s2]` quedó desalineado con la arquitectura real.
+
+El hito es grande para un solo ciclo, por lo que se **parte en dos**:
+
+- **8a** — costura `Enricher` + resolución refs→DOI + subcomando `b2g enrich`.
+- **8b** — poblar `cited_by_id` (2º nivel) y co-citación end-to-end, solo sobre semillas aceptadas y
+  con un tope configurable.
+
+## Decisión
+
+**El `Enricher` vive en el núcleo, sobre OpenAlex**, no en un extra. Es la costura opt-in del ADR
+0004/0007, ahora as-built.
+
+- **Contrato `Enricher`** (`enrichers/base.py`): `Protocol` `@runtime_checkable` con
+  `enrich(corpus: Corpus) -> Corpus`. **Idempotente** (re-correr no duplica trabajo ni efectos),
+  **config/keys inyectadas** (nunca embebidas), **no pierde papers** ante rate limit/reintentos, sin
+  ramas muertas. El núcleo **no importa `duckdb`**; no hay red al importar; **sin red en CI**
+  (`MockTransport`).
+- **`[s2]` queda superado para el Enricher estructural** (supersede el DoD pre-giro del Hito 8): el
+  enricher de referencia es **OpenAlex en el núcleo** (decisión B del PO). El nombre `[s2]` se
+  **reserva** para un futuro `SemanticScholarEnricher` de **señal adicional** (no estructural), no
+  como camino a co-citación.
+- **`enrich` es subcomando CLI propio** (decisión C del PO): `cli/commands/enrich.py`,
+  `run_enrich(store_path, *, email, api_key, transport)`. **NO transiciona el `CycleState`** (es
+  **ortogonal** al lazo del FSM, ADR 0016/0021). `build` sigue **puro/sin red**.
+
+### Ciclo 8a (HECHO, as-built)
+
+- `OpenAlexEnricher` (`enrichers/openalex.py`) reúne los **`references_id` únicos** del corpus, los
+  resuelve a DOI **batcheando por OR** (lotes ≤ 100, filtro `openalex_id:W1|W2|...`,
+  `select=id,doi`) y rellena **`references_doi`** alineado por lookup.
+- Registra un `EnricherRef(name="openalex_references_doi", params=...)` en el `Manifest`;
+  **idempotente** = reemplaza por nombre, no duplica.
+- Métodos nuevos en `sources/openalex.py`: `fetch_dois_for(ids) -> dict` y `_fetch_batch_select`.
+
+### Ciclo 8b (PENDIENTE)
+
+- **Poblar `cited_by_id`** (2º nivel) y co-citación end-to-end, **solo sobre semillas aceptadas** y
+  con un **tope configurable**.
+- **(Decisión A del PO)** el 2º nivel **solo poblará `cited_by_id`**; los citantes **NO** se
+  materializan como filas del corpus. Crecer el corpus con citantes es trabajo del **`Forager` +
+  curación** (chaining forward + accept/reject), no del Enricher.
+
+### Co-citación: el `CoCitationProjector` no cambia (decisión F del PO)
+
+El `CoCitationProjector` (ADR [0014](0014-proyeccion-redes-pesos-asortatividad.md)) **no se toca**:
+cuenta **`cited_by_id` compartido** = los **citantes compartidos** de la
+[`metodología.md`](../metodología.md). La frase de los docs "citantes con sus citas" se **reconcilia**
+documentando que el 2º nivel se materializa como **`cited_by_id`** (8b): "citantes con sus citas" ≡
+**`cited_by_id` compartido**, que es lo que el projector ya consume.
+
+## Consecuencias
+
+- (+) **La co-citación deja de depender de un enricher estructural externo** (ADR 0007 cerrado a
+  nivel de código): el camino es OpenAlex en el núcleo, opt-in.
+- (+) **`enrich` ortogonal al lazo**: se puede enriquecer en cualquier estado sin perturbar el FSM;
+  `build` permanece puro y reproducible.
+- (+) **Batching por OR** mata el N+1 de requests del 2º nivel (mejora de performance; el
+  retry/backoff de R5 se conserva).
+- (−) **El DoD del Hito 8 quedaba encuadrado en `[s2]`**: este ADR lo supersede; el `[s2]` pasa a
+  reserva para señal adicional futura. Los docs (ROADMAP/04, ARCHITECTURE §4.2, API §3) se sincronizan.
+- (−) **La co-citación completa sigue gateada por 8b**: hasta poblar `cited_by_id` (2º nivel),
+  `Networks.quick` omite la co-citación (avisa por log), como ya documenta API §10.
+
+> **AS-BUILT parcial (2026-06-16):** **8a implementado** en esta rama (`b2g enrich`, refs→DOI,
+> `OpenAlexEnricher`), **13 subcomandos** (era 12: se suma `enrich`). **341 tests verdes.** **8b
+> pendiente** (co-citación end-to-end).

--- a/docs/decisiones/README.md
+++ b/docs/decisiones/README.md
@@ -63,3 +63,4 @@ Qué se vuelve posible/fácil y qué se vuelve costoso/imposible. Trade-offs hon
 | [0022](0022-producto-sin-ia-generativa.md) | El producto no usa IA generativa; la "inteligencia" del forrajeo es estructura bibliométrica | Aceptada |
 | [0023](0023-capa-constants-modelos-schema.md) | Capa base de vocabulario + modelos: `constants`, `ProvenanceEvent`, schema única (`PaperRow` ⇄ `CORPUS_SCHEMA`) | Aceptada |
 | [0024](0024-orden-d3-columna-secuencia-duckdb.md) | Orden D3 en DuckDB vía columna de secuencia interna (`_seq`) | Aceptada · AS-BUILT (2026-06-16) |
+| [0025](0025-enricher-cocitacion-openalex.md) | `Enricher` opt-in sobre OpenAlex (núcleo): refs→DOI + co-citación; supersede el `[s2]` del DoD del Hito 8 | Aceptada · AS-BUILT parcial (2026-06-16): 8a hecho, 8b pendiente |

--- a/src/bib2graph/cli/__init__.py
+++ b/src/bib2graph/cli/__init__.py
@@ -7,7 +7,7 @@ Entry point en ``pyproject.toml``:
     b2g = "bib2graph.cli:main"
 
 Subcomandos:
-    seed, chain, filter, build, monitor, export, snapshot,
+    seed, chain, filter, build, enrich, monitor, export, snapshot,
     status, inspect, validate, accept, reject.
 
 Cada subcomando lleva:
@@ -32,6 +32,7 @@ import click
 from bib2graph.cli.commands.accept import accept_cmd
 from bib2graph.cli.commands.build import build_cmd
 from bib2graph.cli.commands.chain import chain_cmd
+from bib2graph.cli.commands.enrich import enrich_cmd
 from bib2graph.cli.commands.export import export_cmd
 from bib2graph.cli.commands.filter import filter_cmd
 from bib2graph.cli.commands.inspect import inspect_cmd
@@ -73,7 +74,7 @@ def b2g(ctx: click.Context, store: str) -> None:
     Transforma corpus bibliográficos en redes bibliométricas reproducibles.
     El estado de la investigación vive en --store (archivo .duckdb).
 
-    Subcomandos: seed, chain, filter, build, monitor, export, snapshot,
+    Subcomandos: seed, chain, filter, build, enrich, monitor, export, snapshot,
     status, inspect, validate, accept, reject.
 
     Ejemplo:
@@ -84,11 +85,12 @@ def b2g(ctx: click.Context, store: str) -> None:
     ctx.obj["store"] = store
 
 
-# Registrar los 12 subcomandos
+# Registrar los 13 subcomandos
 b2g.add_command(seed_cmd)
 b2g.add_command(chain_cmd)
 b2g.add_command(filter_cmd)
 b2g.add_command(build_cmd)
+b2g.add_command(enrich_cmd)
 b2g.add_command(monitor_cmd)
 b2g.add_command(export_cmd)
 b2g.add_command(snapshot_cmd)

--- a/src/bib2graph/cli/commands/enrich.py
+++ b/src/bib2graph/cli/commands/enrich.py
@@ -1,0 +1,144 @@
+"""cli.commands.enrich — Subcomando ``b2g enrich``.
+
+Enriquece el corpus resolviendo ``references_id`` → ``references_doi``
+usando OpenAlex.  Persiste el corpus enriquecido en el store.
+
+Hito 8a: solo la resolución references→DOI.
+Hito 8b (futuro): poblar ``cited_by_id`` (segundo nivel de fetch).
+
+Nota: ``enrich`` NO transiciona el ``CycleState`` del store —el enriquecimiento
+es una operación ortogonal al FSM del lazo bibliométrico.  Si en el futuro
+se decide transicionar (p. ej. a un estado ENRICHED), se agrega la llamada
+a ``apply_transition`` aquí, sin tocar el FSM en el núcleo.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import click
+
+from bib2graph.cli._envelope import build_envelope, emit, emit_human
+from bib2graph.cli._errors import handle_errors
+from bib2graph.cli._store import open_store
+
+# ---------------------------------------------------------------------------
+# Función núcleo (testeable, sin Click)
+# ---------------------------------------------------------------------------
+
+
+def run_enrich(
+    store_path: str | Path,
+    *,
+    email: str | None = None,
+    api_key: str | None = None,
+    transport: Any = None,
+) -> dict[str, Any]:
+    """Enriquece el corpus resolviendo ``references_id`` → ``references_doi``.
+
+    Carga el corpus del store, aplica ``OpenAlexEnricher`` y persiste el
+    resultado.  Si el corpus no tiene ``references_id`` en ningún paper,
+    termina con 0 resueltas sin error.
+
+    Args:
+        store_path: Ruta al archivo ``.duckdb``.
+        email: Email para el polite pool de OpenAlex.
+        api_key: API key opcional de OpenAlex.
+        transport: Transport inyectable para tests (``httpx.MockTransport``).
+
+    Returns:
+        Dict con:
+          - ``refs_resolved``: IDs de referencia resueltos a DOI.
+          - ``refs_total_unique``: Total de references_id únicos en el corpus.
+          - ``total_papers``: Número total de papers en el corpus.
+
+    Raises:
+        httpx.HTTPError: Si falla la conexión a OpenAlex (capturado por
+            ``@handle_errors`` como exit 4).
+        StoreError: Si el store está bloqueado (exit 5).
+    """
+    from bib2graph.enrichers.openalex import OpenAlexEnricher
+    from bib2graph.sources.openalex import OpenAlexSource
+
+    store = open_store(store_path)
+    corpus = store.load()
+
+    source = OpenAlexSource(email=email, api_key=api_key, transport=transport)
+    enricher = OpenAlexEnricher(source)
+    enriched = enricher.enrich(corpus)
+
+    store.persist(enriched)
+
+    # Extraer métricas del EnricherRef registrado
+    enricher_refs = enriched.manifest.enrichers
+    ref_entry = next(
+        (e for e in enricher_refs if e.name == "openalex_references_doi"), None
+    )
+    refs_resolved = int(ref_entry.params.get("resolved", 0)) if ref_entry else 0
+    refs_total = int(ref_entry.params.get("total_unique_refs", 0)) if ref_entry else 0
+
+    return {
+        "refs_resolved": refs_resolved,
+        "refs_total_unique": refs_total,
+        "total_papers": len(enriched),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Comando Click
+# ---------------------------------------------------------------------------
+
+
+@click.command("enrich")
+@click.option(
+    "--email",
+    default=None,
+    help="Email para el polite pool de OpenAlex.",
+)
+@click.option(
+    "--api-key",
+    default=None,
+    help="API key de OpenAlex (opcional; mejora el rate limit).",
+)
+@click.option(
+    "--json",
+    "json_output",
+    is_flag=True,
+    default=False,
+    help="Salida JSON estructurada.",
+)
+@click.pass_context
+@handle_errors("enrich")
+def enrich_cmd(
+    ctx: click.Context,
+    email: str | None,
+    api_key: str | None,
+    json_output: bool,
+) -> None:
+    """Enriquece el corpus resolviendo references_id → references_doi (Hito 8a).
+
+    Consulta OpenAlex para obtener los DOIs de las referencias citadas por cada
+    paper del corpus y rellena la columna ``references_doi``.
+
+    Si no hay referencias en el corpus, termina con 0 resueltas sin error.
+    """
+    store_path = ctx.obj["store"]
+    data = run_enrich(
+        store_path,
+        email=email,
+        api_key=api_key,
+    )
+
+    if json_output:
+        envelope = build_envelope(
+            command="enrich",
+            ok=True,
+            data=data,
+            exit_code=0,
+        )
+        emit(envelope)
+    else:
+        emit_human(f"Referencias únicas en corpus: {data['refs_total_unique']}")
+        emit_human(f"Referencias resueltas a DOI:  {data['refs_resolved']}")
+        emit_human(f"Total de papers en corpus:    {data['total_papers']}")

--- a/src/bib2graph/enrichers/__init__.py
+++ b/src/bib2graph/enrichers/__init__.py
@@ -1,0 +1,16 @@
+"""enrichers — Enriquecedores de corpus bibliométrico.
+
+Expone los enrichers del núcleo: ``OpenAlexEnricher`` (resolución
+``references_id`` → ``references_doi``).  Los enrichers de extras
+(p. ej. S2) se importan de forma perezosa desde sus extras.
+
+Hito 8a: resolución references→DOI via OpenAlex.
+Hito 8b (futuro): poblado de ``cited_by_id`` (segundo nivel de fetch).
+"""
+
+from __future__ import annotations
+
+from bib2graph.enrichers.base import Enricher
+from bib2graph.enrichers.openalex import OpenAlexEnricher
+
+__all__ = ["Enricher", "OpenAlexEnricher"]

--- a/src/bib2graph/enrichers/base.py
+++ b/src/bib2graph/enrichers/base.py
@@ -1,0 +1,53 @@
+"""enrichers.base — Protocolo ``Enricher``.
+
+Define el contrato que deben cumplir todos los enriquecedores del núcleo
+y los extras.  El ``Enricher`` es un ``Protocol`` comprobable en runtime
+(``@runtime_checkable``) para que el tipo-check y ``isinstance`` funcionen
+sin herencia explícita.
+
+Contrato:
+  - ``enrich(corpus)`` devuelve un ``Corpus`` *nuevo* (semántica de valor).
+  - **Idempotente**: ``enrich(enrich(c))`` produce el mismo resultado que
+    ``enrich(c)`` —sin duplicar datos ni alterar papers no enriquecidos.
+  - **No pierde papers**: el corpus resultado siempre tiene al menos los
+    mismos papers que el corpus de entrada.
+  - **Config inyectada**: las credenciales y dependencias se pasan al
+    constructor, nunca como globales ni default secretos.
+  - El método no transiciona el ``CycleState`` del store; eso lo hace el
+    comando CLI ``b2g enrich`` si corresponde.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from bib2graph.corpus import Corpus
+
+
+@runtime_checkable
+class Enricher(Protocol):
+    """Protocolo de enriquecedor de Corpus.
+
+    Cualquier clase con el método ``enrich(corpus: Corpus) -> Corpus``
+    cumple el protocolo, sin necesidad de herencia explícita.
+
+    Args:
+        corpus: Corpus a enriquecer.
+
+    Returns:
+        Corpus nuevo con los campos adicionales rellenados.
+    """
+
+    def enrich(self, corpus: Corpus) -> Corpus:
+        """Enriquece el corpus y devuelve uno nuevo.
+
+        Semántica de valor: la instancia original no muta nunca.
+        El resultado es idempotente: enriquecer dos veces da el mismo corpus.
+
+        Args:
+            corpus: Corpus a enriquecer.
+
+        Returns:
+            Nuevo ``Corpus`` con los campos enriquecidos.
+        """
+        ...

--- a/src/bib2graph/enrichers/openalex.py
+++ b/src/bib2graph/enrichers/openalex.py
@@ -1,0 +1,151 @@
+"""enrichers.openalex — ``OpenAlexEnricher``: enriquecedor via OpenAlex.
+
+Hito 8a: resuelve ``references_id`` → ``references_doi`` para cada paper
+del corpus, batcheando las consultas contra la API de OpenAlex (≤100 IDs
+por request) y rellenando ``references_doi`` alineado al orden de
+``references_id`` (DOI o None si OpenAlex no lo tiene).
+
+Hito 8b (futuro, NO implementado aquí): poblar ``cited_by_id`` con los IDs
+de papers que citan a cada semilla.  El diseño está preparado: agregar un
+método ``_enrich_cited_by(corpus)`` que consulte
+``GET /works?filter=cites:{openalex_id}`` y rellene solo la columna
+``cited_by_id``, sin agregar filas nuevas al corpus (decisión del PO).
+
+La frontera núcleo/costura se mantiene: el ``OpenAlexSource`` hace la I/O
+(``fetch_dois_for``); el ``OpenAlexEnricher`` orquesta la lógica.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import pyarrow as pa
+
+from bib2graph.constants import Col
+from bib2graph.corpus import Corpus, EnricherRef
+
+if TYPE_CHECKING:
+    from bib2graph.sources.openalex import OpenAlexSource
+
+
+class OpenAlexEnricher:
+    """Enriquece el corpus resolviendo ``references_id`` → ``references_doi``.
+
+    Recibe un ``OpenAlexSource`` ya configurado (con email, api_key y/o
+    transport inyectables), de modo que los tests pueden pasar un
+    ``MockTransport`` sin tocar red.
+
+    Ejemplo::
+
+        source = OpenAlexSource(email="yo@example.com")
+        enricher = OpenAlexEnricher(source)
+        corpus_enriquecido = enricher.enrich(corpus)
+
+    Hito 8b (diseño futuro): para poblar ``cited_by_id``, agregar el método
+    ``_enrich_cited_by(corpus)`` y llamarlo desde ``enrich`` tras la resolución
+    de referencias.  La semántica es: solo rellena ``cited_by_id`` de los papers
+    que ya están en el corpus; NO agrega filas nuevas de citantes.
+    """
+
+    def __init__(self, source: OpenAlexSource) -> None:
+        """Inicializa el enricher con un source ya configurado.
+
+        Args:
+            source: ``OpenAlexSource`` con credenciales y transport inyectados.
+                El enricher reutiliza su cliente httpx y retry/backoff via
+                ``source.fetch_dois_for``.
+        """
+        self._source = source
+
+    def enrich(self, corpus: Corpus) -> Corpus:
+        """Enriquece el corpus resolviendo ``references_id`` → ``references_doi``.
+
+        Algoritmo (Hito 8a):
+        1. Recolecta todos los ``references_id`` únicos del corpus.
+        2. Si no hay ninguno, devuelve el corpus sin modificaciones (0 resueltas).
+        3. Resuelve los IDs a DOIs batcheando por OR (≤100 IDs/request) via
+           ``source.fetch_dois_for``.
+        4. Para cada paper, rellena ``references_doi`` alineado al orden de
+           ``references_id``: DOI si se resolvió, None si no.
+        5. Registra un ``EnricherRef`` en el Manifest (procedencia).
+
+        Idempotente: recomputar sobre el corpus ya enriquecido da el mismo
+        resultado (la columna se sobreescribe, no se acumula).
+
+        Args:
+            corpus: Corpus a enriquecer.
+
+        Returns:
+            Nuevo ``Corpus`` con ``references_doi`` rellenado y ``EnricherRef``
+            registrado en el Manifest.
+        """
+        table = corpus.to_arrow()
+        rows = table.to_pylist()
+
+        # 1. Recolectar todos los references_id únicos
+        all_ref_ids: set[str] = set()
+        for row in rows:
+            refs = row.get(Col.REFERENCES_ID) or []
+            all_ref_ids.update(refs)
+
+        if not all_ref_ids:
+            # Sin referencias → devolver corpus con EnricherRef registrado
+            return self._with_enricher_ref(corpus, resolved=0, total=0)
+
+        # 2. Resolver IDs a DOIs
+        doi_map = self._source.fetch_dois_for(list(all_ref_ids))
+
+        # 3. Rellenar references_doi alineado a references_id
+        enriched_rows: list[dict[str, Any]] = []
+        for row in rows:
+            row_copy = dict(row)
+            refs = row_copy.get(Col.REFERENCES_ID) or []
+            if refs:
+                row_copy[Col.REFERENCES_DOI] = [doi_map.get(rid) for rid in refs]
+            else:
+                row_copy[Col.REFERENCES_DOI] = None
+            enriched_rows.append(row_copy)
+
+        # 4. Reconstruir tabla Arrow con el schema canónico
+        from bib2graph.schemas import CORPUS_SCHEMA
+
+        new_table = pa.Table.from_pylist(enriched_rows, schema=CORPUS_SCHEMA)
+        new_corpus = Corpus.from_arrow(new_table)
+
+        # Preservar el manifest original (excepto el campo enrichers)
+        resolved = sum(1 for doi in doi_map.values() if doi)
+        return self._with_enricher_ref(
+            new_corpus.with_manifest(corpus.manifest),
+            resolved=resolved,
+            total=len(all_ref_ids),
+        )
+
+    def _with_enricher_ref(
+        self, corpus: Corpus, *, resolved: int, total: int
+    ) -> Corpus:
+        """Devuelve un Corpus nuevo con el EnricherRef de esta pasada registrado.
+
+        Idempotente: si ya existe un EnricherRef con el mismo nombre, lo
+        reemplaza (no acumula duplicados al re-enriquecer).
+
+        Args:
+            corpus: Corpus al que agregar el EnricherRef.
+            resolved: Cantidad de referencias resueltas en esta pasada.
+            total: Total de references_id únicos del corpus.
+
+        Returns:
+            Nuevo ``Corpus`` con el Manifest actualizado.
+        """
+        params = {
+            "resolved": str(resolved),
+            "total_unique_refs": str(total),
+        }
+        new_ref = EnricherRef(name="openalex_references_doi", params=params)
+
+        # Idempotencia: reemplazar si ya existe un enricher con el mismo nombre
+        existing = corpus.manifest.enrichers
+        updated = [e for e in existing if e.name != new_ref.name]
+        updated.append(new_ref)
+
+        new_manifest = corpus.manifest.model_copy(update={"enrichers": updated})
+        return corpus.with_manifest(new_manifest)

--- a/src/bib2graph/sources/openalex.py
+++ b/src/bib2graph/sources/openalex.py
@@ -589,6 +589,102 @@ class OpenAlexSource:
             rows.append(row)
         return rows
 
+    def fetch_dois_for(self, ids: list[str]) -> dict[str, str]:
+        """Resuelve una lista de IDs de OpenAlex a sus DOIs.
+
+        Batchea la consulta en lotes de hasta 100 IDs por request, usando el
+        filtro ``openalex_id:W1|W2|...`` con ``select=id,doi``.  Reutiliza el
+        retry/backoff de ``_fetch_all_with_retry`` para resiliencia ante 429/5xx.
+
+        Diseñado para el ``OpenAlexEnricher`` (Hito 8a): mantiene la frontera
+        núcleo/costura — el Source hace la I/O; el Enricher orquesta.
+
+        Hito 8b (futuro): el mismo patrón sirve para resolver
+        ``cited_by_id``; el Enricher solo necesita un método distinto o un
+        argumento adicional.
+
+        Args:
+            ids: Lista de IDs cortos de OpenAlex (p. ej. ``["W12345", "W67890"]``).
+                Se acepta con o sin prefijo URL; se normalizan a ID corto.
+
+        Returns:
+            Dict ``{openalex_id: doi}`` con los DOIs encontrados.  Los IDs
+            sin DOI en OpenAlex simplemente no aparecen en el resultado.
+        """
+        if not ids:
+            return {}
+
+        # Normalizar IDs a la forma corta (W...) por si vienen como URL
+        normalized = [_oa_id_short(i) or i for i in ids]
+
+        resultado: dict[str, str] = {}
+        batch_size = 100
+
+        for start in range(0, len(normalized), batch_size):
+            lote = normalized[start : start + batch_size]
+            # Filtro OR de OpenAlex: openalex_id:W1|W2|...
+            filter_str = "openalex_id:" + "|".join(lote)
+
+            # Usamos el cliente directamente con select acotado (id + doi)
+            # en lugar de _fetch_all para no traer todos los campos.
+            works = self._fetch_batch_select(filter_str, select="id,doi")
+
+            for work in works:
+                raw_id = work.get("id")
+                raw_doi = work.get("doi")
+                if raw_id and raw_doi:
+                    short_id = _oa_id_short(raw_id)
+                    doi = _normalize_doi(raw_doi)
+                    if short_id and doi:
+                        resultado[short_id] = doi
+
+        return resultado
+
+    def _fetch_batch_select(
+        self, filter_str: str, *, select: str
+    ) -> list[dict[str, Any]]:
+        """Recupera works de OpenAlex con un ``select`` acotado y retry/backoff.
+
+        A diferencia de ``_fetch_all``, no pagina por cursor: está pensado
+        para lotes de IDs (≤100) donde la respuesta cabe en una sola página.
+        Reutiliza el retry/backoff via la lógica interna de ``_fetch_all_with_retry``
+        adaptada para el parámetro ``select`` personalizado.
+
+        Args:
+            filter_str: Valor del parámetro ``filter`` de la API.
+            select: Campos a traer (p. ej. ``"id,doi"``).
+
+        Returns:
+            Lista de objetos JSON retornados por la API.
+
+        Raises:
+            httpx.HTTPStatusError: Si se agotan los reintentos.
+        """
+        last_exc: Exception | None = None
+        for attempt in range(_RETRY_MAX_ATTEMPTS):
+            try:
+                with self._client() as client:
+                    resp = client.get(
+                        "/works",
+                        params={
+                            "filter": filter_str,
+                            "select": select,
+                            "per_page": 100,
+                        },
+                    )
+                    resp.raise_for_status()
+                    data: dict[str, Any] = resp.json()
+                    return data.get("results") or []
+            except httpx.HTTPStatusError as exc:
+                if exc.response.status_code in _RETRY_STATUS_CODES:
+                    last_exc = exc
+                    wait = _RETRY_BACKOFF_BASE * (2**attempt)
+                    time.sleep(wait)
+                else:
+                    raise
+        assert last_exc is not None
+        raise last_exc
+
     def load(self, path: str) -> Corpus:
         """Carga un export JSON de OpenAlex como ``Corpus``.
 

--- a/tests/unit/test_enrichers.py
+++ b/tests/unit/test_enrichers.py
@@ -1,0 +1,510 @@
+"""Tests unitarios del Hito 8a — ``OpenAlexEnricher`` y ``run_enrich``.
+
+Todos los tests de red usan ``httpx.MockTransport`` (sin red real en CI).
+
+Casos cubiertos:
+1. Resolución refs→DOI: respuesta mockeada → ``references_doi`` poblado y
+   alineado a ``references_id``.
+2. Idempotencia: ``enrich(enrich(c))`` == ``enrich(c)`` (mismo resultado).
+3. Batching: corpus con >100 references únicas dispara >1 request.
+4. Refs no resueltas → None en esa posición (no pierde el paper, no desalinea).
+5. Corpus sin references → 0 resueltas, sin error.
+6. ``run_enrich``: contrato del dict de salida (claves estables).
+7. ``run_enrich``: red caída → propaga ``httpx.ConnectError`` (exit 4 vía
+   ``@handle_errors``).
+8. ``Enricher`` Protocol: ``OpenAlexEnricher`` satisface el protocolo.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pyarrow as pa
+import pytest
+
+from bib2graph.constants import Col
+from bib2graph.corpus import Corpus
+from bib2graph.schemas import CORPUS_SCHEMA
+
+# ---------------------------------------------------------------------------
+# Helpers de filas mínimas y corpus de test
+# ---------------------------------------------------------------------------
+
+
+def _make_row(
+    *,
+    id: str,
+    openalex_id: str | None = None,
+    references_id: list[str] | None = None,
+) -> dict[str, Any]:
+    """Fila mínima compatible con el schema canónico."""
+    return {
+        "id": id,
+        "openalex_id": openalex_id,
+        "doi": None,
+        "title": f"Paper {id}",
+        "year": 2020,
+        "abstract": None,
+        "source": None,
+        "language": "en",
+        "publisher": None,
+        "research_areas": None,
+        "is_seed": True,
+        "curation_status": "candidate",
+        "provenance": None,
+        "authors_raw": None,
+        "authors_id": None,
+        "authors_affiliations": None,
+        "keywords_raw": None,
+        "keywords_id": None,
+        "institutions_raw": None,
+        "institutions_id": None,
+        "references_id": references_id,
+        "references_doi": None,
+        "cited_by_id": None,
+    }
+
+
+def _corpus_from_rows(rows: list[dict[str, Any]]) -> Corpus:
+    """Construye un Corpus Arrow desde una lista de dicts."""
+    table = pa.Table.from_pylist(rows, schema=CORPUS_SCHEMA)
+    return Corpus.from_arrow(table)
+
+
+# ---------------------------------------------------------------------------
+# Helpers de mocks HTTP
+# ---------------------------------------------------------------------------
+
+
+def _make_dois_transport(
+    id_doi_map: dict[str, str],
+) -> httpx.MockTransport:
+    """MockTransport que responde a consultas ``openalex_id:`` con los DOIs dados.
+
+    Responde con una lista de objetos ``{id: url, doi: url}`` filtrando por
+    los IDs presentes en el filtro OR de la request.
+    """
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        # Extraer los IDs pedidos del parámetro filter
+        url_str = str(request.url)
+        results = []
+        for short_id, doi in id_doi_map.items():
+            if short_id in url_str:
+                results.append(
+                    {
+                        "id": f"https://openalex.org/{short_id}",
+                        "doi": f"https://doi.org/{doi}",
+                    }
+                )
+        body = {
+            "results": results,
+            "meta": {"count": len(results), "next_cursor": None},
+        }
+        return httpx.Response(
+            200,
+            json=body,
+            headers={"x-openalex-api-version": "2026-05-01"},
+        )
+
+    return httpx.MockTransport(handler)
+
+
+def _make_error_transport() -> httpx.MockTransport:
+    """MockTransport que simula error de red."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("Sin conexión (mock)")
+
+    return httpx.MockTransport(handler)
+
+
+def _make_counting_transport(
+    id_doi_map: dict[str, str],
+) -> tuple[httpx.MockTransport, list[int]]:
+    """MockTransport que cuenta cuántas requests recibe.
+
+    Returns:
+        Tupla ``(transport, call_counter)`` donde ``call_counter[0]`` se
+        incrementa en cada request recibida.
+    """
+    calls: list[int] = [0]
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls[0] += 1
+        url_str = str(request.url)
+        results = []
+        for short_id, doi in id_doi_map.items():
+            if short_id in url_str:
+                results.append(
+                    {
+                        "id": f"https://openalex.org/{short_id}",
+                        "doi": f"https://doi.org/{doi}",
+                    }
+                )
+        body = {
+            "results": results,
+            "meta": {"count": len(results), "next_cursor": None},
+        }
+        return httpx.Response(200, json=body)
+
+    return httpx.MockTransport(handler), calls
+
+
+# ---------------------------------------------------------------------------
+# Importaciones diferidas (para que el módulo importe limpio sin duckdb en scope)
+# ---------------------------------------------------------------------------
+
+
+def _make_enricher(transport: httpx.BaseTransport) -> Any:
+    from bib2graph.enrichers.openalex import OpenAlexEnricher
+    from bib2graph.sources.openalex import OpenAlexSource
+
+    source = OpenAlexSource(email="test@example.com", transport=transport)
+    return OpenAlexEnricher(source)
+
+
+# ---------------------------------------------------------------------------
+# 1. Resolución refs→DOI: references_doi poblado y alineado
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_enrich_resuelve_references_doi() -> None:
+    """``enrich`` rellena ``references_doi`` alineado a ``references_id``."""
+    doi_map = {"W1111111": "10.1000/paper1", "W2222222": "10.1000/paper2"}
+    corpus = _corpus_from_rows(
+        [
+            _make_row(
+                id="P1",
+                openalex_id="W9999999",
+                references_id=["W1111111", "W2222222"],
+            )
+        ]
+    )
+
+    enricher = _make_enricher(_make_dois_transport(doi_map))
+    result = enricher.enrich(corpus)
+
+    table = result.to_arrow()
+    refs_doi = table.column(Col.REFERENCES_DOI).to_pylist()[0]
+
+    assert refs_doi is not None
+    assert len(refs_doi) == 2
+    assert refs_doi[0] == "10.1000/paper1"
+    assert refs_doi[1] == "10.1000/paper2"
+
+
+@pytest.mark.unit
+def test_enrich_alineacion_con_references_id() -> None:
+    """El orden de ``references_doi`` coincide exactamente con ``references_id``."""
+    # DOI del primer ID pero NO del segundo
+    doi_map = {"W1111111": "10.1000/paper1"}
+    corpus = _corpus_from_rows(
+        [
+            _make_row(
+                id="P1",
+                references_id=["W1111111", "W2222222"],
+            )
+        ]
+    )
+
+    enricher = _make_enricher(_make_dois_transport(doi_map))
+    result = enricher.enrich(corpus)
+
+    table = result.to_arrow()
+    refs_doi = table.column(Col.REFERENCES_DOI).to_pylist()[0]
+
+    assert refs_doi is not None
+    assert refs_doi[0] == "10.1000/paper1"  # resuelto
+    assert refs_doi[1] is None  # no resuelto → None
+
+
+# ---------------------------------------------------------------------------
+# 2. Idempotencia: enrich(enrich(c)) == enrich(c)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_enrich_idempotente() -> None:
+    """``enrich(enrich(c))`` produce el mismo corpus que ``enrich(c)``."""
+    doi_map = {"W1111111": "10.1000/paper1", "W2222222": "10.1000/paper2"}
+    corpus = _corpus_from_rows(
+        [
+            _make_row(
+                id="P1",
+                references_id=["W1111111", "W2222222"],
+            )
+        ]
+    )
+
+    enricher = _make_enricher(_make_dois_transport(doi_map))
+    once = enricher.enrich(corpus)
+    twice = enricher.enrich(once)
+
+    # Contenido idéntico (mismos DOIs, sin duplicar)
+    once_table = once.to_arrow()
+    twice_table = twice.to_arrow()
+    once_doi = once_table.column(Col.REFERENCES_DOI).to_pylist()[0]
+    twice_doi = twice_table.column(Col.REFERENCES_DOI).to_pylist()[0]
+
+    assert once_doi == twice_doi
+
+
+@pytest.mark.unit
+def test_enrich_idempotente_enricher_ref_no_duplica() -> None:
+    """El EnricherRef en el Manifest no se duplica al enriquecer dos veces."""
+    doi_map = {"W1111111": "10.1000/paper1"}
+    corpus = _corpus_from_rows([_make_row(id="P1", references_id=["W1111111"])])
+
+    enricher = _make_enricher(_make_dois_transport(doi_map))
+    once = enricher.enrich(corpus)
+    twice = enricher.enrich(once)
+
+    enricher_refs = twice.manifest.enrichers
+    names = [e.name for e in enricher_refs]
+    # Solo debe haber UNA entrada "openalex_references_doi"
+    assert names.count("openalex_references_doi") == 1
+
+
+# ---------------------------------------------------------------------------
+# 3. Batching: >100 references únicas → >1 request
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_enrich_batching_mas_de_100_referencias() -> None:
+    """Un corpus con >100 references únicas dispara más de 1 request HTTP."""
+    # Crear 150 IDs únicos
+    n = 150
+    ref_ids = [f"W{i:07d}" for i in range(1, n + 1)]
+    doi_map = {rid: f"10.1000/{rid.lower()}" for rid in ref_ids}
+
+    corpus = _corpus_from_rows([_make_row(id="P1", references_id=ref_ids)])
+
+    transport, call_counter = _make_counting_transport(doi_map)
+    enricher = _make_enricher(transport)
+    enricher.enrich(corpus)
+
+    # Con batch_size=100 y 150 IDs únicos → 2 requests mínimo
+    assert call_counter[0] >= 2
+
+
+@pytest.mark.unit
+def test_enrich_batching_exactamente_100_referencias() -> None:
+    """100 referencias exactas → 1 sola request (límite justo del batch)."""
+    n = 100
+    ref_ids = [f"W{i:07d}" for i in range(1, n + 1)]
+    doi_map = {rid: f"10.1000/{rid.lower()}" for rid in ref_ids}
+
+    corpus = _corpus_from_rows([_make_row(id="P1", references_id=ref_ids)])
+
+    transport, call_counter = _make_counting_transport(doi_map)
+    enricher = _make_enricher(transport)
+    enricher.enrich(corpus)
+
+    assert call_counter[0] == 1
+
+
+# ---------------------------------------------------------------------------
+# 4. Refs no resueltas → None (no pierde el paper ni desalinea)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_enrich_ref_no_resuelta_es_none() -> None:
+    """Una referencia sin DOI en OpenAlex → None en esa posición."""
+    # doi_map NO contiene W9999999 → no se resuelve
+    doi_map = {"W1111111": "10.1000/paper1"}
+    corpus = _corpus_from_rows(
+        [
+            _make_row(
+                id="P1",
+                references_id=["W1111111", "W9999999"],
+            )
+        ]
+    )
+
+    enricher = _make_enricher(_make_dois_transport(doi_map))
+    result = enricher.enrich(corpus)
+
+    table = result.to_arrow()
+    refs_doi = table.column(Col.REFERENCES_DOI).to_pylist()[0]
+
+    assert refs_doi is not None
+    assert refs_doi[0] == "10.1000/paper1"
+    assert refs_doi[1] is None
+
+
+@pytest.mark.unit
+def test_enrich_no_pierde_papers() -> None:
+    """El corpus enriquecido tiene al menos tantos papers como el original."""
+    doi_map = {"W1111111": "10.1000/paper1"}
+    rows = [
+        _make_row(id="P1", references_id=["W1111111"]),
+        _make_row(id="P2", references_id=None),
+        _make_row(id="P3", references_id=["W9999999"]),
+    ]
+    corpus = _corpus_from_rows(rows)
+
+    enricher = _make_enricher(_make_dois_transport(doi_map))
+    result = enricher.enrich(corpus)
+
+    assert len(result) == len(corpus)
+
+
+# ---------------------------------------------------------------------------
+# 5. Corpus sin references → 0 resueltas, sin error
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_enrich_corpus_sin_references_no_falla() -> None:
+    """Corpus sin references_id → devuelve corpus sin error y 0 resueltas."""
+    corpus = _corpus_from_rows(
+        [
+            _make_row(id="P1", references_id=None),
+            _make_row(id="P2", references_id=None),
+        ]
+    )
+
+    # El transport nunca debería llamarse
+    transport, call_counter = _make_counting_transport({})
+    enricher = _make_enricher(transport)
+    result = enricher.enrich(corpus)
+
+    # No se hicieron requests a la red
+    assert call_counter[0] == 0
+    # El EnricherRef registra 0/0
+    enricher_refs = result.manifest.enrichers
+    ref_entry = next(
+        (e for e in enricher_refs if e.name == "openalex_references_doi"), None
+    )
+    assert ref_entry is not None
+    assert ref_entry.params["resolved"] == "0"
+    assert ref_entry.params["total_unique_refs"] == "0"
+
+
+# ---------------------------------------------------------------------------
+# 6. run_enrich: contrato del dict de salida (claves estables)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_run_enrich_devuelve_claves_esperadas(tmp_path: Path) -> None:
+    """``run_enrich`` devuelve dict con ``refs_resolved``, ``refs_total_unique``,
+    ``total_papers``."""
+    from bib2graph.cli.commands.enrich import run_enrich
+    from bib2graph.stores.duckdb import DuckDBStore
+
+    doi_map = {"W1111111": "10.1000/paper1"}
+    rows = [_make_row(id="P1", references_id=["W1111111"])]
+    table = pa.Table.from_pylist(rows, schema=CORPUS_SCHEMA)
+    corpus = Corpus.from_arrow(table)
+    store = DuckDBStore(tmp_path / "test.duckdb")
+    store.persist(corpus)
+
+    transport = _make_dois_transport(doi_map)
+    data = run_enrich(tmp_path / "test.duckdb", transport=transport)
+
+    assert "refs_resolved" in data
+    assert "refs_total_unique" in data
+    assert "total_papers" in data
+    assert isinstance(data["refs_resolved"], int)
+    assert isinstance(data["refs_total_unique"], int)
+    assert isinstance(data["total_papers"], int)
+    assert data["total_papers"] == 1
+
+
+@pytest.mark.unit
+def test_run_enrich_corpus_sin_references(tmp_path: Path) -> None:
+    """``run_enrich`` con corpus sin referencias devuelve 0 resueltas, sin error."""
+    from bib2graph.cli.commands.enrich import run_enrich
+    from bib2graph.stores.duckdb import DuckDBStore
+
+    rows = [_make_row(id="P1", references_id=None)]
+    table = pa.Table.from_pylist(rows, schema=CORPUS_SCHEMA)
+    corpus = Corpus.from_arrow(table)
+    store = DuckDBStore(tmp_path / "test.duckdb")
+    store.persist(corpus)
+
+    transport, call_counter = _make_counting_transport({})
+    data = run_enrich(tmp_path / "test.duckdb", transport=transport)
+
+    assert data["refs_resolved"] == 0
+    assert data["refs_total_unique"] == 0
+    assert call_counter[0] == 0  # sin requests a la red
+
+
+# ---------------------------------------------------------------------------
+# 7. run_enrich: red caída → propaga httpx.ConnectError (exit 4 vía @handle_errors)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_run_enrich_red_caida_propaga_error(tmp_path: Path) -> None:
+    """``run_enrich`` con red caída propaga ``httpx.ConnectError`` (exit 4)."""
+    from bib2graph.cli.commands.enrich import run_enrich
+    from bib2graph.stores.duckdb import DuckDBStore
+
+    rows = [_make_row(id="P1", references_id=["W1111111"])]
+    table = pa.Table.from_pylist(rows, schema=CORPUS_SCHEMA)
+    corpus = Corpus.from_arrow(table)
+    store = DuckDBStore(tmp_path / "test.duckdb")
+    store.persist(corpus)
+
+    with pytest.raises(httpx.ConnectError):
+        run_enrich(tmp_path / "test.duckdb", transport=_make_error_transport())
+
+
+# ---------------------------------------------------------------------------
+# 8. Enricher Protocol: OpenAlexEnricher satisface el protocolo
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_openalex_enricher_cumple_protocolo() -> None:
+    """``OpenAlexEnricher`` satisface el ``Enricher`` Protocol."""
+    from bib2graph.enrichers.base import Enricher
+    from bib2graph.enrichers.openalex import OpenAlexEnricher
+    from bib2graph.sources.openalex import OpenAlexSource
+
+    source = OpenAlexSource(email="test@example.com")
+    enricher = OpenAlexEnricher(source)
+
+    assert isinstance(enricher, Enricher)
+
+
+# ---------------------------------------------------------------------------
+# 9. Múltiples papers con referencias solapadas
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_enrich_multiples_papers_referencias_solapadas() -> None:
+    """Corpus con varios papers que comparten referencias → todos resueltos."""
+    doi_map = {
+        "W1111111": "10.1000/paper1",
+        "W2222222": "10.1000/paper2",
+    }
+    rows = [
+        _make_row(id="P1", references_id=["W1111111", "W2222222"]),
+        _make_row(id="P2", references_id=["W2222222"]),
+        _make_row(id="P3", references_id=None),
+    ]
+    corpus = _corpus_from_rows(rows)
+
+    enricher = _make_enricher(_make_dois_transport(doi_map))
+    result = enricher.enrich(corpus)
+
+    table = result.to_arrow()
+    refs_doi = table.column(Col.REFERENCES_DOI).to_pylist()
+
+    # P1: ambos resueltos
+    assert refs_doi[0] == ["10.1000/paper1", "10.1000/paper2"]
+    # P2: uno resuelto
+    assert refs_doi[1] == ["10.1000/paper2"]
+    # P3: sin references → None
+    assert refs_doi[2] is None

--- a/uv.lock
+++ b/uv.lock
@@ -78,7 +78,7 @@ wheels = [
 
 [[package]]
 name = "bib2graph"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
**Ciclo 8a del Hito 8** (co-citación), vía feature-cycle (architect → coder → verifier PASA → architect docs).

## Qué trae
- Costura **`Enricher`** (Protocol) + **`OpenAlexEnricher`** en el **núcleo, sobre OpenAlex** (no extra `[s2]` — ADR 0007/0025).
- Resolución **`references_id → references_doi`** con **batching-por-OR** (≤100, `select=id,doi`), alineada por lookup, **idempotente**, registra `EnricherRef`.
- `OpenAlexSource.fetch_dois_for` / `_fetch_batch_select` (retry/backoff).
- Subcomando **`b2g enrich`** (13 subcomandos); no transiciona `CycleState`; `build` sigue puro/sin red.
- **14 tests** (MockTransport): alineación, idempotencia, split de lotes, ref→None, no pierde papers, `--json`, red caída→exit 4.
- **ADR 0025** + sync de docs (API/ARCH/ROADMAP/PRD/AGENTS).

## Decisiones del PO
A: 8b poblará solo `cited_by_id` (no crece el corpus) · B: núcleo OpenAlex · C: subcomando propio · D: 8b solo semillas aceptadas + tope.

## Verificación
- ✅ verifier PASA · ruff + mypy + **341 tests** verdes · 0 enlaces rotos.

**Pendiente: Ciclo 8b** (poblar `cited_by_id` → co-citación end-to-end).

🤖 Generated with [Claude Code](https://claude.com/claude-code)