### PR TITLE
docs(arch): ADR 0029 workspace por investigación (Propuesta)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -299,6 +299,15 @@ siendo el punto de extensión para destinos externos: **`ZoteroStore`** (sincron
 con una colección Zotero) es **opt-in en V1.1** (`[zotero]`); **`Neo4jStore`** es adaptador opt-in
 post-V1 (`[neo4j]`): un destino más, **ya no el sustrato** (ADR 0002).
 
+> **TARGET (propuesto, no as-built) — workspace por investigación, ADR
+> [0029](decisiones/0029-workspace-por-investigacion.md):** la unidad de persistencia evolucionaría
+> de "1 archivo `.duckdb`" a "**1 workspace = 1 carpeta**" (`workspace.json` + `library.duckdb` +
+> `networks/` + `snapshots/` + `exports/`), formalizando la convención emergente de que `build` ya
+> escribe `<store_dir>/networks/`. El corpus/procedencia/curación/loop-state siguen en el `.duckdb`;
+> redes/exports = cache regenerable sellada por `corpus_hash`; el snapshot sigue siendo lo
+> reproducible (§6.2). Enmienda 0009/0019; single-writer sin cambios. **Propuesta, pendiente de
+> firma — el as-built sigue siendo el `.duckdb` suelto.**
+
 ## 5. Flujo de datos (ciclo iterativo, no pipeline lineal)
 
 ```
@@ -442,6 +451,17 @@ consola cp1252 de Windows (`ecuaci�n`), rompiendo el contrato agente-native. *
 solo lectura:** `status`/`validate` usan `open_store_readonly` (`cli/_store.py`), que **no auto-crea**
 el `.duckdb` ante un typo en `--store` (falla accionable); los comandos de escritura conservan
 `open_store`.
+
+> **TARGET (propuesto, no as-built) — `--store` opcional + `b2g init`, ADR
+> [0029](decisiones/0029-workspace-por-investigacion.md):** con el modelo workspace, `--store`
+> dejaría de ser opción global **obligatoria** y pasaría a **opcional**: la unidad sería una
+> **carpeta workspace** (`workspace.json`), resuelta por ambiente (patrón git/cargo: caminar hacia
+> arriba desde el cwd). Precedencia: `--workspace`/`--store` explícito > `B2G_WORKSPACE` (env) >
+> workspace del cwd. Entraría un subcomando **`b2g init <name>`** (scaffold de la carpeta; `b2g init .`
+> inicializa el cwd) → el conteo de subcomandos pasaría de **13 a 14+** **cuando se implemente**. El
+> `.duckdb` suelto seguiría funcionando (workspace "degenerado", sin migración forzada). Es un cambio
+> **suave/aditivo** del contrato (la resolución ambiente solo cubre el flag ausente). **Propuesta,
+> pendiente de firma — hoy `--store` sigue siendo global obligatorio y son 13 subcomandos.**
 
 ## 7. Layout de dependencias (extras)
 

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -62,6 +62,12 @@ de estados explícita** (`LoopState`: `SEEDED → FORAGED → FILTERED → BUILT
 [0016](decisiones/0016-maquina-estados-lazo.md)): **una investigación = un archivo `.duckdb`**, su
 estado se consulta con `b2g status`.
 
+> **TARGET (propuesto, no as-built) — ADR [0029](decisiones/0029-workspace-por-investigacion.md)
+> (2026-06-16):** "una investigación = un archivo" evolucionaría a "una investigación = un
+> **workspace** (carpeta `workspace.json` + db + redes/snapshots/exports)", con `b2g init` y `--store`
+> opcional vía resolución ambiente. Propuesta pendiente de firma; el `.duckdb` suelto sigue siendo
+> el modelo as-built.
+
 *El final siguen siendo las redes; lo nuevo es **cómo se llega a ellas** (forrajeo asistido) y
 que **la colección vive** (berry growing).*
 

--- a/docs/decisiones/0009-biblioteca-viva-duckdb.md
+++ b/docs/decisiones/0009-biblioteca-viva-duckdb.md
@@ -60,3 +60,18 @@ persistencia núcleo de 1.0.
   persistencia por defecto.
 - Hay que **reescribir `ARCHITECTURE.md` §6.2** y **reordenar `ROADMAP.md`** (el store DuckDB
   stateful sube a un hito temprano del núcleo).
