### PR TITLE
feat(enrichers): co-citación end-to-end (Hito 8b — completa el Hito 8)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,10 +2,11 @@
 
 > Guía para agentes que operen en este repositorio. El proyecto es una **reescritura
 > clean-room** construida de adentro hacia afuera (docs → núcleo puro y tests → costuras).
-> **Estado (v0.3): Hitos 0–6 + 1.5 construidos y tanda de remediación R1–R5 COMPLETA** tras el
-> red-team de la Nota 06 y el modelo nuevo (ADR 0022/0023; el producto **no usa IA generativa** —
-> el desarrollo SÍ es asistido por IA, pero el scent es bibliométrico determinista). **Próximo:
-> Hito 7 (dedup fuzzy).** Ver `docs/ROADMAP/` y "Estado actual" abajo. El diseño objetivo vive en
+> **Estado (v0.3): Hitos 0–6 + 1.5 construidos, remediación R1–R5 COMPLETA y Hito 8 COMPLETO**
+> (Enricher OpenAlex: refs→DOI + co-citación end-to-end), tras el red-team de la Nota 06 y el modelo
+> nuevo (ADR 0022/0023; el producto **no usa IA generativa** — el desarrollo SÍ es asistido por IA,
+> pero el scent es bibliométrico determinista). **Próximo: Hito 7 (dedup fuzzy).** Ver
+> `docs/ROADMAP/` y "Estado actual" abajo. El diseño objetivo vive en
 > `docs/ARCHITECTURE.md`; los contratos
 > públicos en `docs/API.md`; el producto en `docs/PRD.md`; las reglas que motivan este código en
 > `docs/Notas/01-lecciones-v0.md`. Las decisiones vigentes tras **el giro** son los ADR
@@ -28,7 +29,13 @@
   scent bibliométrico), `preprocessors/` (normalize + thesaurus), `filters/` (PRISMA),
   `networks/` (proyectores, analyzer, spec, facade), `exporters/` (GraphML, CSV) y `cli/`.
   El **CLI `b2g` es real** —paquete `cli/` con 13 subcomandos en `cli/commands/`, no un
