### PR TITLE
fix(ci): fijar release-please target-branch a main

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -20,6 +20,10 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@v4
         with:
+          # target-branch FIJO a main: release-please gestiona SIEMPRE main aunque
+          # la rama por defecto del repo sea `dev`. Sin esto, su default es la rama
+          # por defecto del repo (dev) y abre los release PRs contra dev por error.
+          target-branch: main
           # Si existe el secret RELEASE_PLEASE_TOKEN (un PAT), el PR de release lo
           # crea ese token y SÍ dispara el CI (los commits del GITHUB_TOKEN no
           # disparan workflows). Sin el secret, cae al GITHUB_TOKEN y el PR de


### PR DESCRIPTION
**Causa raíz del enredo de releases.** La rama por defecto del repo es `dev`, y `release-please-action` toma su `target-branch` del **default del repo** cuando no se especifica → venía abriendo los PR de release contra `dev` (`chore(dev): release ...`, PRs #9/#15) y tageó `v0.3.2` sobre un commit de dev.

Fix: `target-branch: main` explícito → release-please gestiona `main` siempre, sin importar el default branch. Desbloquea el corte de **0.4.0** (Hito 7/8) sobre `main`.

Infra hotfix a `main` (como CI/#3/#7). Tras mergear, re-disparo release-please y debería abrir el PR `chore(main): release 0.4.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)