+
+## Enmienda — la unidad de persistencia pasa a "workspace/carpeta" (PROPUESTA, 2026-06-16)
+
+> **Propuesta por [0029](0029-workspace-por-investigacion.md) (estado *Propuesta*, no implementado).**
+> El cuerpo queda como historia; la biblioteca viva stateful en DuckDB **no cambia**.
+
+Este ADR estableció la biblioteca viva sobre **un archivo `.duckdb`**. El ADR
+[0029](0029-workspace-por-investigacion.md) propone que la **unidad de persistencia** pase de "1
+archivo" a "**1 workspace = 1 carpeta**" (marcada por `workspace.json`), que contiene el
+`library.duckdb` + `networks/` + `snapshots/` + `exports/`. El **corpus, la procedencia, las
+decisiones de curación y el loop-state siguen viviendo dentro del `.duckdb`** (sin duplicarse en el
+manifest); las redes/exports son cache regenerable y el snapshot sigue siendo lo reproducible (ADR
+0017). Es una **formalización de una convención emergente** (`b2g build` ya escribe
+`<store_dir>/networks/`), no una revisión del modelo de datos. **Hasta que 0029 se firme e
+implemente, la unidad as-built sigue siendo el `.duckdb` suelto.**

--- a/docs/decisiones/0019-concurrencia-diferida.md
+++ b/docs/decisiones/0019-concurrencia-diferida.md
@@ -44,3 +44,17 @@ servidor si aparece el caso multi-agente concurrente).
 - **Recomendación para el `coder`:** el `DuckDBBackend`/`DuckDBStore` del **Hito 3** documenta la
   asunción single-writer y traduce el error de archivo bloqueado de DuckDB a un error accionable
   con exit code `5` (a cablear en el CLI, Hito 6). No se implementa locking propio.
+
+## Enmienda — la unidad pasa a "workspace/carpeta"; el single-writer sigue válido (PROPUESTA, 2026-06-16)
+
+> **Propuesta por [0029](0029-workspace-por-investigacion.md) (estado *Propuesta*, no implementado).**
+> El cuerpo queda como historia.
+
+Este ADR razona sobre "1 archivo `.duckdb` = 1 escritor". El ADR
+[0029](0029-workspace-por-investigacion.md) propone que la **unidad de persistencia** pase a ser un
+**workspace = carpeta** (`workspace.json` + `library.duckdb` + `networks/`/`snapshots/`/`exports/`).
+La conclusión de concurrencia **no cambia**: el `library.duckdb` dentro del workspace sigue siendo
+**single-writer** (un escritor a la vez; lecturas concurrentes OK). Varias investigaciones en
+paralelo = varios workspaces (varias carpetas, varios `.duckdb`) sin contención entre ellos. La
+concurrencia multi-escritor sobre un mismo `.duckdb` sigue diferida post-v1.0. **Léase "1 archivo" ≡
+"el `library.duckdb` del workspace".**

--- a/docs/decisiones/0021-cli-agente-native-contrato.md
+++ b/docs/decisiones/0021-cli-agente-native-contrato.md
@@ -239,3 +239,20 @@ exploratorio). `status` lee y presenta el estado actual + las transiciones dispo
 **Además, el alias `LoopState = CycleState` se RETIRÓ** del código (`backends/duckdb.py` y
 `stores/duckdb.py`): el contrato usa **solo `CycleState`** (de `bib2graph.cycle`). Donde este ADR
 dice "`LoopState`", léase `CycleState` (mismo concepto, una sola clase).
+
+## Enmienda — `--store` deja de ser global obligatorio (PROPUESTA, 2026-06-16)
+
+> **Propuesta por [0029](0029-workspace-por-investigacion.md) (estado *Propuesta*, no implementado).**
+> El cuerpo de este ADR queda como historia; esta enmienda solo señala el cambio futuro al §E.
+
+El §E fija `--store` como **opción global del grupo, obligatoria**. El ADR
+[0029](0029-workspace-por-investigacion.md) (modelo "workspace por investigación") propone que
+`--store` pase a **opcional**: la unidad de persistencia deja de ser un `.duckdb` suelto y pasa a ser
+una **carpeta workspace** (marcada por `workspace.json`), resuelta por **ambiente** (patrón
+git/cargo: caminar hacia arriba desde el cwd). Precedencia: `--workspace`/`--store` explícito >
+`B2G_WORKSPACE` (env) > workspace del cwd. `--workspace` pasa a ser el flag primario; `--store`
+sobrevive para apuntar a un `.duckdb` suelto (workspace "degenerado", retrocompatible).
+
+El cambio es **aditivo/retrocompatible**: la resolución ambiente solo cubre el caso en que falta el
+flag; el resto del contrato (envelope `schema="1"`, exit codes, transiciones) **no cambia**. **Hasta
+que 0029 se firme e implemente, `--store` sigue siendo global obligatorio** (as-built vigente).