-  placeholder—. **341 tests verdes** (mypy/ruff limpios; el núcleo importa sin `duckdb`).
+  placeholder—. **365 tests verdes** (mypy/ruff limpios; el núcleo importa sin `duckdb`).
+- **Hito 8 COMPLETO** (Ciclos 8a + 8b, ADR
+  [0025](docs/decisiones/0025-enricher-cocitacion-openalex.md)): el `OpenAlexEnricher` (opt-in,
+  núcleo) hace 2 pasadas — **refs→DOI** (8a) **+ co-citación end-to-end** (8b): pobla `cited_by_id`
+  trayendo los citantes de las semillas aceptadas vía `OpenAlexSource.fetch_citing_batch` (batcheo OR
+  ≤50 con presupuesto por semilla) y los une (idempotente, sin crecer el corpus). `b2g enrich` con
+  `--max-citing` (tope por semilla); `Networks.quick` → 4 o 5 redes según haya `cited_by_id`.
 - **Tanda de remediación R1–R5 COMPLETA** (v0.3, 2026-06-16). Tras el red-team del AS-BUILT
   ([`docs/Notas/06-critica-as-built-v0.2.md`](docs/Notas/06-critica-as-built-v0.2.md)) el PO bloqueó
   un **modelo nuevo** (ADR [0022](docs/decisiones/0022-producto-sin-ia-generativa.md)/
@@ -40,8 +47,9 @@
   transversal en `status`; **R4** — **scent bibliométrico vía proyectores**, **el producto NO usa
   IA generativa** (se eliminaron `foraging/explain.py`, `explain_candidate`, el extra `[llm]` y la
   "máquina de tensiones"); **R5** — robustez (bulk-load, UTF-8 en la frontera, retry, footguns).
-  Ver `docs/ROADMAP/` (Hitos R1–R5). **PRÓXIMO: Hito 7** (dedup fuzzy `[dedup]`). El entorno se
-  levanta con `uv sync`.
+  Ver `docs/ROADMAP/` (Hitos R1–R5). Tras la remediación se construyó el **Hito 8** (Enricher
+  OpenAlex: refs→DOI + co-citación end-to-end). **PRÓXIMO: Hito 7** (dedup fuzzy `[dedup]`). El
+  entorno se levanta con `uv sync`.
 - Toda la información del producto, la arquitectura, los contratos y la secuencia de
   construcción está en `docs/`. **Leer `docs/ROADMAP/` antes de tocar nada**: cada hito declara
   qué historias del PRD §7 cumple, sus criterios de aceptación (DoD) y los tests TDD que se
@@ -211,7 +219,7 @@ src/bib2graph/
   preprocessors/       # normalize + thesaurus multilingüe DETERMINISTA, sin fallback LLM (núcleo);
                        # dedup fuzzy DETERMINISTA en [dedup]
   filters/             # filtros de inclusión/exclusión con conteo PRISMA (núcleo)
-  enrichers/           # OpenAlexEnricher opt-in, NÚCLEO (refs→DOI = Ciclo 8a ✅; cited_by_id/2º nivel = 8b);
+  enrichers/           # OpenAlexEnricher opt-in, NÚCLEO (Hito 8 ✅: refs→DOI 8a + co-citación 8b → pobla cited_by_id);
                        # Enricher Protocol; S2 ([s2]) reservado para señal adicional, NO el Enricher (ADR 0025)
   networks/            # Projector, Analyzer, NetworkSpec, NetworkArtifact, Networks
   exporters/           # GraphML, CSV
@@ -219,7 +227,7 @@ src/bib2graph/
                        # ParquetStore (export); ZoteroStore ([zotero], V1.1);
                        # Neo4jStore ([neo4j], post-V1)
   cli/                 # paquete de 3 capas (Click → run_<cmd>() núcleo → envelope/errores);
-                       # cli/commands/ = 13 subcomandos (incl. monitor FSM→MONITORED, enrich refs→DOI). CLI = API
+                       # cli/commands/ = 13 subcomandos (incl. monitor FSM→MONITORED, enrich refs→DOI + co-citación). CLI = API
                        # para LLM y agentes (Hito 6, ARCHITECTURE.md §6.3). No es un cli.py plano.
 tests/
   unit/                # tests puros, sin red ni I/O (default)

--- a/docs/API.md
+++ b/docs/API.md
@@ -50,11 +50,13 @@
 > (Hitos 5–6) quedan completas** (ver [`ROADMAP.md`](ROADMAP/README.md)). *(El 12° subcomando `monitor`
 > —AS-BUILT del cleanup pre-v0.3— cierra el paso 8 del ciclo: `MONITORED` ahora es alcanzable.)*
 >
-> **Sincronizado con el Ciclo 8a (2026-06-16):** la costura **`Enricher`** está **construida** (§3) y
-> suma el **13° subcomando `enrich`** (refs→DOI sobre OpenAlex, núcleo; **NO** transiciona el
-> `CycleState`). El Enricher vive en el **núcleo sobre OpenAlex**, no en `[s2]` (ADR
-> [0025](decisiones/0025-enricher-cocitacion-openalex.md)). La **co-citación end-to-end** (poblar
-> `cited_by_id`) queda para el **Ciclo 8b** (pendiente).
+> **Sincronizado con el Hito 8 — Ciclos 8a + 8b (2026-06-16):** la costura **`Enricher`** está
+> **construida** (§3) y suma el **13° subcomando `enrich`** (refs→DOI **+ co-citación** sobre
+> OpenAlex, núcleo; **NO** transiciona el `CycleState`). El Enricher vive en el **núcleo sobre
+> OpenAlex**, no en `[s2]` (ADR [0025](decisiones/0025-enricher-cocitacion-openalex.md)). La
+> **co-citación es end-to-end**: `enrich` puebla `cited_by_id` desde las semillas aceptadas (vía
+> `OpenAlexSource.fetch_citing_batch`, §2) y `Networks.quick` devuelve **4 o 5 redes** según haya
+> `cited_by_id` (§10). Flag `--max-citing`. **Hito 8 completo.**
 
 ## Convenciones
 
@@ -97,13 +99,16 @@ pre-v0.3; el 13° `enrich` en el Ciclo 8a, ADR
   fijo, que **siempre** tiene `fetch_citing` (asimetría deliberada con `chain`, que acepta
   `--direction` variable y sí pre-chequea). Errores accionables: sin corpus/estado previo →
   `DataError` (exit 2). Con `monitor`, **`MONITORED` deja de ser inalcanzable**.
-- **`enrich`** (Ciclo 8a, ADR [0025](decisiones/0025-enricher-cocitacion-openalex.md)): corre el
-  `OpenAlexEnricher` (§3) sobre la biblioteca viva. **8a (hecho):** resuelve `references_id`→
-  `references_doi` (batching por OR) y registra el `EnricherRef` en el `Manifest` (idempotente).
-  Flags: `--email` (polite pool), `--api-key` (opcional), `--json`. `data` =
-  `{enriched, references_resolved, ...}`. **NO transiciona el `CycleState`** (ortogonal al lazo):
-  se puede enriquecer en cualquier estado sin perturbar el FSM. `build` sigue puro/sin red. La
-  co-citación end-to-end (poblar `cited_by_id`, 2º nivel) es el **Ciclo 8b (pendiente)**.
+- **`enrich`** (Hito 8 = Ciclos 8a + 8b, ADR
+  [0025](decisiones/0025-enricher-cocitacion-openalex.md)): corre el `OpenAlexEnricher` (§3) sobre
+  la biblioteca viva en **2 pasadas**. **8a:** resuelve `references_id`→`references_doi` (batching
+  por OR) y registra el `EnricherRef` en el `Manifest` (idempotente). **8b:** la pasada de
+  **co-citación** trae los citantes de las **semillas aceptadas** y **mergea sus `openalex_id` en
+  `cited_by_id`** (unión idempotente; no crece el corpus). Flags: `--email` (polite pool),
+  `--api-key` (opcional), **`--max-citing INTEGER`** (tope de citantes **por semilla**, acota el
+  fetch), `--json`. `data` = `{enriched, references_resolved, ...}`. **NO transiciona el
+  `CycleState`** (ortogonal al lazo): se puede enriquecer en cualquier estado sin perturbar el FSM.
+  `build` sigue puro/sin red.
 
 **`--store` global (obligatoria).** Va en el grupo `b2g`, **antes** del subcomando:
 `b2g --store mi.duckdb seed --equation "..."`. Una investigación = un archivo `.duckdb` (ADR
@@ -468,6 +473,21 @@ class SeedResult(BaseModel):
 | `ScieloSource` / `RedalycSource` / `LaReferenciaSource` | futuro | Fuentes regionales, mínimo universal. Declaradas, no implementadas (ADR 0018). |
 | `RisSource` / `CsvSource` | futuro | No implementados. |
 
+**Capacidades de `OpenAlexSource` fuera del Protocol `Source`** (específicas del backbone, no
+contrato universal; las consumen el `Forager` y el `Enricher`):
+
+- **`fetch_citing(openalex_id) -> list[dict]`** (singular, Forager forward chaining): `GET
+  works?filter=cites:`, con retry/backoff ante 429/5xx (R5). No cambió en el Hito 8.
+- **`fetch_citing_batch(ids, *, max_per_paper) -> dict[seed_id, list[citer_id]]`** (Hito 8b, ADR
+  [0025](decisiones/0025-enricher-cocitacion-openalex.md)): trae los citantes de un conjunto de
+  semillas **batcheando por OR** (`cites:W1|W2|...`, lotes ≤50), pagina por cursor y **atribuye
+  página a página** (cruza `referenced_works` del citante con el set objetivo, por short-id). Con
+  **presupuesto por semilla**: corta la paginación cuando **todas** las semillas del lote alcanzan
+  `max_per_paper` (acota el *fetch*, no solo la columna; **sin starvation** entre semillas; mata el
+  N+1 diferido de R5). Lo consume el `OpenAlexEnricher` (§3) para poblar `cited_by_id`.
+- **`fetch_dois_for(ids) -> dict`** (Hito 8a): resuelve `references_id`→DOI batcheando por OR (lotes
+  ≤100, `select=id,doi`).
+
 **Reporte de cobertura/calidad** (concepto declarado, concreto **v0.2+**; ADR 0018): por
 seed/source, mide % de refs resueltas, % con DOI, distribución idioma/región y completitud del
 enriquecimiento. Alimenta el juicio humano de **cuándo cambiar de Source** y acota la
@@ -479,9 +499,10 @@ en v0.1 (función pura sobre `pa.Table`), sin cablearse vacío (lección 5).
 ## 3. Costura `Enricher` — señal extra (opt-in, ya NO estructural)
 
 Con OpenAlex como backbone, refs y citantes **ya vienen en el corpus** (ADR 0007). El `Enricher`
-deja de ser el camino para co-citación; queda opt-in para **resolver `references` a DOI** y el
-**segundo nivel de fetch** (citantes con sus citas ≡ `cited_by_id` compartido — ver decisión F en
-ADR [0025](decisiones/0025-enricher-cocitacion-openalex.md)). El `Enricher` vive en el **núcleo,
+queda opt-in para **resolver `references` a DOI** y el **segundo nivel de fetch** (poblar
+`cited_by_id` ≡ citantes compartidos — ver decisión F en ADR
+[0025](decisiones/0025-enricher-cocitacion-openalex.md)) que habilita la **co-citación
+end-to-end** (Hito 8 completo). El `Enricher` vive en el **núcleo,
 sobre OpenAlex** (ADR 0025, decisión B), **no** en el extra `[s2]` (ese DoD pre-giro queda superado;
 `[s2]` se reserva para un futuro `SemanticScholarEnricher` de señal adicional).
 
@@ -495,7 +516,7 @@ class Enricher(Protocol):
 
 | Implementación | Estado | Aporta |
 |----------------|--------|--------|
-| `OpenAlexEnricher` | **v1, opt-in (Ciclo 8a construido)** | **refs→DOI hecho:** reúne los `references_id` únicos, los resuelve **batcheando por OR** (lotes ≤100, `openalex_id:W1\|W2\|...`, `select=id,doi`) y rellena `references_doi` por lookup; registra `EnricherRef(name="openalex_references_doi", …)` en el `Manifest` (idempotente: reemplaza por nombre, no duplica). **`cited_by_id` / co-citación end-to-end = Ciclo 8b pendiente** (poblará solo `cited_by_id`, sin crecer el corpus; decisión A) |
+| `OpenAlexEnricher` | **v1, opt-in (Hito 8 = Ciclos 8a + 8b construidos)** | `enrich(corpus)` hace **2 pasadas**. **8a (refs→DOI):** reúne los `references_id` únicos, los resuelve **batcheando por OR** (lotes ≤100, `openalex_id:W1\|W2\|...`, `select=id,doi`) y rellena `references_doi` por lookup; registra `EnricherRef(name="openalex_references_doi", …)` en el `Manifest` (idempotente: reemplaza por nombre, no duplica). **8b (co-citación):** para las **semillas aceptadas** (`is_seed=True AND curation_status=accepted`) trae sus citantes vía `OpenAlexSource.fetch_citing_batch` (§2) y **mergea los `openalex_id` de los citantes en `cited_by_id`** (unión idempotente). **NO** materializa citantes como filas (no crece el corpus; decisión A). Constructor con **`max_citing_per_paper`** (tope **por semilla**, acota el fetch). Frontera: el Source hace I/O + atribución + acotamiento; el Enricher **solo une**. |
 | `SemanticScholarEnricher` | futuro | señal de citas adicional (reserva del `[s2]`, no estructural) |
 | `CrossRefEnricher` / `ScopusEnricher` | futuro | No implementados. |
 
@@ -777,11 +798,12 @@ completo** (crítica #2). La **co-citación** es la más cara (segundo nivel de 
 - **Tipo de nodo** (D2): co-autoría / instituciones / co-word → la **entidad** es el nodo
   (`authors_id` / `institutions_id` / `keywords_id`); acoplamiento / co-citación → el **paper**
   (`id`) es el nodo.
-- **Co-citación en Hito 2:** el `CoCitationProjector` **no cambia** (decisión F, ADR 0025): cuenta
+- **Co-citación:** el `CoCitationProjector` **no cambia** (decisión F, ADR 0025): cuenta
   **`cited_by_id` compartido** = los **citantes compartidos** de la metodología (la frase "citantes
-  con sus citas" ≡ `cited_by_id` compartido). Proyecta con scope `seeds_only`; es válido para los
-  citantes ya presentes en el corpus, pero la co-citación **completa** requiere el 2º nivel de fetch
-  del `OpenAlexEnricher` (poblar `cited_by_id`), que es el **Ciclo 8b** (ADR 0007/0025).
+  con sus citas" ≡ `cited_by_id` compartido). Proyecta con scope `seeds_only`. La co-citación
+  **completa es end-to-end** (Hito 8 ✅): `b2g enrich` (8b) puebla `cited_by_id` con el 2º nivel de
+  fetch del `OpenAlexEnricher` (ADR 0007/0025), y `Networks.quick` la incluye cuando esa columna
+  está poblada (§10).
 
 ---
 
@@ -885,8 +907,10 @@ class Networks:
     def build(corpus: Corpus, spec: NetworkSpec) -> NetworkArtifact: ...
     @staticmethod
     def quick(corpus: Corpus) -> list[NetworkArtifact]:
-        """Arma las specs razonables (coupling full, co-autoría, institución, co-word) y
-        devuelve sus artefactos. Caso 'investigador, baja fricción'."""
+        """Arma las specs razonables y devuelve sus artefactos (caso 'investigador, baja
+        fricción'). Devuelve **4 o 5 redes**: coupling (full), co-autoría, institución, co-word
+        siempre; la **co-citación** se incluye (→5) cuando el corpus tiene `cited_by_id` poblado
+        (tras `b2g enrich`, Hito 8b) y se **omite graceful** (log) si está vacío (→4)."""
 ```
 
 **Modo quick** (v1) cubre baja fricción; **modo spec** (v0.2, YAML) cubre el pipeline declarativo
@@ -894,10 +918,11 @@ versionable.
 
 **Notas de contrato** (Hito 2, ADR [0014](decisiones/0014-proyeccion-redes-pesos-asortatividad.md)):
 
-- **`Networks.quick` arma 4 redes** (coupling `full`, co-autoría, institución, co-word) y **omite
-  la co-citación**, avisándolo por log (D3): la co-citación completa requiere el 2º nivel de fetch
-  del `OpenAlexEnricher` (poblar `cited_by_id`, **Ciclo 8b**; ADR 0025). El `CoCitationProjector`
-  queda disponible vía
+- **`Networks.quick` arma 4 o 5 redes** (D3, AS-BUILT Hito 8b): coupling `full`, co-autoría,
+  institución y co-word **siempre** (4); suma la **co-citación** (→5) cuando el corpus tiene
+  `cited_by_id` poblado por `b2g enrich` (2º nivel de fetch del `OpenAlexEnricher`, ADR 0025), y la
+  **omite avisándolo por log** (→4) si esa columna está vacía (no se corrió `enrich`). El
+  `CoCitationProjector` también queda disponible vía
   `Networks.build(corpus, NetworkSpec(kind="cocitation"))`.
 - **`NetworkSpec` es un hook mínimo en v1** (modelo Pydantic ya consumido por `build`/`quick`); la
   carga desde YAML y la validación avanzada son del Hito 9. El símbolo público re-exportado desde

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -163,7 +163,9 @@ citantes **ya vienen en el corpus**; el `Enricher` deja de ser estructural. El *
 (barato, mira hacia adelante, usa refs que las semillas ya traen) es **ciudadano de primera**
 (crítica #2). La **co-citación** sigue siendo la más cara: necesita los citantes *con sus
 propias citas* (segundo nivel de fetch). El acoplamiento opera sobre el **corpus completo**, no
-solo `is_seed` (rediseño validado en el sandbox IED).
+solo `is_seed` (rediseño validado en el sandbox IED). **AS-BUILT (Hito 8b ✅):** ese 2º nivel ya está
+cableado end-to-end — `b2g enrich` puebla `cited_by_id` (vía `OpenAlexSource.fetch_citing_batch`,
+§4.2) y `Networks.quick` incluye la co-citación cuando esa columna está poblada.
 
 ### 3.3 `Analyzer` — red → resultados
 
@@ -263,14 +265,17 @@ es la fuente y alimenta el juicio de cuándo cambiar de `Source`.
 ### 4.2 `Enricher` — señal extra (opt-in, núcleo sobre OpenAlex)
 
 Con OpenAlex como backbone, **deja de ser estructural** (ADR 0007). Vive en el **núcleo sobre
-OpenAlex** (no en `[s2]`; ADR [0025](decisiones/0025-enricher-cocitacion-openalex.md)). Queda opt-in
-para: **resolver `references_id` a DOI canónico** (OpenAlex las da como URLs internas — T8 del
-sandbox; **Ciclo 8a ✅ construido**, batching por OR, idempotente vía `EnricherRef` en el `Manifest`)
-y el **segundo nivel de fetch** (citantes con sus citas ≡ `cited_by_id` compartido) que habilita la
-co-citación (**Ciclo 8b pendiente**: puebla solo `cited_by_id`, sin crecer el corpus). El subcomando
-`b2g enrich` es propio y **no transiciona el `CycleState`**. S2/CrossRef/Scopus: futuras (`[s2]`
-reservado para señal adicional). Reglas: config inyectada (nunca embebida), sin ramas muertas, rate
-limit y reintentos sin perder papers.
+OpenAlex** (no en `[s2]`; ADR [0025](decisiones/0025-enricher-cocitacion-openalex.md)). El **Hito 8
+está completo** (Ciclos 8a + 8b): `OpenAlexEnricher.enrich` hace **2 pasadas**. **8a** — **resolver
+`references_id` a DOI canónico** (OpenAlex las da como URLs internas — T8 del sandbox; batching por
+OR, idempotente vía `EnricherRef` en el `Manifest`). **8b** — el **segundo nivel de fetch** habilita
+la **co-citación end-to-end**: trae los citantes de las **semillas aceptadas** (vía
+`OpenAlexSource.fetch_citing_batch`: batcheo OR ≤50 con presupuesto por semilla) y **mergea sus
+`openalex_id` en `cited_by_id`** (unión idempotente); **solo puebla `cited_by_id`**, no crece el
+corpus (decisión A). El tope `max_citing_per_paper` **acota el fetch por semilla**. El subcomando
+`b2g enrich` (flag `--max-citing`) es propio y **no transiciona el `CycleState`**. S2/CrossRef/Scopus:
+futuras (`[s2]` reservado para señal adicional). Reglas: config inyectada (nunca embebida), sin ramas
+muertas, rate limit y reintentos sin perder papers.
 
 ### 4.3 `Store` / backend de persistencia (biblioteca viva)
 
@@ -423,9 +428,9 @@ Son **13 subcomandos** (`seed`, `chain`, `filter`, `build`, `export`, `snapshot`
 `inspect`, `validate`, `accept`, `reject`, **`monitor`**, **`enrich`**); `build`/`export` están
 **separados** y el `CycleState` transiciona automáticamente por comando (ADR 0021). El 12°
 **`monitor`** (cleanup pre-v0.3) re-chequea citantes nuevos del corpus (forward chaining) y
-transiciona a `MONITORED`. El 13° **`enrich`** (Ciclo 8a, ADR
-[0025](decisiones/0025-enricher-cocitacion-openalex.md)) corre el `OpenAlexEnricher` (refs→DOI) y
-**no transiciona** el ciclo (ortogonal al lazo). El error de uso (p. ej. falta `--store`) sale **sin
+transiciona a `MONITORED`. El 13° **`enrich`** (Hito 8 = Ciclos 8a + 8b, ADR
+[0025](decisiones/0025-enricher-cocitacion-openalex.md)) corre el `OpenAlexEnricher` (refs→DOI +
+co-citación, flag `--max-citing`) y **no transiciona** el ciclo (ortogonal al lazo). El error de uso (p. ej. falta `--store`) sale **sin
 envelope** (Click aborta el parseo: stderr + exit 1).
 
 **AS-BUILT R5 — UTF-8 en la frontera (Nota 06 RAÍZ 3):** `main()` llama `_force_utf8()` (reconfigura

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -397,5 +397,7 @@ Esta reconciliación ya está reflejada en `ARCHITECTURE.md` (§3.1, §4.3, §6.
    v0.2 alcanza las capacidades del **flujo** `seed → … → export`. **El red-team de la
    [Nota 06](Notas/06-critica-as-built-v0.2.md) corrige el claim "capacidades completas":** falta la
    **tanda de remediación R1–R5** (modelo sin IA, identidad-vs-procedencia reproducible, FSM cíclico,
-   scent bibliométrico, robustez) **antes** de los Hitos 7–11 (dedup fuzzy, `Enricher` co-citación,
-   `NetworkSpec` YAML, viz, Zotero/Neo4j). Estado vivo en el [`ROADMAP.md`](ROADMAP/README.md).
+   scent bibliométrico, robustez) **antes** de los Hitos 7–11. Tras R1–R5 se construyó el **Hito 8 ✅**
+   (`Enricher` OpenAlex: refs→DOI + co-citación end-to-end, `enrich --max-citing`); siguen pendientes
+   los Hitos 7 (dedup fuzzy), 9 (`NetworkSpec` YAML), 10 (viz) y 11 (Zotero/Neo4j). Estado vivo en el
+   [`ROADMAP.md`](ROADMAP/README.md).

--- a/docs/ROADMAP/04-lo-que-viene.md
+++ b/docs/ROADMAP/04-lo-que-viene.md
@@ -31,26 +31,26 @@
 
 ## Hito 8 — `Enricher` opt-in: resolución de refs + co-citación (núcleo OpenAlex)
 
-> **Partición (ADR [0025](../decisiones/0025-enricher-cocitacion-openalex.md), 2026-06-16):** el hito
-> se hace en **2 ciclos**. **8a ✅ (hecho):** costura `Enricher` + refs→DOI + subcomando `b2g enrich`.
-> **8b (pendiente):** co-citación end-to-end (poblar `cited_by_id`), **solo seeds aceptadas + tope
-> configurable**. El Enricher vive en el **núcleo sobre OpenAlex**, **no** en el extra `[s2]`: ese
+> **Partición (ADR [0025](../decisiones/0025-enricher-cocitacion-openalex.md), 2026-06-16) — Hito 8
+> COMPLETO ✅:** el hito se hizo en **2 ciclos**. **8a ✅:** costura `Enricher` + refs→DOI + subcomando
+> `b2g enrich`. **8b ✅:** co-citación end-to-end (poblar `cited_by_id`), **solo seeds aceptadas + tope
+> configurable** (`--max-citing`). El Enricher vive en el **núcleo sobre OpenAlex**, **no** en el extra `[s2]`: ese
 > `[s2]` era residuo pre-giro (ADR [0007](../decisiones/0007-openalex-backbone.md): S2 ya no es
 > estructural) y queda **reservado** para un futuro `SemanticScholarEnricher` de señal adicional.
 
 **Alcance**
 
 - `Enricher` (ya **no estructural**; ADR 0007/0025, API.md §3): **resolver `references_id` a DOI
-  canónico** (T8, **8a ✅**) y el **segundo nivel de fetch** (citantes con sus citas ≡ `cited_by_id`
-  compartido) que habilita la **co-citación** completa (**8b**). El 2º nivel **solo puebla
-  `cited_by_id`**; los citantes NO se materializan como filas del corpus (eso es del `Forager` +
-  curación; decisión A).
+  canónico** (T8, **8a ✅**) y el **segundo nivel de fetch** (citantes ≡ `cited_by_id` compartido) que
+  habilita la **co-citación** completa (**8b ✅**). El 2º nivel **solo puebla `cited_by_id`**; los
+  citantes NO se materializan como filas del corpus (eso es del `Forager` + curación; decisión A).
 - **Batching-por-OR de `fetch_citing`** (seguimiento heredado de R5, encuadrado acá por el arquitecto
-  2026-06-16): R5 entregó **retry/backoff** pero **difirió** el batching (agrupar varios `cites:` en
-  una query `cites:W1|W2|...` para matar el N+1 de requests). El **2º nivel de fetch de este hito** es
-  exactamente donde se vuelve a forrajear citantes/citas a escala, así que el batching **se hace acá**
-  (mejora de performance, no de correctitud: el N+1 ya es resiliente al rate-limit). Ver registro-ia
-  R5.3 y "Cleanup pre-v0.3" C-seguimientos.
+  2026-06-16, **resuelto en 8b ✅**): R5 entregó **retry/backoff** pero **difirió** el batching. El
+  **2º nivel de fetch de este hito** lo materializa: **`OpenAlexSource.fetch_citing_batch`** agrupa
+  varios `cites:` en una query `cites:W1|W2|...` (lotes ≤50) con **presupuesto por semilla**, matando
+  el N+1 de requests (mejora de performance, no de correctitud: el N+1 ya era resiliente al
+  rate-limit). `fetch_citing` singular (Forager) no cambió. Ver registro-ia R5.3 y "Cleanup
+  pre-v0.3" C-seguimientos.
 
 **Historias:** completa **D1** para la red de **co-citación** end-to-end (la más cara) y la
 interoperabilidad de referencias cross-source (OpenAlex ↔ `.bib`).
@@ -62,11 +62,14 @@ interoperabilidad de referencias cross-source (OpenAlex ↔ `.bib`).
   (ortogonal al lazo, decisión C). `build` sigue puro/sin red.
 - **8a ✅** Resuelve `references_id` → `references_doi` **batcheando por OR** (lotes ≤100,
   `openalex_id:W1|W2|...`, `select=id,doi`).
-- **8b** El 2º nivel habilita `CoCitationProjector` completo poblando `cited_by_id` (el projector
+- **8b ✅** El 2º nivel habilita `CoCitationProjector` completo poblando `cited_by_id` (el projector
   **no cambia**: cuenta `cited_by_id` compartido = citantes compartidos; decisión F). Solo seeds
-  aceptadas + tope configurable.
-- **8b** **`fetch_citing` batchea por OR** (`cites:W1|W2|...`) en el 2º nivel de fetch: el N+1 de R5
-  deja de hacer una request por paper (mejora de performance; el retry/backoff de R5 se conserva).
+  aceptadas + tope configurable (`max_citing_per_paper` / `--max-citing`). `Networks.quick` devuelve
+  **4 o 5 redes** según haya `cited_by_id` (incluye co-citación si está poblado; la omite graceful si
+  no).
+- **8b ✅** **`fetch_citing_batch` batchea por OR** (`cites:W1|W2|...`, lotes ≤50) con presupuesto
+  por semilla: el N+1 de R5 deja de hacer una request por paper, sin starvation entre semillas
+  (mejora de performance; el retry/backoff de R5 se conserva).
 - Config/keys **inyectadas**, sin ramas muertas. **Sin red en CI** (mock). Núcleo sin importar
   `duckdb`; sin red al importar.
 

--- a/docs/ROADMAP/README.md
+++ b/docs/ROADMAP/README.md
@@ -40,8 +40,8 @@
 > bibliométrico** (R4: proyectores como olfato, retiro de `explain`/`[llm]`/tensiones, ADR
 > 0020/0022/0008) → **robustez/escala** (R5: bulk-load, UTF-8 en la frontera, `except` anchos de la
 > Nota 06). El `ARCHITECTURE.md` apunta a estos hitos por número (R1–R5).
-> **Lo que falta** (primero la remediación R1–R5, luego v0.3+ → v1.0): Hitos 7 (dedup fuzzy), 8
-> (`Enricher` co-citación), 9 (`NetworkSpec` YAML), 10 (viz) y 11 (Zotero/Neo4j). Tras el **2º giro**
+> **Lo que falta** (tras la remediación R1–R5 y el **Hito 8 ✅** —`Enricher` co-citación end-to-end—,
+> hacia v1.0): Hitos 7 (dedup fuzzy), 9 (`NetworkSpec` YAML), 10 (viz) y 11 (Zotero/Neo4j). Tras el **2º giro**
 > (acta del PO; ADR [0015](../decisiones/0015-corpus-tabular-backend.md)–[0019](../decisiones/0019-concurrencia-diferida.md))
 > se insertó un **Hito 1.5 — Rework de `Corpus` a `TabularBackend`** como el **paso inmediato
 > siguiente, secuenciado por delante del Hito 3** (instrucción explícita del PO: el rework va
@@ -76,8 +76,9 @@ OIDC), no el push de tags. Cortes acordados:
   `API.md` §12). **Sin CLI ni forrajeo todavía** (eso es v0.2). **Tag `v0.1.0`** creado el
   2026-06-15, **publicado en `origin`**.
 > ⚠️ **Honestidad sobre "capacidades completas" (v0.2):** se refiere al *flujo* `seed → chain →
-> filter → build → export`, NO a la totalidad del producto. Falta la **co-citación end-to-end**
-> (Hito 8: `cited_by_id` está vacío tras el seed → 0 aristas hasta el 2º nivel de fetch), y el
+> filter → build → export`, NO a la totalidad del producto. En v0.1/v0.2 faltaba la **co-citación
+> end-to-end** (`cited_by_id` quedaba vacío tras el seed → 0 aristas hasta el 2º nivel de fetch);
+> el **Hito 8 ✅ (Ciclos 8a + 8b)** la cerró: `b2g enrich` puebla `cited_by_id`. Y el
 > *information scent* es —en el AS-BUILT— una **heurística de frecuencia de enlace** (la remediación
 > R4 lo eleva a scent bibliométrico vía proyectores). **Corrección 2026-06-15 (ADR 0022):** lo que
 > antes figuraba acá como "stub/futuro de IA" —`explain_candidate`, el extra `[llm]` y la **máquina
@@ -91,9 +92,9 @@ OIDC), no el push de tags. Cortes acordados:
   `chain`, `filter`, `build`, `export`, `snapshot`, `status`, `inspect`, `validate`, `accept`,
   `reject`, **`monitor`**, **`enrich`**) con envelope `--json` versionado y exit codes 0–5 (ADR
   [0021](../decisiones/0021-cli-agente-native-contrato.md)). El 12° **`monitor`** (cleanup pre-v0.3)
-  re-chequea citantes nuevos del corpus y transiciona a `MONITORED`; el 13° **`enrich`** (Ciclo 8a,
-  ADR [0025](../decisiones/0025-enricher-cocitacion-openalex.md)) resuelve refs→DOI y **no
-  transiciona** el ciclo. El `accept`/`reject` programático
+  re-chequea citantes nuevos del corpus y transiciona a `MONITORED`; el 13° **`enrich`** (Hito 8,
+  ADR [0025](../decisiones/0025-enricher-cocitacion-openalex.md)) resuelve refs→DOI **+ co-citación
+  end-to-end** (`--max-citing`) y **no transiciona** el ciclo. El `accept`/`reject` programático
   sobrevive (ahora como subcomando CLI); la curación interactiva rica (`curate`) y la GUI son
   futuro. Acá se cumple el criterio "V1 hecha" del PRD §9 a nivel de *capacidades* (el número de
   versión sigue en 0.y). **Tag `v0.2.0`** creado el 2026-06-15, **publicado en `origin`**.
@@ -105,7 +106,8 @@ OIDC), no el push de tags. Cortes acordados:
   excluir timestamps; el `LoopState` se mueve a `cycle.py`), pero **no rompe el flujo de 10 minutos**
   ni el contrato `--json` externo. Sin esto, el claim de reproducibilidad y de "ciclo no lineal" no
   se sostiene (Nota 06, RAÍZ 1/2).
