### PR TITLE
ci: subir actions a Node 24 (checkout@v5, setup-uv@v6)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,9 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v6
         with:
           enable-cache: true
           python-version: "3.11"
@@ -41,9 +41,9 @@ jobs:
       matrix:
         python-version: ["3.11", "3.12"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v6
         with:
           enable-cache: true
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     environment: testpypi
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v6
         with:
           python-version: "3.12"
       - name: Build (sdist + wheel)


### PR DESCRIPTION
Cierra la deprecación de Node 20 en GitHub Actions (cambio forzado a Node 24 hoy). Bump de `actions/checkout` v4→v5 y `astral-sh/setup-uv` v5→v6 en ci.yml y publish-testpypi.yml. El CI de este PR ya corre con las versiones nuevas (verifica que resuelven). `release-please-action@v4` queda igual por ahora (aún sin major en Node 24).