--- a/docs/decisiones/0029-workspace-por-investigacion.md
+++ b/docs/decisiones/0029-workspace-por-investigacion.md
@@ -1,0 +1,121 @@
+# 0029 — Workspace por investigación: carpeta autocontenida + resolución ambiente
+
+- **Estado:** Propuesta (pendiente de firma del PO; **no implementado**)
+- **Fecha:** 2026-06-16
+- **Enmienda (propuesta por este ADR):** [0009](0009-biblioteca-viva-duckdb.md) y
+  [0019](0019-concurrencia-diferida.md) — la **unidad de persistencia** pasa de "1 archivo
+  `.duckdb`" a "**1 workspace = 1 carpeta**" (el single-writer sobre el `.duckdb` sigue válido);
+  [0021](0021-cli-agente-native-contrato.md) §E — `--store` deja de ser opción global
+  **obligatoria** y pasa a **opcional** vía resolución ambiente.
+- **Relacionada con:** [0016](0016-maquina-estados-lazo.md) (una investigación = una unidad de
+  persistencia; el `CycleState`/loop-state vive en el `.duckdb`),
+  [0017](0017-reproducibilidad-historia-snapshot.md) (el **snapshot** sigue siendo lo reproducible;
+  redes/exports = cache regenerable), [0010](0010-agente-native-columna.md) (CLI agente-native).
+- **Prerequisito de:** epic GUI [#34](https://github.com/complexluise/bib2graph/issues/34) (la GUI
+  necesita una unidad de proyecto portable y abrible).
+- **Issues:** [#32](https://github.com/complexluise/bib2graph/issues/32) (modelo workspace),
+  [#38](https://github.com/complexluise/bib2graph/issues/38) (`b2g init`),
+  [#39](https://github.com/complexluise/bib2graph/issues/39) (resolución ambiente).
+
+## Contexto
+
+Hoy la unidad de persistencia es **un archivo `.duckdb`** suelto: "una investigación = un archivo"
+(ADR [0009](0009-biblioteca-viva-duckdb.md) / [0019](0019-concurrencia-diferida.md) /
+[0016](0016-maquina-estados-lazo.md)). El estado del lazo, el corpus, la procedencia y las
+decisiones de curación viven dentro de ese archivo. El CLI lo recibe con la opción global
+**obligatoria** `--store <archivo.duckdb>` (ADR [0021](0021-cli-agente-native-contrato.md) §E).
+
+Ese modelo ya **derivó de hecho** hacia una carpeta: `b2g build` **no** escribe solo el `.duckdb`,
+sino que materializa los artefactos de red en **`<store_dir>/networks/<kind>/network.graphml` +
+`metrics.json`** (ADR 0021 §B). Es decir, alrededor del `.duckdb` ya nace una carpeta con
+subproductos — una **convención emergente sin nombre ni contrato**. A esto se suman tres tensiones:
+
+1. **Portabilidad / GUI.** El epic GUI ([#34](https://github.com/complexluise/bib2graph/issues/34))
+   necesita "abrir una investigación" como una unidad: db + redes + snapshots + exports juntos y
+   movibles. Un `.duckdb` suelto cuyos artefactos viven en un dir hermano implícito no es portable
+   ni autodescriptivo.
+2. **Ergonomía del `--store` obligatorio.** El error de uso **más común** es olvidar `--store` (ADR
+   0021 §E, Consecuencias): sale **fuera del envelope** (exit 1, stderr de Click). Repetir
+   `--store mi.duckdb` en cada invocación es fricción tanto para el humano como para el agente.
+3. **Onboarding.** No hay un gesto de "empezar una investigación nueva": el `.duckdb` se
+   auto-crea al primer `seed`, sin estructura ni manifest que diga qué es.
+
+Las sub-decisiones (qué marcador usa el workspace, qué flag, qué estructura de dirs, qué pasa con
+los `.duckdb` existentes) se refinaron en la conversación de
+[#32](https://github.com/complexluise/bib2graph/issues/32) y derivados; este ADR las fija.
+
+## Decisión
+
+**Una investigación = un workspace = una carpeta autocontenida.** Se formaliza la convención
+emergente: la carpeta es la unidad de persistencia, portabilidad y "proyecto" para la GUI.
+
+```
+mi-investigacion/
+├── workspace.json        # manifest mínimo (marcador del workspace)
+├── library.duckdb        # la biblioteca viva (corpus + procedencia + curación + loop-state)
+├── networks/             # cache de redes (build) — regenerable
+├── snapshots/            # snapshots sellados (parquet + manifest) — reproducible
+└── exports/              # exports a formatos (graphml/csv) — regenerable
+```
+
+- **`b2g init <name>`** scaffolds la carpeta con su estructura y `workspace.json`. **`b2g init .`**
+  inicializa el **cwd** como workspace.
+- **Resolución ambiente (patrón git/cargo).** `b2g` **camina hacia arriba** desde el cwd buscando
+  un `workspace.json`. Precedencia, de mayor a menor:
+  1. `--workspace`/`--store` explícito en la invocación,
+  2. variable de entorno `B2G_WORKSPACE`,
+  3. el workspace del cwd (subiendo hasta encontrar `workspace.json`).
+- **Sin migración forzada.** Un `.duckdb` suelto sigue funcionando como **workspace "degenerado"**:
+  `--store ruta.duckdb` apunta al archivo y los artefactos caen en su dir hermano como hoy. No se
+  exige convertir investigaciones existentes.
+- **`b2g status`** muestra el **workspace resuelto** (de dónde salió). Si no hay ninguno (ni
+  `workspace.json` hacia arriba, ni env, ni flag), se emite un **error accionable** que sugiere
+  `b2g init .` o pasar `--workspace`.
+
+### Sub-decisiones resueltas
+
+- **Marcador = `workspace.json`** (manifest **mínimo**): `{name, created_at, bib2graph_version,
+  schema_version}`. El corpus, la procedencia y el loop-state **NO** se duplican acá: ya viven en
+  `library.duckdb` (una pregunta = un doc; ADR 0009). El manifest es solo el marcador del límite del
+  workspace (lo que `b2g` busca al caminar hacia arriba) + metadatos de versión.
+- **Flag = `--workspace` primario, `--store` opcional/degenerado.** `--workspace <carpeta>` es la
+  forma canónica; `--store <archivo.duckdb>` se conserva para apuntar a un `.duckdb` suelto (modo
+  degenerado, retrocompatible). Ambos son **opcionales**: sin ellos, gana la resolución ambiente.
+- **Estructura de directorios estándar y fija.** `networks/`, `snapshots/`, `exports/` son nombres
+  convencionales (no configurables en V1): un workspace es reconocible y la GUI sabe dónde mirar.
+- **Redes/exports = cache regenerable, sellada por `corpus_hash`.** Las redes de `networks/` y los
+  `exports/` son **derivables** del estado vivo; se sellan con el `corpus_hash` del corpus que las
+  produjo (ADR [0017](0017-reproducibilidad-historia-snapshot.md)). El artefacto **reproducible**
+  sigue siendo el **snapshot** (parquet + manifest), no la cache. La **staleness** (cache cuyo
+  `corpus_hash` ya no coincide con el del corpus) se maneja **avisando/regenerando**, **no** con un
+  grafo de dependencias: es una invalidación por hash, no un build system.
+
+## Consecuencias
+
+- (+) **Portabilidad:** una investigación se mueve/comparte/respalda como una sola carpeta
+  autocontenida y autodescriptiva (`workspace.json`).
+- (+) **Prerequisito GUI ([#34](https://github.com/complexluise/bib2graph/issues/34)) cubierto:** la
+  GUI abre una carpeta-proyecto con db + redes + snapshots + exports en su sitio.
+- (+) **Onboarding:** `b2g init` es el gesto explícito de "empezar una investigación", con estructura
+  y manifest desde el día cero (hoy el `.duckdb` nace implícito al primer `seed`).
+- (+) **Ergonomía sin `--store`:** trabajar **dentro** de un workspace (o con `B2G_WORKSPACE`) elimina
+  el `--store` repetido y el error de uso más común (ADR 0021 §E); el patrón git/cargo es familiar.
+- (+) **Formaliza una convención emergente:** `b2g build` **ya** escribe `<store_dir>/networks/`; el
+  workspace le da nombre, límite y manifest en vez de un dir hermano implícito.
+- (+) **Retrocompatible:** sin migración forzada; el `.duckdb` suelto sigue siendo un workspace
+  degenerado válido.
+- (−) **Nueva capa `Workspace`** (resolución, scaffolding, lectura del manifest) a construir y testear;
+  más superficie que un único archivo.
+- (−) **Manejo de staleness por hash** en la cache (`networks/`/`exports/`): hay que sellar con
+  `corpus_hash`, comparar y avisar/regenerar. Se acota deliberadamente a invalidación por hash (no un
+  grafo de dependencias) para no convertir el producto en un build system.
+- (−) **Cambio suave del contrato CLI** (ADR 0021 §E): `--store` deja de ser global obligatorio. Es
+  aditivo/retrocompatible (la resolución ambiente solo **cubre** el caso en que falta el flag), pero
+  toca el contrato público y exige sincronizar `docs/API.md`/`ARCHITECTURE.md` cuando se implemente.
+
+> **PROPUESTA — no implementado (2026-06-16).** Mientras este ADR esté en estado *Propuesta*, el
+> comportamiento **as-built** sigue siendo el de ADR 0009/0019/0021: unidad = `.duckdb`, `--store`
+> global **obligatorio**, sin `b2g init` ni resolución ambiente. El flujo diario (CLAUDE.md /
+> AGENTS.md / CONTRIBUTING.md / referencia del CLI) y los conteos as-built **no** se reescriben hasta
+> que esto se implemente; los marcadores **TARGET** en `ARCHITECTURE.md` describen el objetivo, no el
+> presente.

--- a/docs/decisiones/README.md
+++ b/docs/decisiones/README.md
@@ -37,6 +37,12 @@ Qué se vuelve posible/fácil y qué se vuelve costoso/imposible. Trade-offs hon
 
 ## Índice
 
+> Los ADR se numeran **por orden de creación**, no se reservan en general. La excepción son
+> **0027/0028**, **referenciados por adelantado** desde la [Nota 12](../Notas/12-arquitectura-gui-encuadre.md)
+> (encuadre GUI): el número está apartado para el pivote de posicionamiento (0027) y la arquitectura
+> GUI (0028), **pendientes de firma**; el archivo se crea cuando se firmen. **0029** (workspace) sí
+> existe ya como *Propuesta* porque el PO bloqueó el modelo.
+
 | ADR | Título | Estado |
 |-----|--------|--------|
 | [0001](0001-herramienta-reutilizable.md) | Herramienta reutilizable en vez de pipeline de un solo uso | Aceptada |
@@ -65,3 +71,6 @@ Qué se vuelve posible/fácil y qué se vuelve costoso/imposible. Trade-offs hon
 | [0024](0024-orden-d3-columna-secuencia-duckdb.md) | Orden D3 en DuckDB vía columna de secuencia interna (`_seq`) | Aceptada · AS-BUILT (2026-06-16) |
 | [0025](0025-enricher-cocitacion-openalex.md) | `Enricher` opt-in sobre OpenAlex (núcleo): refs→DOI + co-citación; supersede el `[s2]` del DoD del Hito 8 | Aceptada · AS-BUILT COMPLETO (2026-06-16): 8a + 8b → Hito 8 completo |
 | [0026](0026-dedup-fuzzy-determinista.md) | Dedup fuzzy determinista con `rapidfuzz` (autores + keywords, función de librería); `splink` diferido a post-V1 | Aceptada · AS-BUILT (2026-06-16): Hito 7 |
+| 0027 | *(reservado)* Pivote de posicionamiento GUI local opt-in (gatea 0028/0029 GUI) | **Propuesta** — pendiente de firma ([Nota 12](../Notas/12-arquitectura-gui-encuadre.md)) |
+| 0028 | *(reservado)* Arquitectura GUI/API/frontend + empaquetado | **Propuesta** — pendiente de firma ([Nota 12](../Notas/12-arquitectura-gui-encuadre.md)) |
+| [0029](0029-workspace-por-investigacion.md) | Workspace por investigación: carpeta autocontenida (`workspace.json` + db + redes/snapshots/exports) + resolución ambiente; `--store` opcional | **Propuesta** — enmienda 0009/0019/0021; prerequisito GUI (#34) |


### PR DESCRIPTION
Baja a la doc la dirección del workspace (#32/#38/#39): ADR 0029 (Propuesta) + enmiendas fechadas a 0021/0009/0019 + marcadores TARGET en ARCHITECTURE §4.3/§6.3 + índice (0029 + 0027/0028 reservados) + nota TARGET en PRD. Sin tocar código ni doc as-built (planning; GUI gateada #34). 0 enlaces rotos.