-- **v0.4+ — opcionales (Hitos 7–9):** dedup fuzzy, `Enricher` de co-citación, `NetworkSpec`.
+- **v0.4+ — opcionales (Hitos 7–9):** dedup fuzzy, `Enricher` de co-citación (**Hito 8 ✅**:
+  refs→DOI + co-citación end-to-end), `NetworkSpec`.
 - **1.0.0:** API congelada + caso real (IED) reproducido por un usuario distinto del autor (Nota 06,
   PRODUCTO).
 
@@ -196,10 +198,10 @@ limpio y actual; el cuerpo de cada hito vive en su archivo:
 | C2 thesaurus multilingüe | 5 ✅ | `apply_thesaurus` (sobrescribe `keywords_id` desde `keywords_raw`) |
 | C3 filtros incl/excl con conteo | 5 ✅ (lógica) + 6 ✅ (CLI `filter`) | flujo PRISMA; marcan `rejected`, no borran; `b2g filter` con conteos por paso |
 | C4 aceptar/rechazar + biblioteca viva | 1 (modelo) + 1.5 (backend) + 3 (persist DuckDB) + 6 ✅ (CLI `accept`/`reject`) + 11 (Zotero) | `accept`/`reject` ahora subcomandos CLI (`b2g accept/reject --ids`); `curate`+GUI = futuro |
-| D1 cinco proyecciones | 2 + 8 (co-citación) | |
+| D1 cinco proyecciones | 2 + 8 ✅ (co-citación) | co-citación end-to-end vía `b2g enrich` (8b); `Networks.quick` → 4/5 redes según `cited_by_id` |
 | D2 métricas y comunidades | 2 | |
 | D3 asortatividad + composición + proxy | 2 | |
 | D4 export GraphML/CSV | 2 | |
 | E1 snapshot reproducible | 1 + 6 ✅ | `Corpus.snapshot` + `b2g snapshot` |
-| E2 CLI `--json` + exit codes | 0 (principios) + 6 ✅ (CLI) + cleanup pre-v0.3 ✅ (`monitor`) + 8a ✅ (`enrich`) | `b2g` **13 subcomandos** (Hito 6 entregó 11; `monitor` se sumó en el cleanup pre-v0.3 → `MONITORED`; `enrich` en el Ciclo 8a, ADR 0025, sin transición), envelope `--json` versionado, exit 0–5 (ADR 0021) |
+| E2 CLI `--json` + exit codes | 0 (principios) + 6 ✅ (CLI) + cleanup pre-v0.3 ✅ (`monitor`) + 8 ✅ (`enrich`) | `b2g` **13 subcomandos** (Hito 6 entregó 11; `monitor` se sumó en el cleanup pre-v0.3 → `MONITORED`; `enrich` en el Hito 8 —refs→DOI + co-citación, `--max-citing`—, ADR 0025, sin transición), envelope `--json` versionado, exit 0–5 (ADR 0021) |
 

--- a/docs/decisiones/0021-cli-agente-native-contrato.md
+++ b/docs/decisiones/0021-cli-agente-native-contrato.md
@@ -57,8 +57,9 @@ son deterministas y sin estado interactivo.
 
 ### B. `build` y `export` son comandos separados (decisión del PO)
 
-- **`build`** computa las redes con `Networks.quick` (4 redes: acoplamiento sobre corpus completo,
-  co-autoría, instituciones, co-word) y **escribe artefactos intermedios a disco**
+- **`build`** computa las redes con `Networks.quick` (acoplamiento sobre corpus completo,
+  co-autoría, instituciones, co-word, y co-citación si `cited_by_id` está poblado tras `enrich`,
+  Hito 8b → **4 o 5 redes**) y **escribe artefactos intermedios a disco**
   (`<store_dir>/networks/<kind>/network.graphml` + `metrics.json`). Transiciona el `LoopState` a
   `BUILT`.
 - **`export`** **relee** esos artefactos de build y los **serializa** al formato pedido

--- a/docs/decisiones/0025-enricher-cocitacion-openalex.md
+++ b/docs/decisiones/0025-enricher-cocitacion-openalex.md
@@ -1,7 +1,7 @@
 # 0025 — `Enricher` opt-in sobre OpenAlex (núcleo): refs→DOI + co-citación
 
-- **Estado:** Aceptada · **AS-BUILT parcial (2026-06-16)** (Ciclo **8a** implementado en esta rama;
-  **8b** pendiente)
+- **Estado:** Aceptada · **AS-BUILT COMPLETO (2026-06-16)** (Ciclos **8a + 8b** implementados →
+  Hito 8 completo)
 - **Fecha:** 2026-06-16
 - **Relacionada con:** [0007](0007-openalex-backbone.md) (OpenAlex backbone; el Enricher deja de ser
   estructural y S2 se demota), [0004](0004-enriquecimiento-opcional.md) (principio de enriquecimiento
@@ -51,13 +51,28 @@ El hito es grande para un solo ciclo, por lo que se **parte en dos**:
   **idempotente** = reemplaza por nombre, no duplica.
 - Métodos nuevos en `sources/openalex.py`: `fetch_dois_for(ids) -> dict` y `_fetch_batch_select`.
 
-### Ciclo 8b (PENDIENTE)
+### Ciclo 8b (HECHO, as-built)
 
-- **Poblar `cited_by_id`** (2º nivel) y co-citación end-to-end, **solo sobre semillas aceptadas** y
-  con un **tope configurable**.
-- **(Decisión A del PO)** el 2º nivel **solo poblará `cited_by_id`**; los citantes **NO** se
-  materializan como filas del corpus. Crecer el corpus con citantes es trabajo del **`Forager` +
-  curación** (chaining forward + accept/reject), no del Enricher.
+- `OpenAlexEnricher.enrich(corpus)` hace ahora **2 pasadas**: refs→DOI (8a) **+** co-citación (8b).
+  La pasada de co-citación toma las **semillas aceptadas** (`is_seed=True AND
+  curation_status=accepted`), trae sus citantes y **mergea los `openalex_id` de esos citantes en
+  `cited_by_id`** (unión, idempotente). Constructor con `max_citing_per_paper` (tope **por semilla**).
+- **(Decisión A del PO, respetada)** el 2º nivel **solo puebla `cited_by_id`**; los citantes **NO**
+  se materializan como filas del corpus (no crece el corpus). Crecer el corpus con citantes es
+  trabajo del **`Forager` + curación** (chaining forward + accept/reject), no del Enricher.
+- **Contrato `OpenAlexSource.fetch_citing_batch(ids, *, max_per_paper) -> dict[seed_id,
+  list[citer_id]]`**: **batcheo por OR** (`cites:W1|W2|...`, lotes ≤50), pagina por cursor y
+  **atribuye página a página** (cruza `referenced_works` del citante con el set objetivo, por
+  short-id), con **presupuesto por semilla**: corta la paginación cuando **todas** las semillas del
+  lote alcanzaron `max_per_paper`. `max_citing_per_paper` **acota el fetch por semilla**
+  (decisión del PO: el tope acota el *fetch*, no solo la columna), **sin starvation** entre semillas
+  del mismo lote, y mata el N+1 diferido de R5. `fetch_citing` singular (Forager) **no cambió**.
+- **Frontera de responsabilidades:** el `Source` hace **I/O + atribución + acotamiento** (devuelve
+  ya el mapa `seed → citantes` acotado); el `Enricher` **solo une** ese mapa en `cited_by_id`.
+- **`Networks.quick` (`facade.py`)** incluye la red de **co-citación** cuando el corpus tiene
+  `cited_by_id` poblado (→ **5 redes**) y la **omite graceful** (log) si está vacío (→ **4 redes**).
+  El `CoCitationProjector` **no se modificó** (decisión F).
+- CLI `b2g enrich` expone **`--max-citing INTEGER`**.
 
 ### Co-citación: el `CoCitationProjector` no cambia (decisión F del PO)
 
@@ -77,9 +92,12 @@ documentando que el 2º nivel se materializa como **`cited_by_id`** (8b): "citan
   retry/backoff de R5 se conserva).
 - (−) **El DoD del Hito 8 quedaba encuadrado en `[s2]`**: este ADR lo supersede; el `[s2]` pasa a
   reserva para señal adicional futura. Los docs (ROADMAP/04, ARCHITECTURE §4.2, API §3) se sincronizan.
-- (−) **La co-citación completa sigue gateada por 8b**: hasta poblar `cited_by_id` (2º nivel),
-  `Networks.quick` omite la co-citación (avisa por log), como ya documenta API §10.
+- (+) **La co-citación es end-to-end** (8b hecho): `b2g enrich` puebla `cited_by_id` desde las
+  semillas aceptadas y `Networks.quick` devuelve **5 redes** cuando hay `cited_by_id`; si no se
+  corrió `enrich` (columna vacía), omite la co-citación graceful (avisa por log) → **4 redes**.
 
-> **AS-BUILT parcial (2026-06-16):** **8a implementado** en esta rama (`b2g enrich`, refs→DOI,
-> `OpenAlexEnricher`), **13 subcomandos** (era 12: se suma `enrich`). **341 tests verdes.** **8b
-> pendiente** (co-citación end-to-end).
+> **AS-BUILT COMPLETO (2026-06-16):** **8a + 8b implementados** → **Hito 8 completo**. `b2g enrich`
+> (refs→DOI + co-citación, flag `--max-citing`), `OpenAlexEnricher` de 2 pasadas,
+> `OpenAlexSource.fetch_citing_batch` (batcheo OR ≤50 con presupuesto por semilla),
+> `Networks.quick` → 4/5 redes según `cited_by_id`. **13 subcomandos** (`enrich` incluido).
+> **365 tests verdes** (mypy/ruff limpios).

