### PR TITLE
ci: publicar a TestPyPI vía trusted publishing (OIDC)

### DIFF
--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -1,0 +1,39 @@
+name: publish-testpypi
+
+# Publica el paquete a TestPyPI vía Trusted Publishing (OIDC) — SIN tokens ni secrets.
+# Disparo MANUAL: Actions → "publish-testpypi" → "Run workflow".
+#
+# Requiere (una sola vez) un "pending publisher" en https://test.pypi.org:
+#   Your account → Publishing → Add a pending publisher:
+#     - PyPI Project Name: bib2graph
+#     - Owner:             complexluise
+#     - Repository name:   bib2graph
+#     - Workflow name:     publish-testpypi.yml
+#     - Environment name:  testpypi
+#
+# El paso a PyPI productivo (disparado al crear el GitHub Release de release-please)
+# se agrega en una segunda tanda, una vez validado el flujo en TestPyPI. Ver VERSIONING.md.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write # requerido para el OIDC del trusted publishing
+
+jobs:
+  publish-testpypi:
+    runs-on: ubuntu-latest
+    environment: testpypi
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.12"
+      - name: Build (sdist + wheel)
+        run: uv build
+      - name: Publish to TestPyPI (trusted publishing)
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -86,8 +86,19 @@ Las releases las maneja [`release-please`](https://github.com/googleapis/release
 > contra recursión). Sin ese secret, el PR de release queda sin CI propio y se
 > mergea con bypass de admin.
 
-**PyPI todavía NO está conectado** (decisión del PO: por ahora solo GitHub Releases). El
-paso de publicación a PyPI se agrega cuando se configure *trusted publishing* (OIDC).
+## Publicación a TestPyPI / PyPI (Trusted Publishing, OIDC)
+
+La publicación usa **Trusted Publishing** (OIDC) — sin tokens ni secrets en el repo.
+
+- **TestPyPI** (`.github/workflows/publish-testpypi.yml`, **disparo manual** `workflow_dispatch`):
+  `uv build` + publish a `https://test.pypi.org/legacy/`. Sirve para probar el paquete
+  (`pip install -i https://test.pypi.org/simple/ bib2graph`) antes de productivo.
+  **Setup una sola vez** en https://test.pypi.org (Your account → Publishing → *pending publisher*):
+  Project `bib2graph`, Owner `complexluise`, Repo `bib2graph`, Workflow `publish-testpypi.yml`,
+  Environment `testpypi`.
+- **PyPI productivo:** se conecta en una segunda tanda (workflow disparado al crear el GitHub
+  Release de release-please), una vez validado el flujo en TestPyPI. Mismo mecanismo OIDC con un
+  *pending publisher* en https://pypi.org.
 
 `cz bump --dry-run` te muestra, localmente, qué versión resultaría de los
 commits acumulados sin necesidad de pushear (ayuda de preview; el publicador es


### PR DESCRIPTION
Workflow **`publish-testpypi.yml`** (disparo **manual** `workflow_dispatch`): `uv build` + publish a TestPyPI vía **Trusted Publishing (OIDC)** — sin tokens ni secrets (`id-token: write`, `environment: testpypi`).

Para probar el paquete (`pip install -i https://test.pypi.org/simple/ bib2graph`) antes de PyPI productivo, que se agrega en una 2ª tanda (disparado al GitHub Release de release-please).

**Setup que hace el PO (una vez) en TestPyPI** — Your account → Publishing → *pending publisher*: Project `bib2graph`, Owner `complexluise`, Repo `bib2graph`, Workflow `publish-testpypi.yml`, Environment `testpypi`. Documentado en VERSIONING.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)