--- a/docs/decisiones/README.md
+++ b/docs/decisiones/README.md
@@ -63,4 +63,4 @@ Qué se vuelve posible/fácil y qué se vuelve costoso/imposible. Trade-offs hon
 | [0022](0022-producto-sin-ia-generativa.md) | El producto no usa IA generativa; la "inteligencia" del forrajeo es estructura bibliométrica | Aceptada |
 | [0023](0023-capa-constants-modelos-schema.md) | Capa base de vocabulario + modelos: `constants`, `ProvenanceEvent`, schema única (`PaperRow` ⇄ `CORPUS_SCHEMA`) | Aceptada |
 | [0024](0024-orden-d3-columna-secuencia-duckdb.md) | Orden D3 en DuckDB vía columna de secuencia interna (`_seq`) | Aceptada · AS-BUILT (2026-06-16) |
-| [0025](0025-enricher-cocitacion-openalex.md) | `Enricher` opt-in sobre OpenAlex (núcleo): refs→DOI + co-citación; supersede el `[s2]` del DoD del Hito 8 | Aceptada · AS-BUILT parcial (2026-06-16): 8a hecho, 8b pendiente |
+| [0025](0025-enricher-cocitacion-openalex.md) | `Enricher` opt-in sobre OpenAlex (núcleo): refs→DOI + co-citación; supersede el `[s2]` del DoD del Hito 8 | Aceptada · AS-BUILT COMPLETO (2026-06-16): 8a + 8b → Hito 8 completo |

--- a/src/bib2graph/cli/commands/enrich.py
+++ b/src/bib2graph/cli/commands/enrich.py
@@ -1,10 +1,9 @@
 """cli.commands.enrich — Subcomando ``b2g enrich``.
 
-Enriquece el corpus resolviendo ``references_id`` → ``references_doi``
-usando OpenAlex.  Persiste el corpus enriquecido en el store.
-
-Hito 8a: solo la resolución references→DOI.
-Hito 8b (futuro): poblar ``cited_by_id`` (segundo nivel de fetch).
+Enriquece el corpus en dos pasadas usando OpenAlex:
+- **Pasada 1 (Hito 8a):** resuelve ``references_id`` → ``references_doi``.
+- **Pasada 2 (Hito 8b):** puebla ``cited_by_id`` de las semillas aceptadas
+  con los IDs de sus citantes (segundo nivel de fetch, batcheado por OR).
 
 Nota: ``enrich`` NO transiciona el ``CycleState`` del store —el enriquecimiento
 es una operación ortogonal al FSM del lazo bibliométrico.  Si en el futuro
@@ -34,23 +33,31 @@ def run_enrich(
     email: str | None = None,
     api_key: str | None = None,
     transport: Any = None,
+    max_citing: int | None = None,
 ) -> dict[str, Any]:
-    """Enriquece el corpus resolviendo ``references_id`` → ``references_doi``.
+    """Enriquece el corpus (refs→DOI y cited_by_id) y persiste el resultado.
 
-    Carga el corpus del store, aplica ``OpenAlexEnricher`` y persiste el
-    resultado.  Si el corpus no tiene ``references_id`` en ningún paper,
-    termina con 0 resueltas sin error.
+    Ejecuta ``OpenAlexEnricher.enrich`` que hace dos pasadas:
+    1. Resuelve ``references_id`` → ``references_doi`` (batcheando ≤100 IDs).
+    2. Puebla ``cited_by_id`` de las semillas aceptadas (batcheando ≤50 IDs
+       con ``cites:`` OR, re-atribuyendo citantes a los seeds que realmente citan).
+
+    Si el corpus no tiene seeds aceptadas ni referencias, termina con 0 sin error.
 
     Args:
         store_path: Ruta al archivo ``.duckdb``.
         email: Email para el polite pool de OpenAlex.
         api_key: API key opcional de OpenAlex.
         transport: Transport inyectable para tests (``httpx.MockTransport``).
+        max_citing: Tope de citantes a registrar en ``cited_by_id`` por paper.
+            ``None`` = sin tope.
 
     Returns:
         Dict con:
           - ``refs_resolved``: IDs de referencia resueltos a DOI.
           - ``refs_total_unique``: Total de references_id únicos en el corpus.
+          - ``citing_new``: Nuevos citantes añadidos a ``cited_by_id``.
+          - ``citing_targets``: Seeds aceptadas procesadas en pasada 2.
           - ``total_papers``: Número total de papers en el corpus.
 
     Raises:
@@ -65,22 +72,29 @@ def run_enrich(
     corpus = store.load()
 
     source = OpenAlexSource(email=email, api_key=api_key, transport=transport)
-    enricher = OpenAlexEnricher(source)
+    enricher = OpenAlexEnricher(source, max_citing_per_paper=max_citing)
     enriched = enricher.enrich(corpus)
 
     store.persist(enriched)
 
-    # Extraer métricas del EnricherRef registrado
+    # Extraer métricas de los EnricherRef registrados
     enricher_refs = enriched.manifest.enrichers
-    ref_entry = next(
+
+    doi_entry = next(
         (e for e in enricher_refs if e.name == "openalex_references_doi"), None
     )
-    refs_resolved = int(ref_entry.params.get("resolved", 0)) if ref_entry else 0
-    refs_total = int(ref_entry.params.get("total_unique_refs", 0)) if ref_entry else 0
+    refs_resolved = int(doi_entry.params.get("resolved", 0)) if doi_entry else 0
+    refs_total = int(doi_entry.params.get("total_unique_refs", 0)) if doi_entry else 0
+
+    cb_entry = next((e for e in enricher_refs if e.name == "openalex_cited_by"), None)
+    citing_new = int(cb_entry.params.get("resolved", 0)) if cb_entry else 0
+    citing_targets = int(cb_entry.params.get("total", 0)) if cb_entry else 0
 
     return {
         "refs_resolved": refs_resolved,
         "refs_total_unique": refs_total,
+        "citing_new": citing_new,
+        "citing_targets": citing_targets,
         "total_papers": len(enriched),
     }
 
@@ -102,6 +116,16 @@ def run_enrich(
     help="API key de OpenAlex (opcional; mejora el rate limit).",
 )
 @click.option(
+    "--max-citing",
+    "max_citing",
+    default=None,
+    type=int,
+    help=(
+        "Tope de citantes a registrar en cited_by_id por paper. "
+        "Default: sin tope (todos los citantes encontrados)."
+    ),
+)
+@click.option(
     "--json",
     "json_output",
     is_flag=True,
@@ -114,20 +138,23 @@ def enrich_cmd(
     ctx: click.Context,
     email: str | None,
     api_key: str | None,
+    max_citing: int | None,
     json_output: bool,
 ) -> None:
-    """Enriquece el corpus resolviendo references_id → references_doi (Hito 8a).
+    """Enriquece el corpus: references→DOI (8a) y cited_by_id (8b).
 
-    Consulta OpenAlex para obtener los DOIs de las referencias citadas por cada
-    paper del corpus y rellena la columna ``references_doi``.
+    Pasada 1: resuelve ``references_id`` → ``references_doi`` consultando OpenAlex.
+    Pasada 2: puebla ``cited_by_id`` de las semillas aceptadas con los IDs
+    de sus citantes (segundo nivel de fetch, batcheado por OR).
 
-    Si no hay referencias en el corpus, termina con 0 resueltas sin error.
+    Si no hay referencias ni semillas aceptadas, termina sin error.
     """
     store_path = ctx.obj["store"]
     data = run_enrich(
         store_path,
         email=email,
         api_key=api_key,
+        max_citing=max_citing,
     )
 
     if json_output:
@@ -141,4 +168,6 @@ def enrich_cmd(
     else:
         emit_human(f"Referencias únicas en corpus: {data['refs_total_unique']}")
         emit_human(f"Referencias resueltas a DOI:  {data['refs_resolved']}")
+        emit_human(f"Seeds aceptadas procesadas:   {data['citing_targets']}")
+        emit_human(f"Nuevos citantes en cited_by:  {data['citing_new']}")
         emit_human(f"Total de papers en corpus:    {data['total_papers']}")

--- a/src/bib2graph/enrichers/openalex.py
+++ b/src/bib2graph/enrichers/openalex.py
@@ -5,14 +5,17 @@ del corpus, batcheando las consultas contra la API de OpenAlex (≤100 IDs
 por request) y rellenando ``references_doi`` alineado al orden de
 ``references_id`` (DOI o None si OpenAlex no lo tiene).
 
-Hito 8b (futuro, NO implementado aquí): poblar ``cited_by_id`` con los IDs
-de papers que citan a cada semilla.  El diseño está preparado: agregar un
-método ``_enrich_cited_by(corpus)`` que consulte
-``GET /works?filter=cites:{openalex_id}`` y rellene solo la columna
-``cited_by_id``, sin agregar filas nuevas al corpus (decisión del PO).
+Hito 8b: puebla ``cited_by_id`` con los IDs de los citantes de cada semilla
+aceptada.  Usa batching por OR (``cites:W1|W2|...``, ≤50 IDs/lote) via
+``source.fetch_citing_batch``.  Re-atribución: como el filtro OR no indica
+qué seed citó cada citante, se cruza ``references_id`` del citante con el
+set de IDs objetivo para asignar el citante solo a los seeds que realmente
+cita.  Idempotente: unión de sets en ``cited_by_id``, sin duplicar.
+Solo rellena ``cited_by_id``; los citantes NO entran como filas nuevas
+(decisión A del PO).
 
-La frontera núcleo/costura se mantiene: el ``OpenAlexSource`` hace la I/O
-(``fetch_dois_for``); el ``OpenAlexEnricher`` orquesta la lógica.
+La frontera núcleo/costura se mantiene: el ``OpenAlexSource`` hace la I/O;
+el ``OpenAlexEnricher`` orquesta la lógica.
 """
 
 from __future__ import annotations
@@ -21,7 +24,7 @@ from typing import TYPE_CHECKING, Any
 
 import pyarrow as pa
 
-from bib2graph.constants import Col
+from bib2graph.constants import Col, CurationStatus
 from bib2graph.corpus import Corpus, EnricherRef
 
 if TYPE_CHECKING:
@@ -29,7 +32,13 @@ if TYPE_CHECKING:
 
 
 class OpenAlexEnricher:
-    """Enriquece el corpus resolviendo ``references_id`` → ``references_doi``.
+    """Enriquece el corpus en dos pasadas.
+
+    **Pasada 1 (Hito 8a):** resuelve ``references_id`` → ``references_doi``.
+
+    **Pasada 2 (Hito 8b):** puebla ``cited_by_id`` de las semillas aceptadas
+    consultando sus citantes en OpenAlex con batching por OR y re-atribuye
+    cada citante solo a los seeds que realmente cita.
 
     Recibe un ``OpenAlexSource`` ya configurado (con email, api_key y/o
     transport inyectables), de modo que los tests pueden pasar un
@@ -38,64 +47,95 @@ class OpenAlexEnricher:
     Ejemplo::
 
         source = OpenAlexSource(email="yo@example.com")
-        enricher = OpenAlexEnricher(source)
+        enricher = OpenAlexEnricher(source, max_citing_per_paper=50)
         corpus_enriquecido = enricher.enrich(corpus)
 
-    Hito 8b (diseño futuro): para poblar ``cited_by_id``, agregar el método
-    ``_enrich_cited_by(corpus)`` y llamarlo desde ``enrich`` tras la resolución
-    de referencias.  La semántica es: solo rellena ``cited_by_id`` de los papers
-    que ya están en el corpus; NO agrega filas nuevas de citantes.
+    El ``max_citing_per_paper`` limita cuántos citantes se registran en
+    ``cited_by_id`` por paper (default ``None`` = sin tope).
     """
 
-    def __init__(self, source: OpenAlexSource) -> None:
+    def __init__(
+        self,
+        source: OpenAlexSource,
+        *,
+        max_citing_per_paper: int | None = None,
+    ) -> None:
         """Inicializa el enricher con un source ya configurado.
 
         Args:
             source: ``OpenAlexSource`` con credenciales y transport inyectados.
                 El enricher reutiliza su cliente httpx y retry/backoff via
-                ``source.fetch_dois_for``.
+                ``source.fetch_dois_for`` y ``source.fetch_citing_batch``.
+            max_citing_per_paper: Tope de citantes a registrar en
+                ``cited_by_id`` por paper objetivo.  ``None`` = sin tope.
         """
         self._source = source
+        self._max_citing_per_paper = max_citing_per_paper
 
     def enrich(self, corpus: Corpus) -> Corpus:
-        """Enriquece el corpus resolviendo ``references_id`` → ``references_doi``.
+        """Enriquece el corpus en dos pasadas (refs→DOI y cited_by_id).
 
-        Algoritmo (Hito 8a):
-        1. Recolecta todos los ``references_id`` únicos del corpus.
-        2. Si no hay ninguno, devuelve el corpus sin modificaciones (0 resueltas).
-        3. Resuelve los IDs a DOIs batcheando por OR (≤100 IDs/request) via
-           ``source.fetch_dois_for``.
-        4. Para cada paper, rellena ``references_doi`` alineado al orden de
-           ``references_id``: DOI si se resolvió, None si no.
-        5. Registra un ``EnricherRef`` en el Manifest (procedencia).
+        Algoritmo:
+        1. **Pasada 1 (refs→DOI):** recolecta ``references_id`` únicos, los
+           resuelve a DOIs batcheando por OR (≤100 IDs/request) y rellena
+           ``references_doi`` alineado al orden de ``references_id``.
+        2. **Pasada 2 (cited_by_id):** identifica semillas aceptadas
+           (``is_seed=True AND curation_status=accepted``); batchea sus IDs
+           en lotes ≤50 con ``fetch_citing_batch``; re-atribuye cada citante
+           a los seeds que realmente cita cruzando ``references_id`` del
+           citante con el set de IDs objetivo; respeta ``max_citing_per_paper``.
+        3. Registra dos ``EnricherRef`` en el Manifest (uno por pasada).
 
-        Idempotente: recomputar sobre el corpus ya enriquecido da el mismo
-        resultado (la columna se sobreescribe, no se acumula).
+        **Idempotente:** re-enriquecer produce el mismo resultado (``cited_by_id``
+        es una unión de sets; los DOIs se sobreescriben).
+
+        **No pierde papers:** el corpus resultado tiene exactamente los mismos
+        papers que el corpus de entrada; los citantes NO se agregan como filas.
 
         Args:
             corpus: Corpus a enriquecer.
 
         Returns:
-            Nuevo ``Corpus`` con ``references_doi`` rellenado y ``EnricherRef``
-            registrado en el Manifest.
+            Nuevo ``Corpus`` con ``references_doi`` y ``cited_by_id`` rellenados
+            y dos ``EnricherRef`` registrados en el Manifest.
+        """
+        # Pasada 1: references_id → references_doi
+        corpus = self._enrich_references_doi(corpus)
+
+        # Pasada 2: cited_by_id para semillas aceptadas
+        corpus = self._enrich_cited_by(corpus)
+
+        return corpus
+
+    # ------------------------------------------------------------------
+    # Pasada 1: references_id → references_doi
+    # ------------------------------------------------------------------
+
+    def _enrich_references_doi(self, corpus: Corpus) -> Corpus:
+        """Rellena ``references_doi`` alineado a ``references_id``.
+
+        Args:
+            corpus: Corpus de entrada.
+
+        Returns:
+            Corpus con ``references_doi`` rellenado y ``EnricherRef`` registrado.
         """
         table = corpus.to_arrow()
         rows = table.to_pylist()
 
-        # 1. Recolectar todos los references_id únicos
+        # Recolectar todos los references_id únicos
         all_ref_ids: set[str] = set()
         for row in rows:
             refs = row.get(Col.REFERENCES_ID) or []
             all_ref_ids.update(refs)
 
         if not all_ref_ids:
-            # Sin referencias → devolver corpus con EnricherRef registrado
-            return self._with_enricher_ref(corpus, resolved=0, total=0)
+            return self._with_refs_doi_ref(corpus, resolved=0, total=0)
 
-        # 2. Resolver IDs a DOIs
+        # Resolver IDs a DOIs
         doi_map = self._source.fetch_dois_for(list(all_ref_ids))
 
-        # 3. Rellenar references_doi alineado a references_id
+        # Rellenar references_doi alineado a references_id
         enriched_rows: list[dict[str, Any]] = []
         for row in rows:
             row_copy = dict(row)
@@ -106,27 +146,114 @@ class OpenAlexEnricher:
                 row_copy[Col.REFERENCES_DOI] = None
             enriched_rows.append(row_copy)
 
-        # 4. Reconstruir tabla Arrow con el schema canónico
         from bib2graph.schemas import CORPUS_SCHEMA
 
         new_table = pa.Table.from_pylist(enriched_rows, schema=CORPUS_SCHEMA)
-        new_corpus = Corpus.from_arrow(new_table)
+        new_corpus = Corpus.from_arrow(new_table).with_manifest(corpus.manifest)
 
-        # Preservar el manifest original (excepto el campo enrichers)
         resolved = sum(1 for doi in doi_map.values() if doi)
-        return self._with_enricher_ref(
-            new_corpus.with_manifest(corpus.manifest),
-            resolved=resolved,
-            total=len(all_ref_ids),
+        return self._with_refs_doi_ref(
+            new_corpus, resolved=resolved, total=len(all_ref_ids)
         )
 
-    def _with_enricher_ref(
+    # ------------------------------------------------------------------
+    # Pasada 2: cited_by_id para semillas aceptadas (Hito 8b)
+    # ------------------------------------------------------------------
+
+    def _enrich_cited_by(self, corpus: Corpus) -> Corpus:
+        """Puebla ``cited_by_id`` de las semillas aceptadas.
+
+        Algoritmo:
+        1. Filtra las semillas con ``curation_status=accepted`` y ``openalex_id``
+           no nulo (solo esas tienen IDs válidos para consultar en OpenAlex).
+        2. Si no hay ninguna, devuelve el corpus sin modificar y registra el
+           ``EnricherRef`` con 0 citantes.
+        3. Batchea los IDs objetivo en lotes ≤50 con
+           ``source.fetch_citing_batch``, que pagina con cursor, atribuye
+           por semilla y acota por ``max_per_paper`` (presupuesto por semilla).
+           Devuelve ``{seed_id: [citer_id]}``, ya atribuido y acotado.
+        4. Une los citantes devueltos con los existentes en ``cited_by_id``
+           (idempotencia) y re-aplica el tope.
+        5. Respeta ``max_citing_per_paper``: el Source ya acotó y atribuyó por
+           semilla con presupuesto per-seed (orden determinista, alfabético).
+        6. Idempotencia: ``cited_by_id`` es una unión de sets (existente +
+           nuevos); re-enriquecer no duplica.
+
+        Args:
+            corpus: Corpus (ya con pasada 1 aplicada).
+
+        Returns:
+            Corpus con ``cited_by_id`` rellenado y ``EnricherRef`` registrado.
+        """
+        table = corpus.to_arrow()
+        rows = table.to_pylist()
+
+        # 1. Identificar semillas aceptadas con openalex_id
+        target_ids: list[str] = []
+        for row in rows:
+            if (
+                row.get(Col.IS_SEED)
+                and row.get(Col.CURATION_STATUS) == CurationStatus.ACCEPTED
+                and row.get(Col.OPENALEX_ID)
+            ):
+                target_ids.append(str(row[Col.OPENALEX_ID]))
+
+        if not target_ids:
+            return self._with_cited_by_ref(corpus, resolved=0, total=0)
+
+        target_set: set[str] = set(target_ids)
+
+        # 2. Batching: fetch_citing_batch loteó en ≤50, paginó con presupuesto
+        # por semilla y devuelve ya atribuido y acotado: {seed_id: [citer_id]}
+        citing_dict = self._source.fetch_citing_batch(
+            target_ids, max_per_paper=self._max_citing_per_paper
+        )
+
+        # 3. Reconstruir filas con cited_by_id actualizado (unión con existentes).
+        # total_new cuenta citantes efectivamente agregados post-tope.
+        enriched_rows: list[dict[str, Any]] = []
+        total_new = 0
+        for row in rows:
+            row_copy = dict(row)
+            oa_id = row_copy.get(Col.OPENALEX_ID)
+            if oa_id and str(oa_id) in target_set:
+                existing: list[str] = list(row_copy.get(Col.CITED_BY_ID) or [])
+                existing_set = set(existing)
+                # Citantes devueltos por el source (ya acotados por max_per_paper)
+                source_citers: list[str] = citing_dict.get(str(oa_id)) or []
+                # Unión determinista; re-aplicar tope para idempotencia robusta
+                merged = sorted(existing_set | set(source_citers))
+                if self._max_citing_per_paper is not None:
+                    merged = merged[: self._max_citing_per_paper]
+                row_copy[Col.CITED_BY_ID] = merged
+                # Contar solo los citantes efectivamente agregados (post-tope)
+                total_new += len(set(merged) - existing_set)
+            enriched_rows.append(row_copy)
+
+        from bib2graph.schemas import CORPUS_SCHEMA
+
+        new_table = pa.Table.from_pylist(enriched_rows, schema=CORPUS_SCHEMA)
+        new_corpus = Corpus.from_arrow(new_table).with_manifest(corpus.manifest)
+
+        return self._with_cited_by_ref(
+            new_corpus,
+            resolved=total_new,
+            total=len(target_ids),
+        )
+
+    # ------------------------------------------------------------------
+    # Helper: registrar EnricherRef en el Manifest (idempotente por nombre)
+    # ------------------------------------------------------------------
+
+    def _with_refs_doi_ref(
         self, corpus: Corpus, *, resolved: int, total: int
     ) -> Corpus:
-        """Devuelve un Corpus nuevo con el EnricherRef de esta pasada registrado.
+        """Registra el ``EnricherRef`` de la pasada refs→DOI (Hito 8a).
 
-        Idempotente: si ya existe un EnricherRef con el mismo nombre, lo
-        reemplaza (no acumula duplicados al re-enriquecer).
+        Usa la clave ``total_unique_refs`` (nombre histórico) para compatibilidad
+        con el código cliente que lee ``params["total_unique_refs"]``.
+
+        Idempotente: reemplaza por nombre si ya existe.
 
         Args:
             corpus: Corpus al que agregar el EnricherRef.
@@ -136,16 +263,54 @@ class OpenAlexEnricher:
         Returns:
             Nuevo ``Corpus`` con el Manifest actualizado.
         """
+        name = "openalex_references_doi"
         params = {
             "resolved": str(resolved),
             "total_unique_refs": str(total),
         }
-        new_ref = EnricherRef(name="openalex_references_doi", params=params)
-
-        # Idempotencia: reemplazar si ya existe un enricher con el mismo nombre
+        new_ref = EnricherRef(name=name, params=params)
         existing = corpus.manifest.enrichers
-        updated = [e for e in existing if e.name != new_ref.name]
+        updated = [e for e in existing if e.name != name]
         updated.append(new_ref)
-
         new_manifest = corpus.manifest.model_copy(update={"enrichers": updated})
         return corpus.with_manifest(new_manifest)
+
+    def _with_cited_by_ref(
+        self, corpus: Corpus, *, resolved: int, total: int
+    ) -> Corpus:
+        """Registra el ``EnricherRef`` de la pasada cited_by (Hito 8b).
+
+        Usa la clave ``total`` para el total de seeds objetivo y ``resolved``
+        para el total de nuevos citantes añadidos.
+
+        Idempotente: reemplaza por nombre si ya existe.
+
+        Args:
+            corpus: Corpus al que agregar el EnricherRef.
+            resolved: Nuevos citantes añadidos a ``cited_by_id`` en esta pasada.
+            total: Total de seeds aceptadas procesadas.
+
+        Returns:
+            Nuevo ``Corpus`` con el Manifest actualizado.
+        """
+        name = "openalex_cited_by"
+        params = {
+            "resolved": str(resolved),
+            "total": str(total),
+        }
+        new_ref = EnricherRef(name=name, params=params)
+        existing = corpus.manifest.enrichers
+        updated = [e for e in existing if e.name != name]
+        updated.append(new_ref)
+        new_manifest = corpus.manifest.model_copy(update={"enrichers": updated})
+        return corpus.with_manifest(new_manifest)
+
+    # ------------------------------------------------------------------
+    # Alias de compatibilidad: _with_enricher_ref (Hito 8a)
+    # ------------------------------------------------------------------
+
+    def _with_enricher_ref(
+        self, corpus: Corpus, *, resolved: int, total: int
+    ) -> Corpus:
+        """Alias de ``_with_refs_doi_ref`` para compatibilidad con código externo."""
+        return self._with_refs_doi_ref(corpus, resolved=resolved, total=total)

--- a/src/bib2graph/networks/facade.py
+++ b/src/bib2graph/networks/facade.py
@@ -40,7 +40,7 @@ else:
 
 logger = logging.getLogger(__name__)
 
-# Tipos de red disponibles en Networks.quick (D3: sin co-citación)
+# Tipos de red base en Networks.quick (sin co-citación; esta se añade condicionalmente)
 # Derivado de NetworkKind — fuente única (R1, ADR 0023)
 _QUICK_KINDS: list[str] = [
     NetworkKind.BIBLIOGRAPHIC_COUPLING,
@@ -48,6 +48,24 @@ _QUICK_KINDS: list[str] = [
     NetworkKind.INSTITUTION_COLLAB,
     NetworkKind.KEYWORD_COOCCURRENCE,
 ]
+
+
+def _has_cited_by_data(corpus: Corpus) -> bool:
+    """Devuelve ``True`` si algún paper del corpus tiene ``cited_by_id`` no vacío.
+
+    Se usa para decidir si incluir la red de co-citación en ``Networks.quick``
+    (Hito 8b): si la columna está vacía en todo el corpus, la co-citación
+    produciría 0 nodos/aristas y se omite silenciosamente.
+
+    Args:
+        corpus: Corpus a inspeccionar.
+
+    Returns:
+        ``True`` si al menos un paper tiene ``cited_by_id`` con ≥1 elemento.
+    """
+    table = corpus.to_arrow()
+    col = table.column("cited_by_id")
+    return any(val for val in col.to_pylist())
 
 
 def _louvain_seed_from_hash(corpus_hash: str) -> int:
@@ -176,30 +194,35 @@ class Networks:
 
     @staticmethod
     def quick(corpus: Corpus) -> list[NetworkArtifact]:
-        """Construye las 4 redes principales con configuración razonable.
+        """Construye las redes principales con configuración razonable.
 
         Arma specs para: acoplamiento bibliográfico (full), co-autoría,
         colaboración institucional y co-ocurrencia de keywords.
 
-        La co-citación se OMITE intencionalmente en ``quick`` porque requiere
-        el segundo nivel de fetch del ``OpenAlexEnricher`` (Hito 8). El
-        ``CoCitationProjector`` sí está implementado y disponible vía
-        ``Networks.build(corpus, NetworkSpec(kind='cocitation'))``.
+        **Co-citación (Hito 8b):** se incluye si el corpus tiene ``cited_by_id``
+        poblado en al menos un paper (es decir, si pasó por el
+        ``OpenAlexEnricher`` con la pasada 2).  Si ``cited_by_id`` está vacío
+        en todo el corpus, la co-citación se omite sin error (avisa por log).
 
         Args:
             corpus: Corpus de origen.
 
         Returns:
-            Lista de 4 ``NetworkArtifact`` (coupling, co-autoría, institución,
-            co-word).
+            Lista de 4 o 5 ``NetworkArtifact`` (coupling, co-autoría,
+            institución, co-word y, condicionalmente, co-citación).
         """
-        logger.info(
-            "Networks.quick: construyendo 4 redes (coupling, co-autoría, "
-            "institución, co-word). La co-citación se omite en quick porque "
-            "requiere el 2º nivel de fetch del OpenAlexEnricher (Hito 8). "
-            "Usa Networks.build(corpus, NetworkSpec(kind='cocitation')) para "
-            "proyectar co-citación con los citantes disponibles en el corpus."
-        )
+        kinds = list(_QUICK_KINDS)
 
-        specs = [NetworkSpec(kind=k) for k in _QUICK_KINDS]
+        if _has_cited_by_data(corpus):
+            logger.info("Networks.quick: cited_by_id poblado — incluyendo co-citación.")
+            kinds.append(NetworkKind.COCITATION)
+        else:
+            logger.info(
+                "Networks.quick: cited_by_id vacío — co-citación omitida. "
+                "Ejecutá 'b2g enrich' para poblar cited_by_id de las semillas "
+                "aceptadas, o usá Networks.build(corpus, NetworkSpec(kind='cocitation')) "
+                "para proyectar con los citantes disponibles."
+            )
+
+        specs = [NetworkSpec(kind=k) for k in kinds]
         return [_build_artifact(corpus, spec) for spec in specs]

--- a/src/bib2graph/sources/openalex.py
+++ b/src/bib2graph/sources/openalex.py
@@ -685,6 +685,165 @@ class OpenAlexSource:
         assert last_exc is not None
         raise last_exc
 
+    def fetch_citing_batch(
+        self, ids: list[str], *, max_per_paper: int | None = None
+    ) -> dict[str, list[str]]:
+        """Trae en lote los citantes de varios papers usando ``cites:W1|W2|...``.
+
+        Reemplaza N llamadas individuales a ``fetch_citing`` (patrón N+1) por una
+        sola request por lote (≤50 IDs, límite empírico de OpenAlex para OR en
+        ``cites:``).  Preserva el retry/backoff de ``_fetch_all_with_retry``.
+
+        **Presupuesto por semilla (anti-starvation):** pagina con cursor sobre el
+        filtro OR del lote y, página a página, atribuye cada citante a las semillas
+        objetivo cruzando ``references_id`` del citante con el set de IDs.  Lleva
+        un contador por semilla y deja de paginar cuando TODAS las semillas del
+        lote alcanzaron ``max_per_paper`` citantes (o se agota la paginación).
+        Así la semilla más citada no consume el presupuesto de las demás.
+
+        El filtro ``cites:W1|W2`` es un OR válido en la API de OpenAlex: devuelve
+        todos los works que citan al menos uno de los IDs listados.
+
+        Args:
+            ids: Lista de IDs cortos de OpenAlex (p. ej. ``["W111", "W222"]``).
+                Se normalizan a ID corto internamente.
+            max_per_paper: Presupuesto máximo de citantes a recolectar por semilla.
+                ``None`` = sin tope (pagina todo).  Acota el fetch: cuando todas
+                las semillas del lote alcanzan el tope, se detiene la paginación.
+
+        Returns:
+            Dict ``{seed_id: [citer_id, ...]}``.  Los citantes de cada semilla
+            ya están atribuidos (cruzando ``references_id`` del citante) y
+            acotados a ``max_per_paper``.  Los IDs de citantes son los IDs cortos
+            de OpenAlex.  Orden determinista (alfabético).
+        """
+        if not ids:
+            return {}
+
+        normalized = [_oa_id_short(i) or i for i in ids]
+        batch_size = 50  # límite empírico de OpenAlex para OR en cites:
+
+        result: dict[str, list[str]] = {}
+
+        for start in range(0, len(normalized), batch_size):
+            lote = normalized[start : start + batch_size]
+            lote_set = set(lote)
+            # Acumulador de sets para idempotencia interna (elimina dupes entre páginas)
+            batch_acc: dict[str, set[str]] = {tid: set() for tid in lote}
+
+            # Filtro OR: cites:W1|W2 es un OR válido en OpenAlex (devuelve works que
+            # citan al menos uno de los IDs; no requiere repetir el predicado por ID).
+            filter_str = "cites:" + "|".join(lote)
+
+            # Paginar con cursor, atribuyendo página a página con presupuesto por semilla
+            cursor: str = "*"
+            with self._client() as client:
+                while True:
+                    # Verificar si todas las semillas del lote ya están satisfechas
+                    if max_per_paper is not None and all(
+                        len(batch_acc[tid]) >= max_per_paper for tid in lote
+                    ):
+                        break
+
+                    # Fetch con retry/backoff
+                    page_works = self._fetch_page_with_retry(
+                        client, filter_str, cursor=cursor
+                    )
+                    if page_works is None:
+                        # Error irrecuperable tras reintentos (ya propagado)
+                        break  # pragma: no cover
+
+                    works_list, next_cursor = page_works
+
+                    # Atribuir cada citante de la página a los seeds que realmente cita
+                    for work in works_list:
+                        citer_oa_id = _oa_id_short(work.get("id"))
+                        if not citer_oa_id:
+                            continue
+                        ref_urls: list[str] = work.get("referenced_works") or []
+                        citer_refs: set[str] = {
+                            short
+                            for r in ref_urls
+                            if r and (short := _oa_id_short(r)) is not None
+                        }
+                        # Intersección: seeds que este citante realmente cita
+                        for tid in lote_set & citer_refs:
+                            if (
+                                max_per_paper is None
+                                or len(batch_acc[tid]) < max_per_paper
+                            ):
+                                batch_acc[tid].add(citer_oa_id)
+
+                    if not next_cursor or not works_list:
+                        break
+                    cursor = next_cursor
+
+            # Consolidar en el resultado global (orden determinista: alfabético)
+            for tid in lote:
+                existing = set(result.get(tid) or [])
+                merged = existing | batch_acc[tid]
+                if max_per_paper is not None:
+                    result[tid] = sorted(merged)[:max_per_paper]
+                else:
+                    result[tid] = sorted(merged)
+
+        return result
+
+    def _fetch_page_with_retry(
+        self,
+        client: httpx.Client,
+        filter_str: str,
+        *,
+        cursor: str,
+        per_page: int = 100,
+    ) -> tuple[list[dict[str, Any]], str | None] | None:
+        """Recupera una página de works con retry/backoff ante 429/5xx.
+
+        Comparte la lógica de retry de ``_RETRY_MAX_ATTEMPTS`` y
+        ``_RETRY_BACKOFF_BASE`` sin reimplementar el bucle de backoff.
+
+        Args:
+            client: Cliente httpx ya abierto (reutilizado para conexión persistente).
+            filter_str: Valor del parámetro ``filter`` de la API.
+            cursor: Cursor de paginación (``"*"`` para la primera página).
+            per_page: Tamaño de página (máx. 100 en OpenAlex).
+
+        Returns:
+            Tupla ``(works, next_cursor)`` si la página se obtuvo correctamente,
+            o ``None`` si se agotaron los reintentos (este caso no debería ocurrir
+            porque re-raise al agotar reintentos).
+
+        Raises:
+            httpx.HTTPStatusError: Si se agotan los reintentos.
+        """
+        last_exc: Exception | None = None
+        for attempt in range(_RETRY_MAX_ATTEMPTS):
+            try:
+                resp = client.get(
+                    "/works",
+                    params={
+                        "filter": filter_str,
+                        "select": _FIELDS,
+                        "per_page": per_page,
+                        "cursor": cursor,
+                    },
+                )
+                resp.raise_for_status()
+                data: dict[str, Any] = resp.json()
+                works: list[dict[str, Any]] = data.get("results") or []
+                meta: dict[str, Any] = data.get("meta") or {}
+                next_cursor: str | None = meta.get("next_cursor")
+                return works, next_cursor
+            except httpx.HTTPStatusError as exc:
+                if exc.response.status_code in _RETRY_STATUS_CODES:
+                    last_exc = exc
+                    wait = _RETRY_BACKOFF_BASE * (2**attempt)
+                    time.sleep(wait)
+                else:
+                    raise
+        assert last_exc is not None
+        raise last_exc
+
     def load(self, path: str) -> Corpus:
         """Carga un export JSON de OpenAlex como ``Corpus``.
 

--- a/tests/unit/test_enrichers_8b.py
+++ b/tests/unit/test_enrichers_8b.py
@@ -1,0 +1,1019 @@
+"""Tests unitarios del Hito 8b — co-citación end-to-end.
+
+Todos los tests de red usan ``httpx.MockTransport`` (sin red real en CI).
+
+Casos cubiertos:
+1. Co-citación end-to-end: 2 seeds aceptados + 1 citante compartido →
+   ``cited_by_id`` poblado en ambos → ``CoCitationProjector`` / ``Networks.quick``
+   produce ≥1 arista con peso correcto.
+2. Re-atribución con batch OR: citantes que citan a distintos seeds → cada
+   ``cited_by_id`` recibe solo los citantes correctos.
+3. Idempotencia: re-enrich no duplica en ``cited_by_id``.
+4. Tope ``max_citing_per_paper`` respetado.
+5. Alcance: papers NO-seed o no-aceptados NO se enriquecen.
+6. ``Networks.quick`` sin ``cited_by_id`` → 4 redes, sin fallo (regresión).
+7. ``Networks.quick`` con ``cited_by_id`` → 5 redes, incluyendo co-citación.
+8. No pierde papers; corpus sin seeds aceptados → 0 fetch, sin error.
+9. ``fetch_citing_batch`` en lotes ≤50: 3 seeds → 1 sola request por lote.
+10. Co-citación no afecta papers sin openalex_id.
+11. Presupuesto por semilla (anti-starvation): semilla muy citada no roba cupo.
+12. El tope acota el fetch: se deja de paginar cuando todas las semillas alcanzan tope.
+13. Sin tope (None): pagina todo y atribuye correctamente.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import pyarrow as pa
+import pytest
+
+from bib2graph.constants import CurationStatus
+from bib2graph.corpus import Corpus
+from bib2graph.networks.facade import Networks
+from bib2graph.networks.projectors import CoCitationProjector
+from bib2graph.schemas import CORPUS_SCHEMA
+
+# ---------------------------------------------------------------------------
+# Helpers de filas mínimas
+# ---------------------------------------------------------------------------
+
+
+def _make_row(
+    *,
+    id: str,
+    openalex_id: str | None = None,
+    is_seed: bool = True,
+    curation_status: str = CurationStatus.ACCEPTED,
+    references_id: list[str] | None = None,
+    cited_by_id: list[str] | None = None,
+) -> dict[str, Any]:
+    """Fila mínima compatible con el schema canónico."""
+    return {
+        "id": id,
+        "openalex_id": openalex_id,
+        "doi": None,
+        "title": f"Paper {id}",
+        "year": 2020,
+        "abstract": None,
+        "source": None,
+        "language": "en",
+        "publisher": None,
+        "research_areas": None,
+        "is_seed": is_seed,
+        "curation_status": curation_status,
+        "provenance": None,
+        "authors_raw": None,
+        "authors_id": None,
+        "authors_affiliations": None,
+        "keywords_raw": None,
+        "keywords_id": None,
+        "institutions_raw": None,
+        "institutions_id": None,
+        "references_id": references_id,
+        "references_doi": None,
+        "cited_by_id": cited_by_id,
+    }
+
+
+def _corpus_from_rows(rows: list[dict[str, Any]]) -> Corpus:
+    """Construye un Corpus Arrow desde una lista de dicts."""
+    table = pa.Table.from_pylist(rows, schema=CORPUS_SCHEMA)
+    return Corpus.from_arrow(table)
+
+
+# ---------------------------------------------------------------------------
+# Helpers de MockTransport para cited_by
+# ---------------------------------------------------------------------------
+
+
+def _citing_work(
+    citer_oa_id: str,
+    cites_ids: list[str],
+) -> dict[str, Any]:
+    """Construye un objeto Work de OpenAlex que representa un citante.
+
+    El citante ``citer_oa_id`` tiene en su ``referenced_works`` los IDs
+    ``cites_ids`` (los papers que él cita = los seeds en el corpus).
+    """
+    return {
+        "id": f"https://openalex.org/{citer_oa_id}",
+        "doi": None,
+        "title": f"Citante {citer_oa_id}",
+        "display_name": f"Citante {citer_oa_id}",
+        "publication_year": 2023,
+        "language": "en",
+        "abstract_inverted_index": None,
+        "authorships": [],
+        "keywords": [],
+        "referenced_works": [f"https://openalex.org/{oa_id}" for oa_id in cites_ids],
+        "primary_location": None,
+        "type": "article",
+    }
+
+
+def _make_cited_by_transport(
+    citing_works: list[dict[str, Any]],
+) -> httpx.MockTransport:
+    """MockTransport que responde a consultas ``cites:`` devolviendo works dados.
+
+    Ignora el filtro exacto y devuelve siempre la lista completa (el Enricher
+    se encarga de la re-atribución cruzando ``references_id`` del citante).
+    También responde 200 vacío a las consultas ``openalex_id:`` (pasada DOI).
+    """
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        url_str = str(request.url)
+        # Pasada 1 (references_doi): consultas openalex_id → sin DOIs (vacío)
+        if "openalex_id" in url_str:
+            body = {"results": [], "meta": {"count": 0, "next_cursor": None}}
+        # Pasada 2 (cited_by): consultas cites: → devolver citantes
+        elif "cites" in url_str:
+            body = {
+                "results": citing_works,
+                "meta": {"count": len(citing_works), "next_cursor": None},
+            }
+        else:
+            body = {"results": [], "meta": {"count": 0, "next_cursor": None}}
+        return httpx.Response(
+            200,
+            json=body,
+            headers={"x-openalex-api-version": "2026-05-01"},
+        )
+
+    return httpx.MockTransport(handler)
+
+
+def _make_counting_cited_by_transport(
+    citing_works: list[dict[str, Any]],
+) -> tuple[httpx.MockTransport, dict[str, list[int]]]:
+    """MockTransport que cuenta requests por tipo (openalex_id y cites).
+
+    Returns:
+        Tupla ``(transport, counters)`` donde ``counters`` es un dict con
+        claves ``"doi"`` y ``"citing"``, cada una con una lista de un entero.
+    """
+    counters: dict[str, list[int]] = {"doi": [0], "citing": [0]}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        url_str = str(request.url)
+        if "openalex_id" in url_str:
+            counters["doi"][0] += 1
+            body = {"results": [], "meta": {"count": 0, "next_cursor": None}}
+        elif "cites" in url_str:
+            counters["citing"][0] += 1
+            body = {
+                "results": citing_works,
+                "meta": {"count": len(citing_works), "next_cursor": None},
+            }
+        else:
+            body = {"results": [], "meta": {"count": 0, "next_cursor": None}}
+        return httpx.Response(200, json=body)
+
+    return httpx.MockTransport(handler), counters
+
+
+def _make_enricher(
+    transport: httpx.BaseTransport,
+    max_citing_per_paper: int | None = None,
+) -> Any:
+    """Construye un OpenAlexEnricher con transport inyectado."""
+    from bib2graph.enrichers.openalex import OpenAlexEnricher
+    from bib2graph.sources.openalex import OpenAlexSource
+
+    source = OpenAlexSource(email="test@example.com", transport=transport)
+    return OpenAlexEnricher(source, max_citing_per_paper=max_citing_per_paper)
+
+
+# ---------------------------------------------------------------------------
+# 1. Co-citación end-to-end
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_cocitacion_end_to_end_cited_by_poblado() -> None:
+    """2 seeds aceptados + 1 citante compartido → cited_by_id poblado en ambos."""
+    # Seeds: W100 y W200, ambas aceptadas
+    corpus = _corpus_from_rows(
+        [
+            _make_row(id="P1", openalex_id="W100"),
+            _make_row(id="P2", openalex_id="W200"),
+        ]
+    )
+    # Citante C1 cita a W100 y W200
+    citing_works = [_citing_work("C1", ["W100", "W200"])]
+    transport = _make_cited_by_transport(citing_works)
+
+    enricher = _make_enricher(transport)
+    result = enricher.enrich(corpus)
+
+    table = result.to_arrow()
+    rows = table.to_pylist()
+    cited_by_map = {row["openalex_id"]: row.get("cited_by_id") or [] for row in rows}
+
+    assert "C1" in cited_by_map["W100"], "W100 debe tener C1 como citante"
+    assert "C1" in cited_by_map["W200"], "W200 debe tener C1 como citante"
+
+
+@pytest.mark.unit
+def test_cocitacion_end_to_end_proyector_produce_arista() -> None:
+    """Tras enrich, CoCitationProjector produce ≥1 arista con peso correcto."""
+    corpus = _corpus_from_rows(
+        [
+            _make_row(id="P1", openalex_id="W100"),
+            _make_row(id="P2", openalex_id="W200"),
+        ]
+    )
+    # C1 cita ambos → 1 arista de co-citación peso 1
+    citing_works = [_citing_work("C1", ["W100", "W200"])]
+    transport = _make_cited_by_transport(citing_works)
+
+    enricher = _make_enricher(transport)
+    result = enricher.enrich(corpus)
+
+    projector = CoCitationProjector()
+    g = projector.project(result.to_arrow())
+
+    assert g.number_of_edges() >= 1, "CoCitationProjector debe producir ≥1 arista"
+    edges = list(g.edges(data=True))
+    assert edges[0][2]["weight"] == 1, "Peso debe ser 1 (un citante compartido)"
+
+
+@pytest.mark.unit
+def test_cocitacion_end_to_end_networks_quick_incluye_red() -> None:
+    """Networks.quick incluye co-citación cuando hay cited_by_id poblado."""
+    corpus = _corpus_from_rows(
+        [
+            _make_row(id="P1", openalex_id="W100"),
+            _make_row(id="P2", openalex_id="W200"),
+        ]
+    )
+    citing_works = [_citing_work("C1", ["W100", "W200"])]
+    transport = _make_cited_by_transport(citing_works)
+
+    enricher = _make_enricher(transport)
+    result = enricher.enrich(corpus)
+
+    artifacts = Networks.quick(result)
+    kinds = {a.spec.kind for a in artifacts}
+
+    assert "cocitation" in kinds, "Networks.quick debe incluir co-citación"
+    assert len(artifacts) == 5, "Debe haber 5 redes (4 base + co-citación)"
+
+
+# ---------------------------------------------------------------------------
+# 2. Re-atribución con batch OR
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_reatribucion_citantes_distintos_seeds() -> None:
+    """Citantes que citan a distintos seeds → cited_by_id correcto por seed."""
+    corpus = _corpus_from_rows(
+        [
+            _make_row(id="P1", openalex_id="W100"),
+            _make_row(id="P2", openalex_id="W200"),
+        ]
+    )
+    # C1 cita solo W100; C2 cita solo W200; C3 cita ambos
+    citing_works = [
+        _citing_work("C1", ["W100"]),
+        _citing_work("C2", ["W200"]),
+        _citing_work("C3", ["W100", "W200"]),
+    ]
+    transport = _make_cited_by_transport(citing_works)
+
+    enricher = _make_enricher(transport)
+    result = enricher.enrich(corpus)
+
+    table = result.to_arrow()
+    rows = table.to_pylist()
+    cited_by_map = {
+        row["openalex_id"]: set(row.get("cited_by_id") or []) for row in rows
+    }
+
+    # W100 debe tener C1 y C3 (no C2)
+    assert cited_by_map["W100"] == {"C1", "C3"}, (
+        f"W100 debe tener {{C1, C3}}, tiene {cited_by_map['W100']}"
+    )
+    # W200 debe tener C2 y C3 (no C1)
+    assert cited_by_map["W200"] == {"C2", "C3"}, (
+        f"W200 debe tener {{C2, C3}}, tiene {cited_by_map['W200']}"
+    )
+
+
+@pytest.mark.unit
+def test_reatribucion_citante_sin_referencias_no_se_asigna() -> None:
+    """Un citante sin references_id no contamina ningún cited_by_id."""
+    corpus = _corpus_from_rows([_make_row(id="P1", openalex_id="W100")])
+    # C_empty no tiene referenced_works → no cita a nadie
+    citing_works = [_citing_work("C_empty", [])]
+    transport = _make_cited_by_transport(citing_works)
+
+    enricher = _make_enricher(transport)
+    result = enricher.enrich(corpus)
+
+    table = result.to_arrow()
+    rows_data = table.to_pylist()
+    cited_by = rows_data[0].get("cited_by_id") or []
+    assert cited_by == [] or "C_empty" not in cited_by
+
+
+# ---------------------------------------------------------------------------
+# 3. Idempotencia
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_enrich_cited_by_idempotente() -> None:
+    """Re-enrich no duplica en cited_by_id."""
+    corpus = _corpus_from_rows([_make_row(id="P1", openalex_id="W100")])
+    citing_works = [_citing_work("C1", ["W100"])]
+    transport = _make_cited_by_transport(citing_works)
+
+    enricher = _make_enricher(transport)
+    once = enricher.enrich(corpus)
+    twice = enricher.enrich(once)
+
+    table = twice.to_arrow()
+    rows_data = table.to_pylist()
+    cited_by = rows_data[0].get("cited_by_id") or []
+
+    # No duplicados
+    assert len(cited_by) == len(set(cited_by)), "cited_by_id no debe tener duplicados"
+    assert "C1" in cited_by
+
+
+@pytest.mark.unit
+def test_enrich_cited_by_enricher_ref_no_duplica() -> None:
+    """El EnricherRef 'openalex_cited_by' no se duplica al re-enriquecer."""
+    corpus = _corpus_from_rows([_make_row(id="P1", openalex_id="W100")])
+    citing_works = [_citing_work("C1", ["W100"])]
+    transport = _make_cited_by_transport(citing_works)
+
+    enricher = _make_enricher(transport)
+    once = enricher.enrich(corpus)
+    twice = enricher.enrich(once)
+
+    names = [e.name for e in twice.manifest.enrichers]
+    assert names.count("openalex_cited_by") == 1
+
+
+# ---------------------------------------------------------------------------
+# 4. Tope max_citing_per_paper
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_tope_max_citing_per_paper() -> None:
+    """max_citing_per_paper=2 trunca cited_by_id a 2 citantes por paper."""
+    corpus = _corpus_from_rows([_make_row(id="P1", openalex_id="W100")])
+    # 5 citantes que citan a W100
+    citing_works = [_citing_work(f"C{i}", ["W100"]) for i in range(1, 6)]
+    transport = _make_cited_by_transport(citing_works)
+
+    enricher = _make_enricher(transport, max_citing_per_paper=2)
+    result = enricher.enrich(corpus)
+
+    table = result.to_arrow()
+    rows_data = table.to_pylist()
+    cited_by = rows_data[0].get("cited_by_id") or []
+    assert len(cited_by) <= 2, f"Debe haber ≤2 citantes, hay {len(cited_by)}"
+
+
+@pytest.mark.unit
+def test_tope_none_no_trunca() -> None:
+    """max_citing_per_paper=None no trunca (devuelve todos los citantes)."""
+    corpus = _corpus_from_rows([_make_row(id="P1", openalex_id="W100")])
+    # 10 citantes
+    citing_works = [_citing_work(f"C{i}", ["W100"]) for i in range(1, 11)]
+    transport = _make_cited_by_transport(citing_works)
+
+    enricher = _make_enricher(transport, max_citing_per_paper=None)
+    result = enricher.enrich(corpus)
+
+    table = result.to_arrow()
+    rows_data = table.to_pylist()
+    cited_by = rows_data[0].get("cited_by_id") or []
+    assert len(cited_by) == 10
+
+
+# ---------------------------------------------------------------------------
+# 5. Alcance: NO-seed y no-aceptados no se enriquecen
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_no_seed_no_se_enriquece() -> None:
+    """Papers con is_seed=False no se incluyen como objetivo de cited_by_id."""
+    corpus = _corpus_from_rows(
+        [
+            _make_row(id="P1", openalex_id="W100"),  # seed + accepted
+            _make_row(
+                id="P2",
+                openalex_id="W200",
+                is_seed=False,
+                curation_status=CurationStatus.ACCEPTED,
+            ),  # NO seed
+        ]
+    )
+    citing_works = [_citing_work("C1", ["W100", "W200"])]
+    transport = _make_cited_by_transport(citing_works)
+
+    enricher = _make_enricher(transport)
+    result = enricher.enrich(corpus)
+
+    table = result.to_arrow()
+    rows_data = table.to_pylist()
+    cited_by_map = {
+        row["openalex_id"]: set(row.get("cited_by_id") or []) for row in rows_data
+    }
+
+    # W100 (seed aceptada) debe tener C1
+    assert "C1" in cited_by_map["W100"]
+    # W200 (NO seed) no debe tener C1 en cited_by_id (no fue objetivo del fetch)
+    assert "C1" not in cited_by_map.get("W200", set())
+
+
+@pytest.mark.unit
+def test_candidato_no_se_enriquece() -> None:
+    """Papers con curation_status=candidate no se incluyen como objetivo."""
+    corpus = _corpus_from_rows(
+        [
+            _make_row(id="P1", openalex_id="W100"),  # seed + accepted
+            _make_row(
+                id="P2",
+                openalex_id="W200",
+                curation_status=CurationStatus.CANDIDATE,
+            ),  # candidato
+        ]
+    )
+    citing_works = [_citing_work("C1", ["W100", "W200"])]
+    transport = _make_cited_by_transport(citing_works)
+
+    enricher = _make_enricher(transport)
+    result = enricher.enrich(corpus)
+
+    table = result.to_arrow()
+    rows_data = table.to_pylist()
+    cited_by_map = {
+        row["openalex_id"]: set(row.get("cited_by_id") or []) for row in rows_data
+    }
+
+    # W100 (aceptada) sí
+    assert "C1" in cited_by_map["W100"]
+    # W200 (candidata) no recibe citantes vía el enrich (no fue objetivo)
+    assert "C1" not in cited_by_map.get("W200", set())
+
+
+# ---------------------------------------------------------------------------
+# 6. Networks.quick sin cited_by_id → 4 redes, sin fallo (regresión)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_networks_quick_sin_cited_by_omite_cocitacion_sin_fallar() -> None:
+    """Networks.quick con cited_by_id vacío → 4 redes, sin error."""
+    rows = [
+        {
+            "id": f"P{i}",
+            "openalex_id": None,
+            "doi": None,
+            "title": f"Paper {i}",
+            "year": 2020,
+            "abstract": None,
+            "source": None,
+            "language": None,
+            "publisher": None,
+            "research_areas": None,
+            "is_seed": True,
+            "curation_status": "candidate",
+            "provenance": None,
+            "authors_raw": None,
+            "authors_id": [f"AUTH_{i}", "AUTH_0"],
+            "authors_affiliations": None,
+            "keywords_raw": None,
+            "keywords_id": [f"KW_{i}", "KW_SHARED"],
+            "institutions_raw": None,
+            "institutions_id": [f"INST_{i}"],
+            "references_id": [f"REF_{i}", "REF_SHARED"],
+            "references_doi": None,
+            "cited_by_id": None,  # sin citantes
+        }
+        for i in range(3)
+    ]
+    table = pa.Table.from_pylist(rows, schema=CORPUS_SCHEMA)
+    corpus = Corpus.from_arrow(table)
+
+    # No debe lanzar excepción
+    artifacts = Networks.quick(corpus)
+
+    assert len(artifacts) == 4, "Sin cited_by_id debe haber exactamente 4 redes"
+    kinds = {a.spec.kind for a in artifacts}
+    assert "cocitation" not in kinds
+
+
+# ---------------------------------------------------------------------------
+# 7. Networks.quick con cited_by_id → 5 redes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_networks_quick_con_cited_by_incluye_cocitacion() -> None:
+    """Networks.quick con cited_by_id poblado → 5 redes, incluyendo cocitation."""
+    rows = [
+        {
+            "id": "P1",
+            "openalex_id": "W100",
+            "doi": None,
+            "title": "Paper 1",
+            "year": 2020,
+            "abstract": None,
+            "source": None,
+            "language": None,
+            "publisher": None,
+            "research_areas": None,
+            "is_seed": True,
+            "curation_status": "accepted",
+            "provenance": None,
+            "authors_raw": None,
+            "authors_id": ["AUTH_1"],
+            "authors_affiliations": None,
+            "keywords_raw": None,
+            "keywords_id": ["KW_1"],
+            "institutions_raw": None,
+            "institutions_id": ["INST_1"],
+            "references_id": None,
+            "references_doi": None,
+            "cited_by_id": ["C1"],  # ya tiene citante
+        },
+        {
+            "id": "P2",
+            "openalex_id": "W200",
+            "doi": None,
+            "title": "Paper 2",
+            "year": 2020,
+            "abstract": None,
+            "source": None,
+            "language": None,
+            "publisher": None,
+            "research_areas": None,
+            "is_seed": True,
+            "curation_status": "accepted",
+            "provenance": None,
+            "authors_raw": None,
+            "authors_id": ["AUTH_2"],
+            "authors_affiliations": None,
+            "keywords_raw": None,
+            "keywords_id": ["KW_2"],
+            "institutions_raw": None,
+            "institutions_id": ["INST_2"],
+            "references_id": None,
+            "references_doi": None,
+            "cited_by_id": ["C1"],  # mismo citante → co-cita P1 y P2
+        },
+    ]
+    table = pa.Table.from_pylist(rows, schema=CORPUS_SCHEMA)
+    corpus = Corpus.from_arrow(table)
+
+    artifacts = Networks.quick(corpus)
+    kinds = {a.spec.kind for a in artifacts}
+
+    assert "cocitation" in kinds
+    assert len(artifacts) == 5
+
+
+# ---------------------------------------------------------------------------
+# 8. No pierde papers; corpus sin seeds aceptados → 0 fetch, sin error
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_corpus_sin_seeds_aceptados_0_fetch() -> None:
+    """Corpus sin seeds aceptados → 0 requests a cited_by, sin error."""
+    corpus = _corpus_from_rows(
+        [
+            _make_row(
+                id="P1",
+                openalex_id="W100",
+                curation_status=CurationStatus.CANDIDATE,
+            ),
+            _make_row(
+                id="P2",
+                openalex_id="W200",
+                is_seed=False,
+                curation_status=CurationStatus.ACCEPTED,
+            ),
+        ]
+    )
+
+    transport, counters = _make_counting_cited_by_transport([])
+    enricher = _make_enricher(transport)
+    result = enricher.enrich(corpus)
+
+    # No se hicieron requests de cited_by (ninguna seed aceptada)
+    assert counters["citing"][0] == 0, (
+        "Sin seeds aceptadas no debe hacer requests citing"
+    )
+    # No pierde papers
+    assert len(result) == len(corpus)
+
+
+@pytest.mark.unit
+def test_enrich_no_pierde_papers_con_semillas() -> None:
+    """El corpus enriquecido tiene exactamente los mismos papers que el original."""
+    corpus = _corpus_from_rows(
+        [
+            _make_row(id="P1", openalex_id="W100"),
+            _make_row(
+                id="P2",
+                openalex_id="W200",
+                curation_status=CurationStatus.CANDIDATE,
+            ),
+            _make_row(id="P3", openalex_id=None),
+        ]
+    )
+    citing_works = [_citing_work("C1", ["W100"])]
+    transport = _make_cited_by_transport(citing_works)
+
+    enricher = _make_enricher(transport)
+    result = enricher.enrich(corpus)
+
+    assert len(result) == len(corpus), "No debe perder ni agregar papers"
+
+
+# ---------------------------------------------------------------------------
+# 9. fetch_citing_batch en lotes ≤50
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_fetch_citing_batch_loteo_50_ids() -> None:
+    """Con 60 seeds aceptadas, fetch_citing_batch hace ≥2 requests (lotes ≤50)."""
+    n = 60
+    rows = [_make_row(id=f"P{i}", openalex_id=f"W{i:06d}") for i in range(1, n + 1)]
+    corpus = _corpus_from_rows(rows)
+
+    transport, counters = _make_counting_cited_by_transport([])
+    enricher = _make_enricher(transport)
+    enricher.enrich(corpus)
+
+    # Con 60 seeds y lotes ≤50 → ≥2 requests de cites
+    assert counters["citing"][0] >= 2, (
+        f"Con {n} seeds debe hacer ≥2 requests (lotes ≤50), "
+        f"hizo {counters['citing'][0]}"
+    )
+
+
+@pytest.mark.unit
+def test_fetch_citing_batch_50_ids_exactos() -> None:
+    """Con 50 seeds exactas, fetch_citing_batch hace 1 sola request."""
+    n = 50
+    rows = [_make_row(id=f"P{i}", openalex_id=f"W{i:06d}") for i in range(1, n + 1)]
+    corpus = _corpus_from_rows(rows)
+
+    transport, counters = _make_counting_cited_by_transport([])
+    enricher = _make_enricher(transport)
+    enricher.enrich(corpus)
+
+    assert counters["citing"][0] == 1, (
+        f"Con {n} seeds exactas debe hacer 1 request, hizo {counters['citing'][0]}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 10. Papers sin openalex_id no se usan como objetivo
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_papers_sin_openalex_id_no_son_objetivo() -> None:
+    """Seeds aceptadas sin openalex_id no disparan fetch_citing."""
+    # Todas sin openalex_id → no hay targets válidos
+    corpus = _corpus_from_rows(
+        [
+            _make_row(id="P1", openalex_id=None),
+            _make_row(id="P2", openalex_id=None),
+        ]
+    )
+
+    transport, counters = _make_counting_cited_by_transport([])
+    enricher = _make_enricher(transport)
+    result = enricher.enrich(corpus)
+
+    assert counters["citing"][0] == 0
+    assert len(result) == 2  # no pierde papers
+
+
+# ---------------------------------------------------------------------------
+# 11. run_enrich expone claves citing_new y citing_targets
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_run_enrich_8b_claves_en_salida(tmp_path: Any) -> None:
+    """``run_enrich`` devuelve las nuevas claves citing_new y citing_targets."""
+    from bib2graph.cli.commands.enrich import run_enrich
+    from bib2graph.stores.duckdb import DuckDBStore
+
+    rows = [_make_row(id="P1", openalex_id="W100")]
+    table = pa.Table.from_pylist(rows, schema=CORPUS_SCHEMA)
+    corpus = Corpus.from_arrow(table)
+    store = DuckDBStore(tmp_path / "test.duckdb")
+    store.persist(corpus)
+
+    citing_works = [_citing_work("C1", ["W100"])]
+    transport = _make_cited_by_transport(citing_works)
+
+    data = run_enrich(tmp_path / "test.duckdb", transport=transport)
+
+    assert "citing_new" in data, "Debe incluir clave citing_new"
+    assert "citing_targets" in data, "Debe incluir clave citing_targets"
+    assert isinstance(data["citing_new"], int)
+    assert isinstance(data["citing_targets"], int)
+    assert data["citing_targets"] == 1  # 1 seed aceptada
+    assert data["citing_new"] == 1  # 1 nuevo citante
+
+
+# ---------------------------------------------------------------------------
+# 12. EnricherRef openalex_cited_by en Manifest
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_enricher_ref_cited_by_en_manifest() -> None:
+    """Tras enrich, el Manifest tiene EnricherRef 'openalex_cited_by'."""
+    corpus = _corpus_from_rows([_make_row(id="P1", openalex_id="W100")])
+    citing_works = [_citing_work("C1", ["W100"])]
+    transport = _make_cited_by_transport(citing_works)
+
+    enricher = _make_enricher(transport)
+    result = enricher.enrich(corpus)
+
+    names = [e.name for e in result.manifest.enrichers]
+    assert "openalex_cited_by" in names
+    assert "openalex_references_doi" in names
+
+
+# ---------------------------------------------------------------------------
+# Helpers para tests de presupuesto por semilla (multi-página con cursor)
+# ---------------------------------------------------------------------------
+
+
+def _make_paginated_cited_by_transport(
+    pages: list[list[dict[str, Any]]],
+) -> tuple[httpx.MockTransport, dict[str, list[int]]]:
+    """MockTransport multi-página que simula paginación por cursor para cites:.
+
+    ``pages[0]`` es la primera página, ``pages[1]`` la segunda, etc.
+    Cada request que llega con un cursor distinto de ``"*"`` avanza al
+    siguiente índice de páginas.  El cursor devuelto es ``"cursor_N"``
+    donde N es el índice de la siguiente página, o ``None`` si no hay más.
+
+    Returns:
+        Tupla ``(transport, counters)`` donde ``counters["citing"]`` acumula
+        el número de requests con ``cites`` en la URL (= número de páginas
+        fetcheadas).
+    """
+    counters: dict[str, list[int]] = {"doi": [0], "citing": [0]}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        url_str = str(request.url)
+        if "openalex_id" in url_str:
+            counters["doi"][0] += 1
+            body: dict[str, Any] = {
+                "results": [],
+                "meta": {"count": 0, "next_cursor": None},
+            }
+            return httpx.Response(200, json=body)
+
+        if "cites" not in url_str:
+            return httpx.Response(
+                200, json={"results": [], "meta": {"count": 0, "next_cursor": None}}
+            )
+
+        counters["citing"][0] += 1
+
+        # Determinar qué página devolver según el cursor de la request
+        params = dict(request.url.params)
+        cursor_val = params.get("cursor", "*")
+        if cursor_val == "*":
+            page_idx = 0
+        elif cursor_val.startswith("cursor_"):
+            page_idx = int(cursor_val.split("_")[1])
+        else:
+            page_idx = 0
+
+        if page_idx >= len(pages):
+            # Sin más páginas
+            return httpx.Response(
+                200,
+                json={"results": [], "meta": {"count": 0, "next_cursor": None}},
+            )
+
+        works = pages[page_idx]
+        next_idx = page_idx + 1
+        next_cursor = f"cursor_{next_idx}" if next_idx < len(pages) else None
+
+        body = {
+            "results": works,
+            "meta": {"count": len(works), "next_cursor": next_cursor},
+        }
+        return httpx.Response(
+            200,
+            json=body,
+            headers={"x-openalex-api-version": "2026-05-01"},
+        )
+
+    return httpx.MockTransport(handler), counters
+
+
+# ---------------------------------------------------------------------------
+# 11. Presupuesto por semilla SIN starvation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_presupuesto_por_semilla_sin_starvation() -> None:
+    """Semilla con muchos citantes no consume el presupuesto de la otra.
+
+    Escenario:
+    - W100: muy citada → tiene citantes C1..C10 en páginas 1 y 2
+    - W200: poco citada → solo tiene citante C11
+    - max_citing_per_paper=3
+
+    W100 debe tener ≤3 citantes.  W200 debe tener su citante C11 aunque
+    W100 ya había consumido capacidad en páginas anteriores.
+    """
+    # Página 1: C1..C5 citan W100; C11 cita W200
+    page1 = [_citing_work(f"C{i}", ["W100"]) for i in range(1, 6)] + [
+        _citing_work("C11", ["W200"])
+    ]
+    # Página 2: C6..C10 citan W100 (solo W100 sigue sin tope en page1 parcialmente)
+    page2 = [_citing_work(f"C{i}", ["W100"]) for i in range(6, 11)]
+
+    transport, _counters = _make_paginated_cited_by_transport([page1, page2])
+
+    corpus = _corpus_from_rows(
+        [
+            _make_row(id="P1", openalex_id="W100"),
+            _make_row(id="P2", openalex_id="W200"),
+        ]
+    )
+    enricher = _make_enricher(transport, max_citing_per_paper=3)
+    result = enricher.enrich(corpus)
+
+    table = result.to_arrow()
+    rows = table.to_pylist()
+    cited_by_map = {
+        row["openalex_id"]: set(row.get("cited_by_id") or []) for row in rows
+    }
+
+    # W100 no debe superar el tope
+    assert len(cited_by_map["W100"]) <= 3, (
+        f"W100 no debe superar max=3, tiene {len(cited_by_map['W100'])}"
+    )
+    # W200 debe tener su citante C11 (no starved)
+    assert "C11" in cited_by_map["W200"], (
+        "W200 debe tener C11 aunque W100 tenga muchos citantes"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 12. El tope acota el fetch: se deja de paginar cuando todas las semillas
+#     del lote están satisfechas
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_tope_detiene_paginacion_cuando_todas_satisfechas() -> None:
+    """Con max_citing_per_paper=1, se detiene antes de la página 2 si ya satisfecho.
+
+    Escenario:
+    - 1 semilla W100, max_citing_per_paper=1
+    - Página 1: C1 cita W100 (→ W100 satisfecha tras página 1)
+    - Página 2: C2 cita W100 (nunca debe fetchearse)
+
+    Se espera que el número de páginas fetcheadas sea 1 (no 2).
+    """
+    page1 = [_citing_work("C1", ["W100"])]
+    page2 = [_citing_work("C2", ["W100"])]
+
+    transport, counters = _make_paginated_cited_by_transport([page1, page2])
+
+    corpus = _corpus_from_rows([_make_row(id="P1", openalex_id="W100")])
+    enricher = _make_enricher(transport, max_citing_per_paper=1)
+    result = enricher.enrich(corpus)
+
+    # Solo debe haberse hecho 1 request de cites (página 1; página 2 no debe fetchearse)
+    assert counters["citing"][0] == 1, (
+        f"Con max=1 y 1 semilla satisfecha en página 1, "
+        f"no debe fetchear página 2; hizo {counters['citing'][0]} requests"
+    )
+
+    table = result.to_arrow()
+    rows = table.to_pylist()
+    cited_by = rows[0].get("cited_by_id") or []
+    assert len(cited_by) == 1
+    assert "C1" in cited_by
+
+
+@pytest.mark.unit
+def test_tope_detiene_paginacion_dos_semillas_ambas_satisfechas() -> None:
+    """Con 2 semillas y max=2, se detiene cuando AMBAS alcanzan el tope.
+
+    - W100 y W200, max=2 cada una
+    - Página 1: C1 y C2 citan W100; C3 y C4 citan W200 → ambas satisfechas
+    - Página 2: más citantes → nunca deben fetchearse
+    """
+    page1 = [
+        _citing_work("C1", ["W100"]),
+        _citing_work("C2", ["W100"]),
+        _citing_work("C3", ["W200"]),
+        _citing_work("C4", ["W200"]),
+    ]
+    page2 = [
+        _citing_work("C5", ["W100"]),
+        _citing_work("C6", ["W200"]),
+    ]
+
+    transport, counters = _make_paginated_cited_by_transport([page1, page2])
+
+    corpus = _corpus_from_rows(
+        [
+            _make_row(id="P1", openalex_id="W100"),
+            _make_row(id="P2", openalex_id="W200"),
+        ]
+    )
+    enricher = _make_enricher(transport, max_citing_per_paper=2)
+    result = enricher.enrich(corpus)
+
+    # Ambas satisfechas en página 1 → solo 1 request
+    assert counters["citing"][0] == 1, (
+        f"Ambas semillas satisfechas en página 1; "
+        f"no debe fetchear página 2; hizo {counters['citing'][0]} requests"
+    )
+
+    table = result.to_arrow()
+    rows = table.to_pylist()
+    cited_by_map = {
+        row["openalex_id"]: set(row.get("cited_by_id") or []) for row in rows
+    }
+    assert len(cited_by_map["W100"]) == 2
+    assert len(cited_by_map["W200"]) == 2
+
+
+# ---------------------------------------------------------------------------
+# 13. Sin tope (None): pagina todo y atribuye correctamente
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_sin_tope_pagina_todo_y_atribuye() -> None:
+    """max_citing_per_paper=None pagina todas las páginas y atribuye correctamente.
+
+    - W100 y W200, sin tope
+    - Página 1: C1 cita W100, C2 cita W200
+    - Página 2: C3 cita W100 y W200, C4 cita W100
+    - Deben fetchearse las 2 páginas y atribuirse correctamente.
+    """
+    page1 = [
+        _citing_work("C1", ["W100"]),
+        _citing_work("C2", ["W200"]),
+    ]
+    page2 = [
+        _citing_work("C3", ["W100", "W200"]),
+        _citing_work("C4", ["W100"]),
+    ]
+
+    transport, counters = _make_paginated_cited_by_transport([page1, page2])
+
+    corpus = _corpus_from_rows(
+        [
+            _make_row(id="P1", openalex_id="W100"),
+            _make_row(id="P2", openalex_id="W200"),
+        ]
+    )
+    enricher = _make_enricher(transport, max_citing_per_paper=None)
+    result = enricher.enrich(corpus)
+
+    # Sin tope → debe fetchear ambas páginas
+    assert counters["citing"][0] == 2, (
+        f"Sin tope debe fetchear las 2 páginas; hizo {counters['citing'][0]}"
+    )
+
+    table = result.to_arrow()
+    rows = table.to_pylist()
+    cited_by_map = {
+        row["openalex_id"]: set(row.get("cited_by_id") or []) for row in rows
+    }
+
+    # W100: C1, C3, C4
+    assert cited_by_map["W100"] == {"C1", "C3", "C4"}, (
+        f"W100 debe tener {{C1, C3, C4}}, tiene {cited_by_map['W100']}"
+    )
+    # W200: C2, C3
+    assert cited_by_map["W200"] == {"C2", "C3"}, (
+        f"W200 debe tener {{C2, C3}}, tiene {cited_by_map['W200']}"
+    )


### PR DESCRIPTION
**Ciclo 8b** del Hito 8 (vía feature-cycle: coder → verifier PASA-con-reservas → decisión PO → coder → verifier **PASA**). Completa el Hito 8.

## Qué trae
- `OpenAlexEnricher.enrich` ahora puebla **`cited_by_id`** de las semillas aceptadas → habilita la **red de co-citación** (antes 0 aristas). Decisión A: no mete citantes como filas.
- `OpenAlexSource.fetch_citing_batch` → `dict[seed, [citers]]`: batcheo OR `cites:W1|W2|...` (≤50), pagina por cursor y atribuye página a página, con **presupuesto por semilla** (corta la paginación al alcanzar `max_citing_per_paper` — acota el fetch, **sin starvation**; mata el N+1 diferido de R5).
- `Networks.quick` incluye co-citación cuando hay datos (5 redes) y la omite graceful si no (4). `CoCitationProjector` intacto (decisión F).
- CLI `b2g enrich --max-citing`.

## Decisión del PO en el loop
Reserva alta del verifier (el tope no acotaba el fetch + sesgo por cap compartido) → elegiste **batcheo OR + presupuesto de páginas por semilla**. Implementado y reverificado.

## Verificación
- ✅ verifier **PASA** · ruff + mypy + **365 tests** verdes · 0 enlaces rotos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)