### PR TITLE
feat(workspace): workspace por investigación (ADR 0029, #38/#39)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,8 +29,8 @@
   (`DuckDBStore`), `sources/` (`OpenAlexSource`, `BibtexSource`), `foraging/` (`Forager`,
   scent bibliométrico), `preprocessors/` (normalize + thesaurus), `filters/` (PRISMA),
   `networks/` (proyectores, analyzer, spec, facade), `exporters/` (GraphML, CSV) y `cli/`.
-  El **CLI `b2g` es real** —paquete `cli/` con 13 subcomandos en `cli/commands/`, no un
-  placeholder—. **388 tests verdes** (mypy/ruff limpios; el núcleo importa sin `duckdb`).
+  El **CLI `b2g` es real** —paquete `cli/` con 14 subcomandos en `cli/commands/`, no un
+  placeholder—. **416 tests verdes** (mypy/ruff limpios; el núcleo importa sin `duckdb`).
 - **Hito 8 COMPLETO** (Ciclos 8a + 8b, ADR
   [0025](docs/decisiones/0025-enricher-cocitacion-openalex.md)): el `OpenAlexEnricher` (opt-in,
   núcleo) hace 2 pasadas — **refs→DOI** (8a) **+ co-citación end-to-end** (8b): pobla `cited_by_id`
@@ -51,8 +51,21 @@
   Ver `docs/ROADMAP/` (Hitos R1–R5). Tras la remediación se construyeron el **Hito 8** (Enricher
   OpenAlex: refs→DOI + co-citación end-to-end) y el **Hito 7 ✅** (dedup fuzzy determinista
   `rapidfuzz`, extra `[dedup]`: `deduplicate_authors`/`deduplicate_keywords`, función de librería sin
-  CLI; ADR [0026](docs/decisiones/0026-dedup-fuzzy-determinista.md)). **388 tests verdes. PRÓXIMO:
+  CLI; ADR [0026](docs/decisiones/0026-dedup-fuzzy-determinista.md)). **PRÓXIMO:
   Hito 9** (`NetworkSpec` YAML). El entorno se levanta con `uv sync`.
+- **Fundación workspace COMPLETA** (ADR
+  [0029](docs/decisiones/0029-workspace-por-investigacion.md), AS-BUILT 2026-06-16; issues
+  [#32](https://github.com/complexluise/bib2graph/issues/32)/
+  [#38](https://github.com/complexluise/bib2graph/issues/38)/
+  [#39](https://github.com/complexluise/bib2graph/issues/39)): una investigación = un **workspace =
+  carpeta** (`workspace.json` + `library.duckdb` + `networks/`/`snapshots/`/`exports/`). Nuevo módulo
+  `src/bib2graph/workspace.py` (`Workspace`, `WorkspaceManifest`; el núcleo NO importa `duckdb`) +
+  **14° subcomando `b2g init`**. `--store` pasó a **opcional** y se agregó **`--workspace`** (ambos
+  opcionales, mutuamente excluyentes) con **resolución ambiente** (flag > env `B2G_WORKSPACE` >
+  walk-up del cwd buscando `workspace.json`). El `.duckdb` suelto sigue válido (workspace degenerado).
+  `b2g status` suma `workspace: {root, source}`; `b2g build` sella `networks/.corpus_hash`. **416
+  tests verdes**, 14 subcomandos. Flujo: `b2g init <name>` → trabajar **dentro** de la carpeta sin
+  `--store`.
 - Toda la información del producto, la arquitectura, los contratos y la secuencia de
   construcción está en `docs/`. **Leer `docs/ROADMAP/` antes de tocar nada**: cada hito declara
   qué historias del PRD §7 cumple, sus criterios de aceptación (DoD) y los tests TDD que se
@@ -230,8 +243,11 @@ src/bib2graph/
                        # ParquetStore (export); ZoteroStore ([zotero], V1.1);
                        # Neo4jStore ([neo4j], post-V1)
   cli/                 # paquete de 3 capas (Click → run_<cmd>() núcleo → envelope/errores);
-                       # cli/commands/ = 13 subcomandos (incl. monitor FSM→MONITORED, enrich refs→DOI + co-citación). CLI = API
+                       # cli/commands/ = 14 subcomandos (incl. monitor FSM→MONITORED, enrich refs→DOI + co-citación,
+                       # init scaffold de workspace —ADR 0029). CLI = API
                        # para LLM y agentes (Hito 6, ARCHITECTURE.md §6.3). No es un cli.py plano.
+  workspace.py         # Workspace (init/open/resolve) + WorkspaceManifest (ADR 0029): la carpeta es la
+                       # unidad de persistencia; resolución ambiente; import perezoso de DuckDBStore
 tests/
   unit/                # tests puros, sin red ni I/O (default)
   integration/         # red / APIs externas / Neo4j; @pytest.mark.integration

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,10 @@ Modelo **GitFlow-lite** — detalle en [`AGENTS.md`](AGENTS.md) §Flujo de traba
 ## Reglas que no se negocian
 
 - **uv** para todo (`uv sync`, `uv run …`); no `pip`, no editar `[project.dependencies]` a mano.
+- **Workspace por investigación** (ADR 0029): una investigación = una carpeta. Se arranca con
+  `b2g init <name>` (o `b2g init .`) y, trabajando **dentro** de ella, los comandos se resuelven por
+  ambiente (sin `--store`). `--workspace`/`--store` son opcionales y mutuamente excluyentes; el
+  `.duckdb` suelto sigue válido (workspace degenerado).
 - **Conventional Commits** estricto. Un PR = una idea, con sus tests.
 - Gate antes de PR: `uv run ruff check . && uv run ruff format --check . && uv run mypy src && uv run pytest`.
 - **Leer `docs/ROADMAP/` antes de empezar un hito** (historias del PRD §7, DoD, tests TDD).

--- a/docs/API.md
+++ b/docs/API.md
@@ -57,6 +57,13 @@
 > **co-citación es end-to-end**: `enrich` puebla `cited_by_id` desde las semillas aceptadas (vía
 > `OpenAlexSource.fetch_citing_batch`, §2) y `Networks.quick` devuelve **4 o 5 redes** según haya
 > `cited_by_id` (§10). Flag `--max-citing`. **Hito 8 completo.**
+>
+> **Sincronizado con el workspace — ADR [0029](decisiones/0029-workspace-por-investigacion.md)
+> (AS-BUILT, 2026-06-16):** la unidad de persistencia es un **workspace = carpeta** (`workspace.json`
+> + `library.duckdb` + `networks/`/`snapshots/`/`exports/`). `--store` pasó a **opcional** y se agregó
+> **`--workspace`** (ambos opcionales, mutuamente excluyentes) con **resolución ambiente** (flag > env
+> `B2G_WORKSPACE` > walk-up del cwd). Suma el **14° subcomando `init`**. El `.duckdb` suelto sigue
+> válido (workspace degenerado). Ver §convenciones CLI.
 
 ## Convenciones
 
@@ -73,12 +80,14 @@ El CLI `b2g` (paquete `bib2graph.cli`, entry point `b2g = "bib2graph.cli:main"`)
 **construido** con el contrato del ADR [0021](decisiones/0021-cli-agente-native-contrato.md). Cada
 subcomando lleva `--json` (envelope estable/versionado) y exit codes (`0` éxito · `1` uso · `2`
 datos · `3` dependencia · `4` red · `5` store/snapshot corrupto o bloqueado). **Sin estado entre
-invocaciones:** el estado vive en el archivo `.duckdb` (opción global `--store`).
+invocaciones:** el estado vive en el `library.duckdb` del **workspace** (opciones globales
+**opcionales** `--workspace`/`--store`, ver abajo).
 
-**Set de 13 subcomandos** (decisión del PO, ADR 0021 §A — **amplía** este doc, que antes listaba 9
+**Set de 14 subcomandos** (decisión del PO, ADR 0021 §A — **amplía** este doc, que antes listaba 9
 y dejaba `accept`/`reject` como "solo programático"; el 12° `monitor` se agregó en el cleanup
 pre-v0.3; el 13° `enrich` en el Ciclo 8a, ADR
-[0025](decisiones/0025-enricher-cocitacion-openalex.md)):
+[0025](decisiones/0025-enricher-cocitacion-openalex.md); el 14° `init` con el workspace, ADR
+[0029](decisiones/0029-workspace-por-investigacion.md)):
 
 - `seed`, `chain`, **`filter`** (filtros PRISMA deterministas: año/tipo/idioma/citas **con conteo
   en cada paso**), `build`, `export`, `snapshot`, **`status`** (expone el ciclo: estado actual,
@@ -86,7 +95,9 @@ pre-v0.3; el 13° `enrich` en el Ciclo 8a, ADR
   es el FSM cíclico `SEEDED/FORAGED/FILTERED/BUILT/MONITORED` (dominio en `bib2graph.cycle`) con
   **`reseed`**/contador de ronda; `status` **muestra `accept`/`reject` como acción siempre-disponible**
   (`curation_available`, curación transversal) + la **ronda** (`round`), campos aditivos que mantienen
-  `schema="1"`. `inspect`, `validate`.
+  `schema="1"`. **AS-BUILT workspace (ADR 0029):** `status` suma el campo aditivo
+  `workspace: {root, source}` (la raíz resuelta y de dónde salió — flag/env/cwd); `schema="1"`
+  intacto. `inspect`, `validate`.
 - **`accept`** / **`reject`** (decisión del PO, ADR 0021 §A): curación programática por `--ids`,
   ahora **subcomandos CLI de primera clase** (no solo API de librería), para que un agente cure la
   biblioteca viva por subprocess (historia C4). La **curación interactiva rica (`curate`) y la GUI
@@ -109,10 +120,23 @@ pre-v0.3; el 13° `enrich` en el Ciclo 8a, ADR
   fetch), `--json`. `data` = `{enriched, references_resolved, ...}`. **NO transiciona el
   `CycleState`** (ortogonal al lazo): se puede enriquecer en cualquier estado sin perturbar el FSM.
   `build` sigue puro/sin red.
+- **`init`** (ADR [0029](decisiones/0029-workspace-por-investigacion.md)): **scaffold de un
+  workspace**. `b2g init <name>` crea `<name>/` con `workspace.json` + `library.duckdb` +
+  `networks/`/`snapshots/`/`exports/`; **`b2g init .`** inicializa el cwd. Si la carpeta ya es un
+  workspace → error (`WorkspaceExistsError`). **NO transiciona** el `CycleState`. `data` =
+  `{root, name, ...}`; `--json` con `schema="1"`.
 
-**`--store` global (obligatoria).** Va en el grupo `b2g`, **antes** del subcomando:
-`b2g --store mi.duckdb seed --equation "..."`. Una investigación = un archivo `.duckdb` (ADR
-0015/0016). El CLI es stateful **vía archivo**, no vía proceso.
+**`--workspace` / `--store` globales (ambos OPCIONALES, mutuamente excluyentes).** Van en el grupo
+`b2g`, **antes** del subcomando. Una investigación = un **workspace** (carpeta marcada por
+`workspace.json`; ADR [0029](decisiones/0029-workspace-por-investigacion.md), AS-BUILT). El estado
+vive en su `library.duckdb`; el CLI es stateful **vía archivo**, no vía proceso.
+
+- **`--workspace <carpeta>`** apunta a la raíz de un workspace; **`--store <archivo.duckdb>`** apunta
+  a un `.duckdb` suelto (**workspace degenerado**, retrocompatible — los artefactos caen en su dir
+  hermano). Pasarlos **juntos** = error de uso (exit 1).
+- **Resolución ambiente** cuando no se pasa ninguno (patrón git/cargo), precedencia de mayor a menor:
+  (1) `--workspace`/`--store` explícito, (2) `B2G_WORKSPACE` (variable de entorno), (3) **walk-up**
+  del cwd buscando `workspace.json`. Sin ninguno → **error accionable** que sugiere `b2g init`.
 
 **`build` y `export` separados** (decisión del PO, ADR 0021 §B): `build` computa `Networks.quick`
 (4 redes) y escribe artefactos a `<store_dir>/networks/<kind>/` (+ transiciona a `BUILT`);
@@ -150,8 +174,9 @@ faltante"); la capacidad-de-source-faltante se convierte en `DependencyError` co
 `hasattr` en el comando** (p. ej. `chain` antes del `Forager`). Un `AttributeError` inesperado se
 propaga limpio.
 
-**Borde: el error de uso sale SIN envelope.** Si falta `--store` (u otra opción requerida), Click
-aborta el parseo **antes** de entrar al comando: se emite el mensaje de uso de Click en **stderr** y
+**Borde: el error de uso sale SIN envelope.** Ante un error de uso (p. ej. `--workspace` y `--store`
+juntos, una opción requerida faltante, o ningún store/workspace resoluble), Click aborta el parseo
+**antes** de entrar al comando: se emite el mensaje de uso de Click en **stderr** y
 exit code `1`, **sin** envelope JSON. El envelope versionado solo cubre errores que ocurren
 **dentro** de la ejecución del comando.
 
@@ -1032,22 +1057,29 @@ for s in steps:
 
 ### 12.3 Por CLI agente-native (Hito 6 — construido)
 
-El mismo flujo, sin escribir Python, vía `b2g` (`--store` global, una línea JSON por comando):
+El mismo flujo, sin escribir Python, vía `b2g`: se **inicia el workspace una vez** y, trabajando
+**dentro** de su carpeta, los comandos se resuelven por ambiente (sin `--store` repetido). Una línea
+JSON por comando:
 
 ```bash
-b2g --store biblioteca.duckdb seed --equation '"unequal ecological exchange"' --email luis@sostaina.com --json
-b2g --store biblioteca.duckdb chain --direction both --max-candidates 300 --json
-b2g --store biblioteca.duckdb filter --year-gte 2010 --language en --language es --json
-b2g --store biblioteca.duckdb accept --ids oa:abc123 --ids oa:def456 --json
-b2g --store biblioteca.duckdb build --json
-b2g --store biblioteca.duckdb export --format graphml --out-dir redes/ --json
-b2g --store biblioteca.duckdb status --json     # CycleState + round + curation_available + conteos
+b2g init ied                                    # crea ./ied/ (workspace.json + library.duckdb + networks/…)
+cd ied                                           # a partir de acá el workspace se resuelve por cwd
+b2g seed --equation '"unequal ecological exchange"' --email luis@sostaina.com --json
+b2g chain --direction both --max-candidates 300 --json
+b2g filter --year-gte 2010 --language en --language es --json
+b2g accept --ids oa:abc123 --ids oa:def456 --json
+b2g build --json                                 # escribe networks/ + sella networks/.corpus_hash
+b2g export --format graphml --out-dir redes/ --json
+b2g status --json     # CycleState + round + curation_available + workspace + conteos
 ```
+
+Retrocompat: `b2g --store biblioteca.duckdb seed …` (sin `init`, `.duckdb` suelto = workspace
+degenerado) sigue siendo válido.
 
 El **modo declarativo** (`b2g ... --spec redes.yaml`, `NetworkSpec` desde YAML) es del **Hito 9**
 (v0.3+), **no construido todavía**:
 
 ```bash
-# Hito 9 (futuro): pipeline declarativo desde un YAML versionable
-b2g --store biblioteca.duckdb networks --spec redes.yaml --json
+# Hito 9 (futuro): pipeline declarativo desde un YAML versionable (dentro del workspace)
+b2g networks --spec redes.yaml --json
 ```

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -289,9 +289,10 @@ tablas de **procedencia, decisiones de curación** (aceptar/rechazar) y el **`Lo
 en memoria). **Cleanup pre-v0.3:** el `merge` ya **no interpola ids crudos** en el SQL (eliminado el
 `CASE WHEN`/`IN (...)` con f-strings); lee las filas y **ordena en Python** por orden de aparición
 antes de reinsertar (orden determinista D3 preservado, sin construir SQL con datos). Soporta query
-SQL. Es **núcleo**, no extra. **Una investigación = un archivo
-`.duckdb`** (single-writer; concurrencia diferida, ADR
-[0019](decisiones/0019-concurrencia-diferida.md)).
+SQL. Es **núcleo**, no extra. **Una investigación = un workspace** (carpeta autocontenida con su
+`library.duckdb`; AS-BUILT ADR [0029](decisiones/0029-workspace-por-investigacion.md)); el
+`library.duckdb` sigue siendo single-writer (un `.duckdb` suelto = workspace degenerado;
+concurrencia diferida, ADR [0019](decisiones/0019-concurrencia-diferida.md)).
 
 El **snapshot** es un **export sellado** del estado vivo (ver §6.2), no la persistencia en sí;
 `ParquetStore` puede servir como **formato de export/intercambio**. La costura `Store` sigue
@@ -299,14 +300,16 @@ siendo el punto de extensión para destinos externos: **`ZoteroStore`** (sincron
 con una colección Zotero) es **opt-in en V1.1** (`[zotero]`); **`Neo4jStore`** es adaptador opt-in
 post-V1 (`[neo4j]`): un destino más, **ya no el sustrato** (ADR 0002).
 
-> **TARGET (propuesto, no as-built) — workspace por investigación, ADR
-> [0029](decisiones/0029-workspace-por-investigacion.md):** la unidad de persistencia evolucionaría
-> de "1 archivo `.duckdb`" a "**1 workspace = 1 carpeta**" (`workspace.json` + `library.duckdb` +
-> `networks/` + `snapshots/` + `exports/`), formalizando la convención emergente de que `build` ya
-> escribe `<store_dir>/networks/`. El corpus/procedencia/curación/loop-state siguen en el `.duckdb`;
-> redes/exports = cache regenerable sellada por `corpus_hash`; el snapshot sigue siendo lo
-> reproducible (§6.2). Enmienda 0009/0019; single-writer sin cambios. **Propuesta, pendiente de
-> firma — el as-built sigue siendo el `.duckdb` suelto.**
+> **AS-BUILT (2026-06-16) — workspace por investigación, ADR
+> [0029](decisiones/0029-workspace-por-investigacion.md):** la **unidad de persistencia es el
+> workspace = una carpeta** (`workspace.json` + `library.duckdb` + `networks/` + `snapshots/` +
+> `exports/`), formalizando la convención emergente de que `build` ya escribía `<store_dir>/networks/`.
+> El corpus/procedencia/curación/loop-state siguen en el `.duckdb`; redes/exports = cache regenerable
+> sellada por `corpus_hash` (`b2g build` graba `networks/.corpus_hash`); el snapshot sigue siendo lo
+> reproducible (§6.2). El `.duckdb` suelto sigue válido como **workspace degenerado** (sin migración
+> forzada). Enmienda 0009/0019; single-writer sin cambios. **Acotado en este corte:**
+> `snapshot`/`export` aún usan `--out-dir` explícito; la staleness solo sella el hash (sin aviso ni
+> regeneración automática todavía).
 
 ## 5. Flujo de datos (ciclo iterativo, no pipeline lineal)
 
@@ -435,14 +438,18 @@ trabajo posterior, pero la API se **diseña con estos principios desde el hito 1
    faltante"); la capacidad-de-source-faltante se convierte en `DependencyError` mediante un
    **pre-check `hasattr` en el borde** (p. ej. `chain.py` antes del `Forager`). Ver ADR 0021 §D.
 
-Son **13 subcomandos** (`seed`, `chain`, `filter`, `build`, `export`, `snapshot`, `status`,
-`inspect`, `validate`, `accept`, `reject`, **`monitor`**, **`enrich`**); `build`/`export` están
+Son **14 subcomandos** (`seed`, `chain`, `filter`, `build`, `export`, `snapshot`, `status`,
+`inspect`, `validate`, `accept`, `reject`, **`monitor`**, **`enrich`**, **`init`**); `build`/`export` están
 **separados** y el `CycleState` transiciona automáticamente por comando (ADR 0021). El 12°
 **`monitor`** (cleanup pre-v0.3) re-chequea citantes nuevos del corpus (forward chaining) y
 transiciona a `MONITORED`. El 13° **`enrich`** (Hito 8 = Ciclos 8a + 8b, ADR
 [0025](decisiones/0025-enricher-cocitacion-openalex.md)) corre el `OpenAlexEnricher` (refs→DOI +
-co-citación, flag `--max-citing`) y **no transiciona** el ciclo (ortogonal al lazo). El error de uso (p. ej. falta `--store`) sale **sin
-envelope** (Click aborta el parseo: stderr + exit 1).
+co-citación, flag `--max-citing`) y **no transiciona** el ciclo (ortogonal al lazo). El 14°
+**`init`** (AS-BUILT ADR [0029](decisiones/0029-workspace-por-investigacion.md)) hace scaffold de un
+workspace (carpeta + `workspace.json` + `library.duckdb` + `networks/`/`snapshots/`/`exports/`;
+`b2g init .` inicializa el cwd) y **no transiciona** el ciclo. El error de uso (p. ej.
+`--workspace` y `--store` juntos, o ningún store/workspace resoluble) sale **sin envelope** (Click
+aborta el parseo: stderr + exit 1).
 
 **AS-BUILT R5 — UTF-8 en la frontera (Nota 06 RAÍZ 3):** `main()` llama `_force_utf8()` (reconfigura
 `sys.stdout`/`stderr` a UTF-8, con guarda por si la stream no es reconfigurable) **antes de que Click
@@ -452,16 +459,17 @@ solo lectura:** `status`/`validate` usan `open_store_readonly` (`cli/_store.py`)
 el `.duckdb` ante un typo en `--store` (falla accionable); los comandos de escritura conservan
 `open_store`.
 
-> **TARGET (propuesto, no as-built) — `--store` opcional + `b2g init`, ADR
-> [0029](decisiones/0029-workspace-por-investigacion.md):** con el modelo workspace, `--store`
-> dejaría de ser opción global **obligatoria** y pasaría a **opcional**: la unidad sería una
-> **carpeta workspace** (`workspace.json`), resuelta por ambiente (patrón git/cargo: caminar hacia
-> arriba desde el cwd). Precedencia: `--workspace`/`--store` explícito > `B2G_WORKSPACE` (env) >
-> workspace del cwd. Entraría un subcomando **`b2g init <name>`** (scaffold de la carpeta; `b2g init .`
-> inicializa el cwd) → el conteo de subcomandos pasaría de **13 a 14+** **cuando se implemente**. El
-> `.duckdb` suelto seguiría funcionando (workspace "degenerado", sin migración forzada). Es un cambio
-> **suave/aditivo** del contrato (la resolución ambiente solo cubre el flag ausente). **Propuesta,
-> pendiente de firma — hoy `--store` sigue siendo global obligatorio y son 13 subcomandos.**
+> **AS-BUILT (2026-06-16) — `--store` opcional + `--workspace` + `b2g init`, ADR
+> [0029](decisiones/0029-workspace-por-investigacion.md):** con el modelo workspace, `--store` dejó de
+> ser opción global **obligatoria** y pasó a **opcional**, y se agregó **`--workspace`** (ambos
+> opcionales y **mutuamente excluyentes** — juntos = error de uso). La unidad es una **carpeta
+> workspace** (`workspace.json`), resuelta por ambiente (patrón git/cargo: walk-up del cwd).
+> Precedencia: `--workspace`/`--store` explícito > `B2G_WORKSPACE` (env) > workspace del cwd. Sin flag
+> y sin workspace resoluble → error accionable que sugiere `b2g init`. Entró el subcomando **`b2g init
+> <name>`** (scaffold de la carpeta; `b2g init .` inicializa el cwd) → el conteo de subcomandos pasó de
+> **13 a 14**. El `.duckdb` suelto sigue funcionando (workspace "degenerado", sin migración forzada).
+> Es un cambio **suave/aditivo** del contrato (la resolución ambiente solo cubre el flag ausente). El
+> `status` suma el campo aditivo `workspace: {root, source}` (`schema="1"` intacto).
 
 ## 7. Layout de dependencias (extras)
 

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -398,8 +398,9 @@ Esta reconciliación ya está reflejada en `ARCHITECTURE.md` (§3.1, §4.3, §6.
 3. ✅ Implementación por hitos en curso (coder): **Hitos 0–6 + 1.5 terminados** (núcleo del corpus
    stateful sobre `TabularBackend`, proyectores/analizadores/export, biblioteca viva en DuckDB,
    fuentes OpenAlex/BibTeX, forrajeo + `Preprocessor` + filtros PRISMA, y el **CLI agente-native
-   `b2g`** — 13 subcomandos, ADR [0021](decisiones/0021-cli-agente-native-contrato.md) +
-   [0025](decisiones/0025-enricher-cocitacion-openalex.md) (`enrich`, Ciclo 8a)). Con ello
+   `b2g`** — 14 subcomandos, ADR [0021](decisiones/0021-cli-agente-native-contrato.md) +
+   [0025](decisiones/0025-enricher-cocitacion-openalex.md) (`enrich`, Ciclo 8a) +
+   [0029](decisiones/0029-workspace-por-investigacion.md) (`init` + workspace)). Con ello
    v0.2 alcanza las capacidades del **flujo** `seed → … → export`. **El red-team de la
    [Nota 06](Notas/06-critica-as-built-v0.2.md) corrige el claim "capacidades completas":** falta la
    **tanda de remediación R1–R5** (modelo sin IA, identidad-vs-procedencia reproducible, FSM cíclico,

--- a/docs/ROADMAP/04-lo-que-viene.md
+++ b/docs/ROADMAP/04-lo-que-viene.md
@@ -177,13 +177,17 @@ No se prometen ni se cablean clientes que no se usan.
 
 ## Backlog / ideas pendientes (sin hito ni DoD todavía)
 
-- **Workspace por investigación:** cada investigación = una carpeta auto-contenida (la
-  `.duckdb` + `networks/` + snapshots/exports/artefactos), en vez de un `.duckdb` suelto.
-  Evoluciona el modelo "una investigación = un archivo" (ADR
-  [0009](../decisiones/0009-biblioteca-viva-duckdb.md) /
-  [0019](../decisiones/0019-concurrencia-diferida.md)). Encaja con la GUI local
-  ([Nota 07](../Notas/07-frontend-tool-for-thought.md)). Pendiente de diseño (probable ADR
-  que enmiende 0009/0019).
+- **Workspace por investigación · ✅ HECHO (2026-06-16, ADR
+  [0029](../decisiones/0029-workspace-por-investigacion.md); issues #32/#38/#39):** cada investigación
+  = una carpeta auto-contenida (`workspace.json` + `library.duckdb` + `networks/`/`snapshots/`/
+  `exports/`), en vez de un `.duckdb` suelto. Evolucionó el modelo "una investigación = un archivo"
+  (enmienda a ADR [0009](../decisiones/0009-biblioteca-viva-duckdb.md) /
+  [0019](../decisiones/0019-concurrencia-diferida.md)). Construido: módulo `workspace.py`, **14°
+  subcomando `b2g init`**, `--store` opcional + `--workspace` con resolución ambiente; el `.duckdb`
+  suelto sigue válido (workspace degenerado). Prerequisito de la epic GUI local
+  ([#34](https://github.com/complexluise/bib2graph/issues/34),
+  [Nota 07](../Notas/07-frontend-tool-for-thought.md)). **Fuera de este corte:** `snapshot`/`export`
+  aún con `--out-dir` explícito; staleness solo sella el hash (sin aviso/regeneración automática).
 
 > **RETIRADO del producto (ADR [0022](../decisiones/0022-producto-sin-ia-generativa.md), 2026-06-15):**
 > el **fallback fuzzy/semántico del thesaurus por LLM** y la **"máquina de tensiones"** (la antigua

--- a/docs/ROADMAP/README.md
+++ b/docs/ROADMAP/README.md
@@ -95,7 +95,9 @@ OIDC), no el push de tags. Cortes acordados:
   [0021](../decisiones/0021-cli-agente-native-contrato.md)). El 12° **`monitor`** (cleanup pre-v0.3)
   re-chequea citantes nuevos del corpus y transiciona a `MONITORED`; el 13° **`enrich`** (Hito 8,
   ADR [0025](../decisiones/0025-enricher-cocitacion-openalex.md)) resuelve refs→DOI **+ co-citación
-  end-to-end** (`--max-citing`) y **no transiciona** el ciclo. El `accept`/`reject` programático
+  end-to-end** (`--max-citing`) y **no transiciona** el ciclo. *(Más tarde, la fundación workspace
+  sumó el 14° `init` —ADR [0029](../decisiones/0029-workspace-por-investigacion.md)—, fuera del corte
+  v0.2.)* El `accept`/`reject` programático
   sobrevive (ahora como subcomando CLI); la curación interactiva rica (`curate`) y la GUI son
   futuro. Acá se cumple el criterio "V1 hecha" del PRD §9 a nivel de *capacidades* (el número de
   versión sigue en 0.y). **Tag `v0.2.0`** creado el 2026-06-15, **publicado en `origin`**.
@@ -107,6 +109,12 @@ OIDC), no el push de tags. Cortes acordados:
   excluir timestamps; el `LoopState` se mueve a `cycle.py`), pero **no rompe el flujo de 10 minutos**
   ni el contrato `--json` externo. Sin esto, el claim de reproducibilidad y de "ciclo no lineal" no
   se sostiene (Nota 06, RAÍZ 1/2).
+- **Fundación workspace · ✅ HECHA (2026-06-16, ADR
+  [0029](../decisiones/0029-workspace-por-investigacion.md); issues #32/#38/#39):** una investigación
+  = un **workspace = carpeta** (`workspace.json` + `library.duckdb` + `networks/`/`snapshots/`/
+  `exports/`). Suma el **14° subcomando `b2g init`**; `--store` pasó a opcional + nuevo `--workspace`
+  (resolución ambiente). El `.duckdb` suelto sigue válido (workspace degenerado). No fue un hito
+  numerado (prerequisito de la epic GUI #34). Ver [04 · Lo que viene](04-lo-que-viene.md) §Backlog.
 - **v0.4+ — opcionales (Hitos 7–9):** dedup fuzzy, `Enricher` de co-citación (**Hito 8 ✅**:
   refs→DOI + co-citación end-to-end), `NetworkSpec`.
 - **1.0.0:** API congelada + caso real (IED) reproducido por un usuario distinto del autor (Nota 06,
@@ -204,5 +212,5 @@ limpio y actual; el cuerpo de cada hito vive en su archivo:
 | D3 asortatividad + composición + proxy | 2 | |
 | D4 export GraphML/CSV | 2 | |
 | E1 snapshot reproducible | 1 + 6 ✅ | `Corpus.snapshot` + `b2g snapshot` |
-| E2 CLI `--json` + exit codes | 0 (principios) + 6 ✅ (CLI) + cleanup pre-v0.3 ✅ (`monitor`) + 8 ✅ (`enrich`) | `b2g` **13 subcomandos** (Hito 6 entregó 11; `monitor` se sumó en el cleanup pre-v0.3 → `MONITORED`; `enrich` en el Hito 8 —refs→DOI + co-citación, `--max-citing`—, ADR 0025, sin transición), envelope `--json` versionado, exit 0–5 (ADR 0021) |
+| E2 CLI `--json` + exit codes | 0 (principios) + 6 ✅ (CLI) + cleanup pre-v0.3 ✅ (`monitor`) + 8 ✅ (`enrich`) + workspace ✅ (`init`) | `b2g` **14 subcomandos** (Hito 6 entregó 11; `monitor` se sumó en el cleanup pre-v0.3 → `MONITORED`; `enrich` en el Hito 8 —refs→DOI + co-citación, `--max-citing`—, ADR 0025, sin transición; `init` con el workspace, ADR 0029), envelope `--json` versionado, exit 0–5 (ADR 0021) |
 

--- a/docs/decisiones/0009-biblioteca-viva-duckdb.md
+++ b/docs/decisiones/0009-biblioteca-viva-duckdb.md
@@ -61,17 +61,17 @@ persistencia núcleo de 1.0.
 - Hay que **reescribir `ARCHITECTURE.md` §6.2** y **reordenar `ROADMAP.md`** (el store DuckDB
   stateful sube a un hito temprano del núcleo).
 
-## Enmienda — la unidad de persistencia pasa a "workspace/carpeta" (PROPUESTA, 2026-06-16)
+## Enmienda — la unidad de persistencia pasa a "workspace/carpeta" (AS-BUILT, 2026-06-16)
 
-> **Propuesta por [0029](0029-workspace-por-investigacion.md) (estado *Propuesta*, no implementado).**
-> El cuerpo queda como historia; la biblioteca viva stateful en DuckDB **no cambia**.
+> **Implementado por [0029](0029-workspace-por-investigacion.md) (ver su AS-BUILT).** El cuerpo de
+> este ADR queda como historia; la biblioteca viva stateful en DuckDB **no cambia**.
 
 Este ADR estableció la biblioteca viva sobre **un archivo `.duckdb`**. El ADR
-[0029](0029-workspace-por-investigacion.md) propone que la **unidad de persistencia** pase de "1
-archivo" a "**1 workspace = 1 carpeta**" (marcada por `workspace.json`), que contiene el
-`library.duckdb` + `networks/` + `snapshots/` + `exports/`. El **corpus, la procedencia, las
-decisiones de curación y el loop-state siguen viviendo dentro del `.duckdb`** (sin duplicarse en el
-manifest); las redes/exports son cache regenerable y el snapshot sigue siendo lo reproducible (ADR
-0017). Es una **formalización de una convención emergente** (`b2g build` ya escribe
-`<store_dir>/networks/`), no una revisión del modelo de datos. **Hasta que 0029 se firme e
-implemente, la unidad as-built sigue siendo el `.duckdb` suelto.**
+[0029](0029-workspace-por-investigacion.md) eleva la **unidad de persistencia** de "1 archivo" a "**1
+workspace = 1 carpeta**" (marcada por `workspace.json`), que contiene el `library.duckdb` +
+`networks/` + `snapshots/` + `exports/`. El **corpus, la procedencia, las decisiones de curación y
+el loop-state siguen viviendo dentro del `.duckdb`** (sin duplicarse en el manifest); las
+redes/exports son cache regenerable y el snapshot sigue siendo lo reproducible (ADR 0017). Es una
+**formalización de una convención emergente** (`b2g build` ya escribía `<store_dir>/networks/`), no
+una revisión del modelo de datos. El `.duckdb` suelto sigue funcionando como **workspace degenerado**
+(retrocompatible).

--- a/docs/decisiones/0019-concurrencia-diferida.md
+++ b/docs/decisiones/0019-concurrencia-diferida.md
@@ -45,16 +45,17 @@ servidor si aparece el caso multi-agente concurrente).
   asunción single-writer y traduce el error de archivo bloqueado de DuckDB a un error accionable
   con exit code `5` (a cablear en el CLI, Hito 6). No se implementa locking propio.
 
-## Enmienda — la unidad pasa a "workspace/carpeta"; el single-writer sigue válido (PROPUESTA, 2026-06-16)
+## Enmienda — la unidad pasa a "workspace/carpeta"; el single-writer sigue válido (AS-BUILT, 2026-06-16)
 
-> **Propuesta por [0029](0029-workspace-por-investigacion.md) (estado *Propuesta*, no implementado).**
-> El cuerpo queda como historia.
+> **Implementado por [0029](0029-workspace-por-investigacion.md) (ver su AS-BUILT).** El cuerpo de
+> este ADR queda como historia.
 
 Este ADR razona sobre "1 archivo `.duckdb` = 1 escritor". El ADR
-[0029](0029-workspace-por-investigacion.md) propone que la **unidad de persistencia** pase a ser un
+[0029](0029-workspace-por-investigacion.md) eleva la **unidad de persistencia** a un
 **workspace = carpeta** (`workspace.json` + `library.duckdb` + `networks/`/`snapshots/`/`exports/`).
 La conclusión de concurrencia **no cambia**: el `library.duckdb` dentro del workspace sigue siendo
 **single-writer** (un escritor a la vez; lecturas concurrentes OK). Varias investigaciones en
 paralelo = varios workspaces (varias carpetas, varios `.duckdb`) sin contención entre ellos. La
 concurrencia multi-escritor sobre un mismo `.duckdb` sigue diferida post-v1.0. **Léase "1 archivo" ≡
-"el `library.duckdb` del workspace".**
+"el `library.duckdb` del workspace".** (El `.duckdb` suelto = workspace degenerado, también
+single-writer.)

--- a/docs/decisiones/0021-cli-agente-native-contrato.md
+++ b/docs/decisiones/0021-cli-agente-native-contrato.md
@@ -240,19 +240,21 @@ exploratorio). `status` lee y presenta el estado actual + las transiciones dispo
 `stores/duckdb.py`): el contrato usa **solo `CycleState`** (de `bib2graph.cycle`). Donde este ADR
 dice "`LoopState`", léase `CycleState` (mismo concepto, una sola clase).
 
-## Enmienda — `--store` deja de ser global obligatorio (PROPUESTA, 2026-06-16)
+## Enmienda — `--store` deja de ser global obligatorio (AS-BUILT, 2026-06-16)
 
-> **Propuesta por [0029](0029-workspace-por-investigacion.md) (estado *Propuesta*, no implementado).**
-> El cuerpo de este ADR queda como historia; esta enmienda solo señala el cambio futuro al §E.
+> **Implementado por [0029](0029-workspace-por-investigacion.md) (ver su AS-BUILT).** El cuerpo de
+> este ADR queda como historia; esta enmienda actualiza el §E al as-built.
 
-El §E fija `--store` como **opción global del grupo, obligatoria**. El ADR
-[0029](0029-workspace-por-investigacion.md) (modelo "workspace por investigación") propone que
-`--store` pase a **opcional**: la unidad de persistencia deja de ser un `.duckdb` suelto y pasa a ser
-una **carpeta workspace** (marcada por `workspace.json`), resuelta por **ambiente** (patrón
-git/cargo: caminar hacia arriba desde el cwd). Precedencia: `--workspace`/`--store` explícito >
-`B2G_WORKSPACE` (env) > workspace del cwd. `--workspace` pasa a ser el flag primario; `--store`
-sobrevive para apuntar a un `.duckdb` suelto (workspace "degenerado", retrocompatible).
+El §E fijaba `--store` como **opción global del grupo, obligatoria**. Con el modelo "workspace por
+investigación" (ADR [0029](0029-workspace-por-investigacion.md)), `--store` pasó a **opcional** y se
+agregó **`--workspace`** (ambos opcionales): la unidad de persistencia deja de ser un `.duckdb`
+suelto y pasa a ser una **carpeta workspace** (marcada por `workspace.json`), resuelta por
+**ambiente** (patrón git/cargo: walk-up del cwd). Precedencia: `--workspace`/`--store` explícito >
+`B2G_WORKSPACE` (env) > workspace del cwd. **`--workspace` y `--store` son mutuamente excluyentes**
+(juntos = error de uso). `--workspace` es el flag primario; `--store` sobrevive para apuntar a un
+`.duckdb` suelto (workspace "degenerado", retrocompatible). Sin flag y sin workspace resoluble → error
+accionable que sugiere `b2g init`.
 
 El cambio es **aditivo/retrocompatible**: la resolución ambiente solo cubre el caso en que falta el
-flag; el resto del contrato (envelope `schema="1"`, exit codes, transiciones) **no cambia**. **Hasta
-que 0029 se firme e implemente, `--store` sigue siendo global obligatorio** (as-built vigente).
+flag; el resto del contrato (envelope `schema="1"`, exit codes, transiciones) **no cambia**. El set
+de subcomandos pasa de 13 a **14** con el alta de `b2g init` (scaffold del workspace).

--- a/docs/decisiones/0029-workspace-por-investigacion.md
+++ b/docs/decisiones/0029-workspace-por-investigacion.md
@@ -1,8 +1,8 @@
 # 0029 — Workspace por investigación: carpeta autocontenida + resolución ambiente
 
-- **Estado:** Propuesta (pendiente de firma del PO; **no implementado**)
+- **Estado:** Aceptada — **AS-BUILT (2026-06-16)** (firmado por el PO e implementado)
 - **Fecha:** 2026-06-16
-- **Enmienda (propuesta por este ADR):** [0009](0009-biblioteca-viva-duckdb.md) y
+- **Enmienda (de este ADR):** [0009](0009-biblioteca-viva-duckdb.md) y
   [0019](0019-concurrencia-diferida.md) — la **unidad de persistencia** pasa de "1 archivo
   `.duckdb`" a "**1 workspace = 1 carpeta**" (el single-writer sobre el `.duckdb` sigue válido);
   [0021](0021-cli-agente-native-contrato.md) §E — `--store` deja de ser opción global
@@ -113,9 +113,34 @@ mi-investigacion/
   aditivo/retrocompatible (la resolución ambiente solo **cubre** el caso en que falta el flag), pero
   toca el contrato público y exige sincronizar `docs/API.md`/`ARCHITECTURE.md` cuando se implemente.
 
-> **PROPUESTA — no implementado (2026-06-16).** Mientras este ADR esté en estado *Propuesta*, el
-> comportamiento **as-built** sigue siendo el de ADR 0009/0019/0021: unidad = `.duckdb`, `--store`
-> global **obligatorio**, sin `b2g init` ni resolución ambiente. El flujo diario (CLAUDE.md /
-> AGENTS.md / CONTRIBUTING.md / referencia del CLI) y los conteos as-built **no** se reescriben hasta
-> que esto se implemente; los marcadores **TARGET** en `ARCHITECTURE.md` describen el objetivo, no el
-> presente.
+## AS-BUILT (2026-06-16)
+
+Implementado y verificado (gate verde, 416 tests). Lo construido en este corte:
+
+- **`src/bib2graph/workspace.py`** — clase `Workspace` (factories `init`/`open`/`resolve`),
+  `WorkspaceManifest` (`{name, created_at, bib2graph_version, schema_version}`) y las excepciones
+  `WorkspaceNotFoundError` / `WorkspaceExistsError`. El **núcleo NO importa `duckdb`**: `DuckDBStore`
+  se importa de forma **perezosa** dentro de `Workspace`.
+- **`b2g init <name>`** (14º subcomando, `cli/commands/init.py`): scaffolds `<name>/` con
+  `workspace.json` + `library.duckdb` + `networks/`/`snapshots/`/`exports/`. **`b2g init .`**
+  inicializa el cwd. Si la carpeta ya es un workspace → error (`WorkspaceExistsError`).
+- **`--store` global pasó a OPCIONAL** y se agregó **`--workspace`** (ambos opcionales). **Resolución
+  ambiente** con precedencia: `--workspace`/`--store` explícito > `B2G_WORKSPACE` (env) > **walk-up**
+  del cwd buscando `workspace.json`. **`--workspace` y `--store` son mutuamente excluyentes**
+  (pasarlos juntos = error de uso). Sin ninguno y sin workspace resoluble → **error accionable** que
+  sugiere `b2g init`.
+- **Retrocompat (workspace degenerado):** `--store archivo.duckdb` suelto sigue válido; los
+  artefactos caen en su dir hermano, como hoy. Sin migración forzada.
+- **`b2g status`:** campo aditivo `workspace: {root, source}` (de dónde se resolvió). `schema="1"`
+  intacto.
+- **`b2g build`:** escribe las redes en `<workspace>/networks/` y **sella** `networks/.corpus_hash`
+  (cache regenerable; el snapshot sigue siendo lo reproducible).
+
+**Fuera de este corte (acotado deliberadamente):**
+
+- **`snapshot`/`export` siguen usando `--out-dir` explícito** — no se redirigen automáticamente a
+  `<workspace>/snapshots/`/`exports/`.
+- **Staleness = solo se sella el hash.** `build` graba `networks/.corpus_hash`, pero **no** hay aún
+  aviso de cache obsoleta ni regeneración automática cuando el `corpus_hash` deja de coincidir; se
+  implementará cuando aparezca la necesidad (la invalidación por hash sigue siendo el modelo, no un
+  build system — ver Consecuencias).

--- a/src/bib2graph/cli/__init__.py
+++ b/src/bib2graph/cli/__init__.py
@@ -1,19 +1,26 @@
-"""cli — CLI agente-native ``b2g`` (Hito 6).
+"""cli — CLI agente-native ``b2g`` (Hito 6 + ADR 0029 workspace).
 
-Arma el grupo Click principal, registra los 12 subcomandos y expone
+Arma el grupo Click principal, registra los 14 subcomandos y expone
 ``main()`` como entry point del paquete.
 
 Entry point en ``pyproject.toml``:
     b2g = "bib2graph.cli:main"
 
 Subcomandos:
-    seed, chain, filter, build, enrich, monitor, export, snapshot,
+    init, seed, chain, filter, build, enrich, monitor, export, snapshot,
     status, inspect, validate, accept, reject.
 
 Cada subcomando lleva:
   - ``--json``: salida JSON estructurada (envelope versionado, §API.md).
   - Exit codes 0-5 (ADR 0010).
-  - Sin estado entre invocaciones: el estado vive en ``--store``.
+  - Sin estado entre invocaciones: el estado vive en el workspace / --store.
+
+ADR 0029 — resolución ambiente:
+  Las opciones globales ``--workspace`` y ``--store`` son OPCIONALES.
+  Si no se pasa ninguna, los comandos resuelven el workspace activo vía
+  ``Workspace.resolve(...)`` (B2G_WORKSPACE env o cwd walk).
+  ``--store`` se conserva para retrocompatibilidad con el modo degenerado
+  (un ``.duckdb`` suelto).
 
 R5 — UTF-8 en la frontera:
   ``main()`` fuerza ``sys.stdout``/``sys.stderr`` a UTF-8 antes de que Click
@@ -35,6 +42,7 @@ from bib2graph.cli.commands.chain import chain_cmd
 from bib2graph.cli.commands.enrich import enrich_cmd
 from bib2graph.cli.commands.export import export_cmd
 from bib2graph.cli.commands.filter import filter_cmd
+from bib2graph.cli.commands.init import init_cmd
 from bib2graph.cli.commands.inspect import inspect_cmd
 from bib2graph.cli.commands.monitor import monitor_cmd
 from bib2graph.cli.commands.reject import reject_cmd
@@ -62,30 +70,59 @@ def _force_utf8() -> None:
 
 @click.group()
 @click.option(
-    "--store",
-    required=True,
+    "--workspace",
+    default=None,
     type=click.Path(),
-    help="Ruta al archivo .duckdb de la biblioteca viva. Una investigación = un archivo.",
+    help=(
+        "Carpeta del workspace activo. "
+        "Si no se pasa, se resuelve vía B2G_WORKSPACE o buscando workspace.json "
+        "hacia arriba desde el directorio actual (ADR 0029)."
+    ),
+)
+@click.option(
+    "--store",
+    default=None,
+    type=click.Path(),
+    help=(
+        "Ruta directa al archivo .duckdb (modo degenerado, retrocompat). "
+        "Mutuamente excluyente con --workspace; no uses ambos. "
+        "Preferí --workspace para investigaciones nuevas."
+    ),
 )
 @click.pass_context
-def b2g(ctx: click.Context, store: str) -> None:
+def b2g(ctx: click.Context, workspace: str | None, store: str | None) -> None:
     """b2g — bib2graph CLI agente-native.
 
     Transforma corpus bibliográficos en redes bibliométricas reproducibles.
-    El estado de la investigación vive en --store (archivo .duckdb).
 
-    Subcomandos: seed, chain, filter, build, enrich, monitor, export, snapshot,
-    status, inspect, validate, accept, reject.
+    El workspace activo se resuelve en este orden (ADR 0029):
+      1. --workspace <carpeta>  (forma canónica)
+      2. --store <archivo.duckdb>  (modo degenerado, retrocompat — mutuamente excluyente con --workspace)
+      3. Variable de entorno B2G_WORKSPACE
+      4. workspace.json encontrado subiendo desde el directorio actual
 
-    Ejemplo:
-        b2g --store mi_investigacion.duckdb seed --equation "unequal exchange"
-        b2g --store mi_investigacion.duckdb status --json
+    Si no hay ninguno, los comandos que necesitan la biblioteca emiten un
+    error accionable (exit 1) que sugiere 'b2g init' o '--workspace'.
+
+    Subcomandos: init, seed, chain, filter, build, enrich, monitor, export,
+    snapshot, status, inspect, validate, accept, reject.
+
+    Ejemplo con workspace:
+        b2g init mi-investigacion
+        cd mi-investigacion
+        b2g seed --equation "unequal exchange"
+        b2g status --json
+
+    Ejemplo legado (--store):
+        b2g --store mi.duckdb seed --equation "unequal exchange"
     """
     ctx.ensure_object(dict)
+    ctx.obj["workspace"] = workspace
     ctx.obj["store"] = store
 
 
-# Registrar los 13 subcomandos
+# Registrar los 14 subcomandos
+b2g.add_command(init_cmd)
 b2g.add_command(seed_cmd)
 b2g.add_command(chain_cmd)
 b2g.add_command(filter_cmd)

--- a/src/bib2graph/cli/_store.py
+++ b/src/bib2graph/cli/_store.py
@@ -1,7 +1,12 @@
-"""cli._store — Helper para abrir DuckDBStore y traducir StoreLockedError.
+"""cli._store — Helper para resolver el workspace y abrir DuckDBStore.
 
 Centraliza la apertura del store y el manejo del error de bloqueo,
 para que cada subcomando no tenga que repetir el try/except.
+
+ADR 0029 — resolución workspace:
+  ``resolve_library_path`` lee ``ctx.obj["workspace"]`` y ``ctx.obj["store"]``
+  y delega en ``Workspace.resolve(...)`` con las env actuales y el cwd.
+  El resultado es siempre una ``Path`` al archivo ``.duckdb``.
 
 R5 — footgun de auto-creación:
   ``open_store_readonly`` verifica que el archivo exista antes de abrirlo.
@@ -16,7 +21,67 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-from bib2graph.cli._errors import StoreError
+from bib2graph.cli._errors import StoreError, UsageError
+
+
+def resolve_library_path(ctx_obj: dict[str, Any]) -> Path:
+    """Resuelve la ruta al archivo .duckdb desde el contexto Click (ADR 0029).
+
+    Lee ``workspace`` y ``store`` del dict de contexto Click y delega en
+    ``Workspace.resolve(...)`` para aplicar la precedencia (ADR 0029):
+      1. ``--workspace`` explícito (forma canónica),
+      2. ``--store`` explícito (modo degenerado, retrocompat; mutuamente excluyente con ``--workspace``),
+      3. variable de entorno ``B2G_WORKSPACE``,
+      4. caminar hacia arriba desde cwd buscando ``workspace.json``.
+
+    Args:
+        ctx_obj: El dict ``ctx.obj`` del grupo Click (contiene ``workspace``
+            y ``store`` con los valores de las opciones globales).
+
+    Returns:
+        Ruta al archivo ``.duckdb`` de la biblioteca viva.
+
+    Raises:
+        UsageError: Si no se puede resolver ningún workspace (exit 1).
+    """
+    from bib2graph.workspace import Workspace, WorkspaceNotFoundError
+
+    workspace: str | None = ctx_obj.get("workspace")
+    store: str | None = ctx_obj.get("store")
+
+    try:
+        ws = Workspace.resolve(workspace=workspace, store=store)
+    except WorkspaceNotFoundError as exc:
+        raise UsageError(str(exc)) from exc
+
+    return ws.library_path
+
+
+def resolve_workspace(ctx_obj: dict[str, Any]) -> Any:
+    """Resuelve el Workspace completo desde el contexto Click (ADR 0029).
+
+    Variante de ``resolve_library_path`` que devuelve el ``Workspace`` completo
+    (útil cuando el comando necesita más que solo la ruta al store, p.ej.
+    ``networks_dir`` para ``build`` o el manifest para ``status``).
+
+    Args:
+        ctx_obj: El dict ``ctx.obj`` del grupo Click.
+
+    Returns:
+        El ``Workspace`` resuelto.
+
+    Raises:
+        UsageError: Si no se puede resolver ningún workspace (exit 1).
+    """
+    from bib2graph.workspace import Workspace, WorkspaceNotFoundError
+
+    workspace: str | None = ctx_obj.get("workspace")
+    store: str | None = ctx_obj.get("store")
+
+    try:
+        return Workspace.resolve(workspace=workspace, store=store)
+    except WorkspaceNotFoundError as exc:
+        raise UsageError(str(exc)) from exc
 
 
 def open_store(path: str | Path) -> Any:

--- a/src/bib2graph/cli/commands/accept.py
+++ b/src/bib2graph/cli/commands/accept.py
@@ -19,7 +19,7 @@ import click
 
 from bib2graph.cli._envelope import build_envelope, emit, emit_human
 from bib2graph.cli._errors import DataError, handle_errors
-from bib2graph.cli._store import open_store
+from bib2graph.cli._store import open_store, resolve_library_path
 
 # ---------------------------------------------------------------------------
 # Función núcleo (testeable, sin Click)
@@ -113,7 +113,7 @@ def accept_cmd(
     Curación TRANSVERSAL: no transiciona el CycleState.  Disponible en
     cualquier estado del lazo (Nota 05 §4, ADR 0016 enmendado R3).
     """
-    store_path = ctx.obj["store"]
+    store_path = resolve_library_path(ctx.obj)
     data = run_accept(store_path, list(ids), by=by)
 
     if json_output:

--- a/src/bib2graph/cli/commands/build.py
+++ b/src/bib2graph/cli/commands/build.py
@@ -3,7 +3,15 @@
 Computa las redes bibliométricas con Networks.quick y escribe artefactos
 a disco. Transiciona el CycleState a BUILT tras persistir con éxito.
 
-Los artefactos se escriben en ``<store_dir>/networks/<kind>/``:
+ADR 0029 — workspace:
+  El directorio de artefactos es ``<workspace>/networks/`` por defecto.
+  Si se pasa ``--out-dir`` explícito, se usa ese.
+
+ADR 0029 — sellado por corpus_hash:
+  Escribe ``networks/.corpus_hash`` con el hash del corpus que produjo
+  las redes. Permite detectar staleness sin un build system completo.
+
+Los artefactos se escriben en ``<networks_dir>/<kind>/``:
   - ``network.graphml``: el grafo en formato GraphML.
   - ``metrics.json``: métricas de red calculadas.
 """
@@ -18,7 +26,7 @@ import click
 
 from bib2graph.cli._envelope import build_envelope, emit, emit_human
 from bib2graph.cli._errors import DependencyError, handle_errors
-from bib2graph.cli._store import open_store
+from bib2graph.cli._store import open_store, resolve_workspace
 
 # ---------------------------------------------------------------------------
 # Función núcleo (testeable, sin Click)
@@ -34,6 +42,7 @@ def run_build(
 
     Usa ``Networks.quick`` para las 4 redes principales (coupling, co-autoría,
     institución, co-word). Escribe GraphML + metrics.json por red.
+    Sella ``networks/.corpus_hash`` con el hash del corpus que las produjo.
     Transiciona a BUILT tras escribir con éxito.
 
     Args:
@@ -41,7 +50,8 @@ def run_build(
         out_dir: Directorio base de salida. Default: ``<store_dir>/networks/``.
 
     Returns:
-        Dict con ``networks_built``, ``artifacts_dir`` y lista de redes.
+        Dict con ``networks_built``, ``artifacts_dir``, ``corpus_hash``
+        y lista de redes.
 
     Raises:
         DependencyError: Si falta ``python-louvain``.
@@ -120,11 +130,22 @@ def run_build(
             }
         )
 
+    # ADR 0029 — sellar con corpus_hash para detección de staleness.
+    # El hash ya lo tiene el corpus vía Manifest/CorpusSnapshot; lo derivamos
+    # del corpus cargado usando la misma función que usa Manifest.
+    from bib2graph.backends.memory import compute_corpus_hash
+
+    corpus_hash = compute_corpus_hash(corpus.to_arrow())
+    hash_file = artifacts_dir / ".corpus_hash"
+    artifacts_dir.mkdir(parents=True, exist_ok=True)
+    hash_file.write_text(corpus_hash, encoding="utf-8")
+
     store.backend.set_loop_state(new_state, cycle_round=new_round)
 
     return {
         "networks_built": len(artifacts),
         "artifacts_dir": str(artifacts_dir),
+        "corpus_hash": corpus_hash,
         "networks": networks_info,
     }
 
@@ -138,7 +159,10 @@ def run_build(
 @click.option(
     "--out-dir",
     default=None,
-    help="Directorio base de artefactos (default: <store_dir>/networks/).",
+    help=(
+        "Directorio base de artefactos "
+        "(default: <workspace>/networks/ o <store_dir>/networks/)."
+    ),
 )
 @click.option(
     "--json",
@@ -157,9 +181,15 @@ def build_cmd(
     """Computa las 4 redes con Networks.quick y escribe artefactos.
 
     Tras el build, el estado del lazo transiciona a BUILT.
+    El directorio networks/ queda sellado con .corpus_hash.
     """
-    store_path = ctx.obj["store"]
-    data = run_build(store_path, out_dir=out_dir)
+    # ADR 0029: usar networks_dir del workspace si no se especifica --out-dir
+    ws = resolve_workspace(ctx.obj)
+    effective_out_dir: str | Path | None = out_dir
+    if effective_out_dir is None:
+        effective_out_dir = ws.networks_dir
+
+    data = run_build(ws.library_path, out_dir=effective_out_dir)
 
     if json_output:
         envelope = build_envelope(
@@ -172,5 +202,6 @@ def build_cmd(
     else:
         emit_human(f"Redes construidas: {data['networks_built']}")
         emit_human(f"Artefactos en: {data['artifacts_dir']}")
+        emit_human(f"corpus_hash: {data['corpus_hash']}")
         for net in data["networks"]:
             emit_human(f"  {net['kind']}: {net['nodes']} nodos, {net['edges']} aristas")

--- a/src/bib2graph/cli/commands/chain.py
+++ b/src/bib2graph/cli/commands/chain.py
@@ -13,7 +13,7 @@ import click
 
 from bib2graph.cli._envelope import build_envelope, emit, emit_human
 from bib2graph.cli._errors import DependencyError, handle_errors
-from bib2graph.cli._store import open_store
+from bib2graph.cli._store import open_store, resolve_library_path
 
 # ---------------------------------------------------------------------------
 # Función núcleo (testeable, sin Click)
@@ -157,7 +157,7 @@ def chain_cmd(
 
     Tras el chain, el estado del lazo transiciona a FORAGED.
     """
-    store_path = ctx.obj["store"]
+    store_path = resolve_library_path(ctx.obj)
     data = run_chain(
         store_path,
         direction=direction,  # type: ignore[arg-type]

--- a/src/bib2graph/cli/commands/enrich.py
+++ b/src/bib2graph/cli/commands/enrich.py
@@ -20,7 +20,7 @@ import click
 
 from bib2graph.cli._envelope import build_envelope, emit, emit_human
 from bib2graph.cli._errors import handle_errors
-from bib2graph.cli._store import open_store
+from bib2graph.cli._store import open_store, resolve_library_path
 
 # ---------------------------------------------------------------------------
 # Función núcleo (testeable, sin Click)
@@ -149,7 +149,7 @@ def enrich_cmd(
 
     Si no hay referencias ni semillas aceptadas, termina sin error.
     """
-    store_path = ctx.obj["store"]
+    store_path = resolve_library_path(ctx.obj)
     data = run_enrich(
         store_path,
         email=email,

--- a/src/bib2graph/cli/commands/export.py
+++ b/src/bib2graph/cli/commands/export.py
@@ -14,6 +14,7 @@ import click
 
 from bib2graph.cli._envelope import build_envelope, emit, emit_human
 from bib2graph.cli._errors import DataError, handle_errors
+from bib2graph.cli._store import resolve_library_path
 
 # ---------------------------------------------------------------------------
 # Función núcleo (testeable, sin Click)
@@ -154,7 +155,7 @@ def export_cmd(
 
     No transiciona el CycleState.
     """
-    store_path = ctx.obj["store"]
+    store_path = resolve_library_path(ctx.obj)
     data = run_export(
         store_path,
         format=fmt,  # type: ignore[arg-type]

--- a/src/bib2graph/cli/commands/filter.py
+++ b/src/bib2graph/cli/commands/filter.py
@@ -14,7 +14,7 @@ import click
 
 from bib2graph.cli._envelope import build_envelope, emit, emit_human
 from bib2graph.cli._errors import DataError, handle_errors
-from bib2graph.cli._store import open_store
+from bib2graph.cli._store import open_store, resolve_library_path
 
 # ---------------------------------------------------------------------------
 # Función núcleo (testeable, sin Click)
@@ -156,7 +156,7 @@ def filter_cmd(
 
     Tras el filtro, el estado del lazo transiciona a FILTERED.
     """
-    store_path = ctx.obj["store"]
+    store_path = resolve_library_path(ctx.obj)
     data = run_filter(
         store_path,
         year_gte=year_gte,

--- a/src/bib2graph/cli/commands/init.py
+++ b/src/bib2graph/cli/commands/init.py
@@ -1,0 +1,127 @@
+"""cli.commands.init — Subcomando ``b2g init``.
+
+Scaffolds un workspace nuevo (carpeta autocontenida) para una investigación.
+
+Uso:
+    b2g init <nombre>    # crea ./<nombre>/ como workspace
+    b2g init .           # inicializa el cwd como workspace
+
+El workspace creado contiene:
+    workspace.json    — manifest mínimo (marcador)
+    library.duckdb    — biblioteca viva inicializada
+    networks/         — cache de redes (build), regenerable
+    snapshots/        — snapshots sellados
+    exports/          — exports regenerables
+
+ADR 0029 §Decisión.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import click
+
+from bib2graph.cli._envelope import build_envelope, emit, emit_human
+from bib2graph.cli._errors import UsageError, handle_errors
+
+# ---------------------------------------------------------------------------
+# Función núcleo (testeable, sin Click)
+# ---------------------------------------------------------------------------
+
+
+def run_init(path: Path, name: str) -> dict[str, Any]:
+    """Crea un workspace nuevo en ``path`` con el nombre ``name``.
+
+    Si ``path`` ya contiene un ``workspace.json``, falla con error accionable.
+    Si ``path`` no existe, la crea.
+
+    Args:
+        path: Directorio destino del workspace.
+        name: Nombre legible de la investigación (va al manifest).
+
+    Returns:
+        Dict con ``workspace_dir``, ``library_path``, ``manifest``.
+
+    Raises:
+        UsageError: Si ya existe un workspace en ``path``.
+    """
+    from bib2graph.workspace import Workspace, WorkspaceExistsError
+
+    try:
+        ws = Workspace.init(path, name)
+    except WorkspaceExistsError as exc:
+        raise UsageError(str(exc)) from exc
+
+    return {
+        "workspace_dir": str(ws.root),
+        "library_path": str(ws.library_path),
+        "manifest": ws.manifest.model_dump() if ws.manifest else {},
+    }
+
+
+# ---------------------------------------------------------------------------
+# Comando Click
+# ---------------------------------------------------------------------------
+
+
+@click.command("init")
+@click.argument("target", default=".")
+@click.option(
+    "--name",
+    default=None,
+    help=(
+        "Nombre legible de la investigación (default: nombre del directorio destino)."
+    ),
+)
+@click.option(
+    "--json",
+    "json_output",
+    is_flag=True,
+    default=False,
+    help="Salida JSON estructurada.",
+)
+@handle_errors("init")
+def init_cmd(
+    target: str,
+    name: str | None,
+    json_output: bool,
+) -> None:
+    """Inicializa una carpeta como workspace de investigación.
+
+    TARGET puede ser un nombre de carpeta nueva (se crea en el cwd) o un
+    directorio existente (incluido '.' para el directorio actual).
+
+    Ejemplos:
+
+      b2g init mi-estudio        # crea ./mi-estudio/ como workspace
+
+      b2g init .                 # inicializa el cwd como workspace
+
+      b2g init mi-estudio --name "Estudio de redes IED"
+    """
+    target_path = Path(target)
+
+    # Si el target es un nombre simple (no una ruta que ya existe ni "."),
+    # se crea como subdirectorio del cwd.
+    if not target_path.is_absolute() and not target_path.exists() and target != ".":
+        target_path = Path.cwd() / target_path
+
+    # Nombre de la investigación: --name explícito o nombre del directorio
+    resolved_name = name if name else target_path.resolve().name
+
+    data = run_init(target_path, resolved_name)
+
+    if json_output:
+        envelope = build_envelope(
+            command="init",
+            ok=True,
+            data=data,
+            exit_code=0,
+        )
+        emit(envelope)
+    else:
+        emit_human(f"Workspace creado en: {data['workspace_dir']}")
+        emit_human(f"Biblioteca: {data['library_path']}")
+        emit_human(f"Nombre: {data['manifest'].get('name', resolved_name)}")

--- a/src/bib2graph/cli/commands/inspect.py
+++ b/src/bib2graph/cli/commands/inspect.py
@@ -14,7 +14,7 @@ import click
 
 from bib2graph.cli._envelope import build_envelope, emit, emit_human
 from bib2graph.cli._errors import DataError, handle_errors
-from bib2graph.cli._store import open_store
+from bib2graph.cli._store import open_store, resolve_library_path
 from bib2graph.constants import Col
 
 # ---------------------------------------------------------------------------
@@ -138,7 +138,7 @@ def inspect_cmd(
     Sin --id: muestra el manifest y conteos.
     Con --id: muestra datos + provenance de ese paper.
     """
-    store_path = ctx.obj["store"]
+    store_path = resolve_library_path(ctx.obj)
     data = run_inspect(store_path, paper_id=paper_id)
 
     if json_output:

--- a/src/bib2graph/cli/commands/monitor.py
+++ b/src/bib2graph/cli/commands/monitor.py
@@ -18,7 +18,7 @@ import click
 
 from bib2graph.cli._envelope import build_envelope, emit, emit_human
 from bib2graph.cli._errors import DataError, handle_errors
-from bib2graph.cli._store import open_store
+from bib2graph.cli._store import open_store, resolve_library_path
 
 # ---------------------------------------------------------------------------
 # Función núcleo (testeable, sin Click)
@@ -137,7 +137,7 @@ def monitor_cmd(
     Requiere un corpus previo (ejecutar 'b2g seed' primero).
     Requiere --email para el polite pool de OpenAlex.
     """
-    store_path = ctx.obj["store"]
+    store_path = resolve_library_path(ctx.obj)
     data = run_monitor(store_path, email=email)
 
     if json_output:

--- a/src/bib2graph/cli/commands/reject.py
+++ b/src/bib2graph/cli/commands/reject.py
@@ -19,7 +19,7 @@ import click
 
 from bib2graph.cli._envelope import build_envelope, emit, emit_human
 from bib2graph.cli._errors import DataError, handle_errors
-from bib2graph.cli._store import open_store
+from bib2graph.cli._store import open_store, resolve_library_path
 
 # ---------------------------------------------------------------------------
 # Función núcleo (testeable, sin Click)
@@ -113,7 +113,7 @@ def reject_cmd(
     Curación TRANSVERSAL: no transiciona el CycleState.  Disponible en
     cualquier estado del lazo (Nota 05 §4, ADR 0016 enmendado R3).
     """
-    store_path = ctx.obj["store"]
+    store_path = resolve_library_path(ctx.obj)
     data = run_reject(store_path, list(ids), by=by)
 
     if json_output:

--- a/src/bib2graph/cli/commands/seed.py
+++ b/src/bib2graph/cli/commands/seed.py
@@ -17,7 +17,7 @@ import click
 
 from bib2graph.cli._envelope import build_envelope, emit, emit_human
 from bib2graph.cli._errors import DataError, NetworkError, handle_errors
-from bib2graph.cli._store import open_store
+from bib2graph.cli._store import open_store, resolve_library_path
 
 # ---------------------------------------------------------------------------
 # Función núcleo (testeable, sin Click)
@@ -138,7 +138,7 @@ def seed_cmd(
 
     Tras el seed, el estado del lazo transiciona a SEEDED.
     """
-    store_path = ctx.obj["store"]
+    store_path = resolve_library_path(ctx.obj)
     data = run_seed(store_path, equation, native=native, email=email)
 
     if json_output:

--- a/src/bib2graph/cli/commands/snapshot.py
+++ b/src/bib2graph/cli/commands/snapshot.py
@@ -13,7 +13,7 @@ import click
 
 from bib2graph.cli._envelope import build_envelope, emit, emit_human
 from bib2graph.cli._errors import handle_errors
-from bib2graph.cli._store import open_store
+from bib2graph.cli._store import open_store, resolve_library_path
 
 # ---------------------------------------------------------------------------
 # Función núcleo (testeable, sin Click)
@@ -82,7 +82,7 @@ def snapshot_cmd(
 
     No transiciona el CycleState.
     """
-    store_path = ctx.obj["store"]
+    store_path = resolve_library_path(ctx.obj)
     data = run_snapshot(store_path, out_dir=out_dir)
 
     if json_output:

--- a/src/bib2graph/cli/commands/status.py
+++ b/src/bib2graph/cli/commands/status.py
@@ -11,9 +11,9 @@ R3: el mapa honesto del lazo (ADR 0016 enmendado).  Muestra:
 - contador de ronda,
 - conteos por curation_status.
 
-El envelope ``--json`` incluye ``curation_available`` y ``round`` como campos
-ADITIVOS que mantienen ``schema="1"`` (decisión del PO 2026-06-16: campos
-nuevos no rompen a los agentes, no se bumpea).
+ADR 0029 (aditivo): el envelope incluye ``workspace`` con el workspace
+resuelto (root, source) para que el agente sepa de dónde salió la biblioteca.
+Mantiene ``schema="1"`` (campos nuevos son aditivos, no rompen agentes).
 """
 
 from __future__ import annotations
@@ -25,7 +25,7 @@ import click
 
 from bib2graph.cli._envelope import build_envelope, emit, emit_human
 from bib2graph.cli._errors import handle_errors
-from bib2graph.cli._store import open_store_readonly
+from bib2graph.cli._store import open_store_readonly, resolve_workspace
 from bib2graph.cycle import CURATION_ACTIONS, available_transitions
 
 # ---------------------------------------------------------------------------
@@ -123,9 +123,19 @@ def status_cmd(
     - Estado actual y transiciones disponibles (incluyendo reseed).
     - accept/reject como acciones siempre-disponibles (curación transversal).
     - Contador de ronda.
+    - ADR 0029: workspace resuelto (root y fuente de resolución).
     """
-    store_path = ctx.obj["store"]
+    # ADR 0029: resolver workspace para obtener library_path + info de origen
+    ws = resolve_workspace(ctx.obj)
+    store_path = ws.library_path
+
     data = run_status(store_path)
+
+    # Agregar info del workspace (campo aditivo, schema="1" se mantiene)
+    data["workspace"] = {
+        "root": str(ws.root) if ws.root is not None else None,
+        "source": ws.source,
+    }
 
     if json_output:
         envelope = build_envelope(
@@ -150,3 +160,5 @@ def status_cmd(
         emit_human(
             f"Curación (siempre disponible): {', '.join(data['curation_available'])}"
         )
+        ws_root = data["workspace"]["root"] or "(modo degenerado)"
+        emit_human(f"Workspace: {ws_root} (resuelto vía {data['workspace']['source']})")

--- a/src/bib2graph/cli/commands/validate.py
+++ b/src/bib2graph/cli/commands/validate.py
@@ -14,7 +14,7 @@ import click
 
 from bib2graph.cli._envelope import build_envelope, emit, emit_human
 from bib2graph.cli._errors import DataError, StoreError, handle_errors
-from bib2graph.cli._store import open_store_readonly
+from bib2graph.cli._store import open_store_readonly, resolve_library_path
 from bib2graph.constants import Col, CurationStatus
 
 # ---------------------------------------------------------------------------
@@ -128,7 +128,7 @@ def validate_cmd(
 
     Exit 0: válido. Exit 2: datos inválidos. Exit 5: store corrupto.
     """
-    store_path = ctx.obj["store"]
+    store_path = resolve_library_path(ctx.obj)
     data = run_validate(store_path)
 
     if json_output:

--- a/src/bib2graph/workspace.py
+++ b/src/bib2graph/workspace.py
@@ -1,0 +1,421 @@
+"""workspace — Abstracción de «una investigación = una carpeta workspace».
+
+Capa seam-level: maneja filesystem, paths y manifest.  El núcleo puro
+(corpus, cycle, projectors, analyzer) **NO importa este módulo**.
+
+Estructura canónica de un workspace:
+
+    mi-investigacion/
+    ├── workspace.json    # marcador + manifest mínimo
+    ├── library.duckdb    # biblioteca viva
+    ├── networks/         # cache de redes (build), regenerable
+    ├── snapshots/        # snapshots sellados
+    └── exports/          # exports regenerables
+
+Resolución ambiente (patrón git/cargo), de mayor a menor precedencia:
+  1. ``--workspace``/``--store`` explícito en la invocación CLI.
+  2. Variable de entorno ``B2G_WORKSPACE``.
+  3. Caminar hacia arriba desde cwd buscando ``workspace.json``.
+  4. Sin ninguno → ``WorkspaceNotFoundError`` con sugerencia accionable.
+
+El workspace «degenerado» (``--store archivo.duckdb`` suelto) mantiene
+retrocompatibilidad: ``library_path`` apunta al archivo y los dirs caen
+en su dir hermano, como antes de ADR 0029.
+
+ADR 0029: https://github.com/complexluise/bib2graph/docs/decisiones/0029-workspace-por-investigacion.md
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+# ---------------------------------------------------------------------------
+# Manifest mínimo (marcador del workspace)
+# ---------------------------------------------------------------------------
+
+WORKSPACE_MANIFEST_FILE = "workspace.json"
+WORKSPACE_SCHEMA_VERSION = "1"
+LIBRARY_FILENAME = "library.duckdb"
+
+
+def _lib_version() -> str:
+    """Devuelve la versión instalada de bib2graph (fallback 'unknown')."""
+    try:
+        import importlib.metadata as _meta
+
+        return _meta.version("bib2graph")
+    except Exception:
+        return "unknown"
+
+
+class WorkspaceManifest(BaseModel):
+    """Manifest mínimo del workspace (marcador + metadatos de versión).
+
+    Campos:
+        name: Nombre legible de la investigación.
+        created_at: Timestamp ISO-8601 UTC de creación (frontera, no entra a hashes).
+        bib2graph_version: Versión del paquete al momento de la creación.
+        schema_version: Versión del schema del manifest (``"1"`` por ahora).
+    """
+
+    name: str
+    created_at: str = Field(default_factory=lambda: datetime.now(UTC).isoformat())
+    bib2graph_version: str = Field(default_factory=_lib_version)
+    schema_version: str = WORKSPACE_SCHEMA_VERSION
+
+
+# ---------------------------------------------------------------------------
+# Excepción propia del seam workspace
+# ---------------------------------------------------------------------------
+
+
+class WorkspaceNotFoundError(Exception):
+    """No se pudo resolver ningún workspace desde el contexto actual.
+
+    Incluye un mensaje accionable que sugiere ``b2g init .`` o ``--workspace``.
+    """
+
+    def __init__(self, message: str | None = None) -> None:
+        if message is None:
+            message = (
+                "No se encontró un workspace activo.\n"
+                "  • Creá uno con: b2g init <nombre> (o b2g init . para el directorio actual)\n"
+                "  • O apuntá a uno con: --workspace <carpeta> o --store <archivo.duckdb>\n"
+                "  • O exportá la variable: export B2G_WORKSPACE=<carpeta>"
+            )
+        super().__init__(message)
+
+
+class WorkspaceExistsError(Exception):
+    """Ya existe un workspace.json en el directorio destino."""
+
+
+# ---------------------------------------------------------------------------
+# Workspace
+# ---------------------------------------------------------------------------
+
+_DIRS = ("networks", "snapshots", "exports")
+
+
+class Workspace:
+    """Abstracción de «una investigación = una carpeta workspace».
+
+    Maneja scaffolding, resolución ambiente y acceso a paths derivados.
+    No importa duckdb ni ningún módulo del núcleo.
+
+    Atributos principales:
+        root: Carpeta raíz del workspace (o ``None`` para el modo degenerado).
+        manifest: ``WorkspaceManifest`` leído/creado.
+        library_path: Ruta al archivo ``library.duckdb``.
+        networks_dir: Ruta al directorio ``networks/``.
+        snapshots_dir: Ruta al directorio ``snapshots/``.
+        exports_dir: Ruta al directorio ``exports/``.
+        source: De dónde salió la resolución (``"flag"``, ``"env"``, ``"cwd"``, ``"degenerate"``).
+    """
+
+    def __init__(
+        self,
+        *,
+        root: Path | None,
+        library_path: Path,
+        manifest: WorkspaceManifest | None,
+        source: str,
+    ) -> None:
+        self._root = root
+        self._library_path = library_path
+        self._manifest = manifest
+        self._source = source
+
+    # ------------------------------------------------------------------
+    # Propiedades públicas
+    # ------------------------------------------------------------------
+
+    @property
+    def root(self) -> Path | None:
+        """Carpeta raíz del workspace (``None`` en modo degenerado)."""
+        return self._root
+
+    @property
+    def library_path(self) -> Path:
+        """Ruta al archivo ``library.duckdb`` (o al ``.duckdb`` suelto en modo degenerado)."""
+        return self._library_path
+
+    @property
+    def networks_dir(self) -> Path:
+        """Directorio ``networks/`` del workspace."""
+        if self._root is not None:
+            return self._root / "networks"
+        return self._library_path.parent / "networks"
+
+    @property
+    def snapshots_dir(self) -> Path:
+        """Directorio ``snapshots/`` del workspace."""
+        if self._root is not None:
+            return self._root / "snapshots"
+        return self._library_path.parent / "snapshots"
+
+    @property
+    def exports_dir(self) -> Path:
+        """Directorio ``exports/`` del workspace."""
+        if self._root is not None:
+            return self._root / "exports"
+        return self._library_path.parent / "exports"
+
+    @property
+    def manifest(self) -> WorkspaceManifest | None:
+        """Manifest del workspace (``None`` en modo degenerado)."""
+        return self._manifest
+
+    @property
+    def source(self) -> str:
+        """De dónde salió la resolución del workspace.
+
+        Valores posibles: ``"flag"``, ``"env"``, ``"cwd"``, ``"degenerate"``.
+        """
+        return self._source
+
+    # ------------------------------------------------------------------
+    # Factory: init (scaffolding)
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def init(cls, path: Path, name: str) -> Workspace:
+        """Scaffolds una carpeta como workspace nuevo.
+
+        Crea el directorio ``path`` (si no existe), escribe ``workspace.json``,
+        crea los subdirectorios ``networks/``, ``snapshots/``, ``exports/`` y
+        toca ``library.duckdb`` mediante el store existente para inicializarlo.
+
+        Args:
+            path: Ruta de la carpeta a inicializar como workspace.
+            name: Nombre legible de la investigación.
+
+        Returns:
+            Workspace recién creado.
+
+        Raises:
+            WorkspaceExistsError: Si ya existe un ``workspace.json`` en ``path``.
+        """
+        root = path.resolve()
+        manifest_path = root / WORKSPACE_MANIFEST_FILE
+
+        if manifest_path.exists():
+            raise WorkspaceExistsError(
+                f"Ya existe un workspace en '{root}'. "
+                "Si querés reiniciarlo, borrá workspace.json manualmente."
+            )
+
+        root.mkdir(parents=True, exist_ok=True)
+        for d in _DIRS:
+            (root / d).mkdir(exist_ok=True)
+
+        manifest = WorkspaceManifest(name=name)
+        manifest_path.write_text(
+            json.dumps(manifest.model_dump(), ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+
+        # Inicializar library.duckdb vía DuckDBStore (carga perezosa de duckdb)
+        library_path = root / LIBRARY_FILENAME
+        _init_library(library_path)
+
+        return cls(
+            root=root,
+            library_path=library_path,
+            manifest=manifest,
+            source="init",
+        )
+
+    # ------------------------------------------------------------------
+    # Factory: open (desde carpeta ya existente)
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def open(cls, path: Path, *, source: str = "flag") -> Workspace:
+        """Abre un workspace existente desde su carpeta raíz.
+
+        Args:
+            path: Carpeta raíz del workspace (debe contener ``workspace.json``).
+            source: Etiqueta de origen para diagnóstico.
+
+        Returns:
+            Workspace resuelto.
+
+        Raises:
+            WorkspaceNotFoundError: Si no existe ``workspace.json`` en ``path``.
+        """
+        root = path.resolve()
+        manifest_path = root / WORKSPACE_MANIFEST_FILE
+        if not manifest_path.exists():
+            raise WorkspaceNotFoundError(
+                f"No se encontró workspace.json en '{root}'. "
+                "¿Es esta la carpeta correcta? Podés crear el workspace con "
+                f"'b2g init {root.name}' o apuntar a otro con '--workspace <carpeta>'."
+            )
+        manifest = _read_manifest(manifest_path)
+        library_path = root / LIBRARY_FILENAME
+        return cls(
+            root=root,
+            library_path=library_path,
+            manifest=manifest,
+            source=source,
+        )
+
+    # ------------------------------------------------------------------
+    # Factory: resolve (resolución ambiente completa)
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def resolve(
+        cls,
+        *,
+        workspace: str | None = None,
+        store: str | None = None,
+        cwd: Path | None = None,
+        env: dict[str, str] | None = None,
+    ) -> Workspace:
+        """Resuelve el workspace activo aplicando la precedencia del ADR 0029.
+
+        Precedencia (de mayor a menor):
+          1. ``workspace`` (--workspace explícito) → ``Workspace.open()``.
+          2. ``store`` (--store explícito, modo degenerado) → library_path = ese archivo.
+          3. ``B2G_WORKSPACE`` en ``env`` → ``Workspace.open()``.
+          4. Caminar hacia arriba desde ``cwd`` buscando ``workspace.json``.
+          5. Ninguno → ``WorkspaceNotFoundError``.
+
+        Args:
+            workspace: Ruta a la carpeta del workspace (--workspace).
+            store: Ruta a un archivo .duckdb suelto (--store, retrocompat).
+            cwd: Directorio actual (default: ``Path.cwd()``).
+            env: Variables de entorno (default: ``os.environ``).
+
+        Returns:
+            El ``Workspace`` resuelto.
+
+        Raises:
+            WorkspaceNotFoundError: Si no se puede resolver ningún workspace,
+                o si se pasan ``--workspace`` y ``--store`` simultáneamente
+                (son mutuamente excluyentes).
+        """
+        if env is None:
+            env = dict(os.environ)
+        if cwd is None:
+            cwd = Path.cwd()
+
+        # Colisión de flags: --workspace y --store son mutuamente excluyentes.
+        # --workspace es la forma canónica; --store es el modo degenerado
+        # de retrocompat. Pasar ambos es ambiguo y se rechaza explícitamente
+        # (ADR 0029 §Sub-decisiones).
+        if workspace is not None and store is not None:
+            raise WorkspaceNotFoundError(
+                "--workspace y --store son mutuamente excluyentes.\n"
+                "  • Usá --workspace <carpeta> para un workspace completo.\n"
+                "  • Usá --store <archivo.duckdb> solo para un .duckdb suelto (modo legado)."
+            )
+
+        # 1. --workspace explícito
+        if workspace is not None:
+            return cls.open(Path(workspace), source="flag")
+
+        # 2. --store explícito (modo degenerado — retrocompatibilidad ADR 0029)
+        if store is not None:
+            library_path = Path(store).resolve()
+            return cls(
+                root=None,
+                library_path=library_path,
+                manifest=None,
+                source="degenerate",
+            )
+
+        # 3. Variable de entorno B2G_WORKSPACE
+        env_ws = env.get("B2G_WORKSPACE")
+        if env_ws:
+            return cls.open(Path(env_ws), source="env")
+
+        # 4. Caminar hacia arriba desde cwd
+        found = _walk_up(cwd)
+        if found is not None:
+            return cls.open(found, source="cwd")
+
+        # 5. Sin workspace → error accionable
+        raise WorkspaceNotFoundError()
+
+    # ------------------------------------------------------------------
+    # Representación
+    # ------------------------------------------------------------------
+
+    def __repr__(self) -> str:
+        return (
+            f"Workspace(root={self._root!r}, "
+            f"library={self._library_path!r}, source={self._source!r})"
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serializa el workspace a dict para el envelope JSON del CLI."""
+        return {
+            "root": str(self._root) if self._root is not None else None,
+            "library_path": str(self._library_path),
+            "networks_dir": str(self.networks_dir),
+            "snapshots_dir": str(self.snapshots_dir),
+            "exports_dir": str(self.exports_dir),
+            "source": self._source,
+            "manifest": self._manifest.model_dump() if self._manifest else None,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Helpers internos
+# ---------------------------------------------------------------------------
+
+
+def _walk_up(start: Path) -> Path | None:
+    """Camina hacia arriba desde ``start`` buscando un directorio con workspace.json.
+
+    Args:
+        start: Directorio desde donde comenzar la búsqueda.
+
+    Returns:
+        El primer directorio que contiene ``workspace.json``, o ``None``.
+    """
+    current = start.resolve()
+    while True:
+        if (current / WORKSPACE_MANIFEST_FILE).exists():
+            return current
+        parent = current.parent
+        if parent == current:
+            # Llegamos a la raíz del filesystem sin encontrar nada
+            return None
+        current = parent
+
+
+def _read_manifest(path: Path) -> WorkspaceManifest:
+    """Lee y valida el manifest desde un archivo workspace.json.
+
+    Args:
+        path: Ruta al archivo ``workspace.json``.
+
+    Returns:
+        WorkspaceManifest validado con Pydantic.
+    """
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    return WorkspaceManifest.model_validate(raw)
+
+
+def _init_library(library_path: Path) -> None:
+    """Inicializa la biblioteca viva en ``library_path`` vía DuckDBStore.
+
+    Importación perezosa de duckdb: solo se importa cuando se llama esta función.
+    El núcleo (workspace.py en sí) no importa duckdb al nivel de módulo.
+
+    Args:
+        library_path: Ruta donde crear el archivo ``library.duckdb``.
+    """
+    from bib2graph.stores.duckdb import DuckDBStore
+
+    DuckDBStore(library_path)

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -334,13 +334,18 @@ def test_run_reject_marca_rechazado(tmp_path: Path) -> None:
 
 
 @pytest.mark.unit
-def test_exit_code_1_sin_store() -> None:
-    """Sin --store (opción requerida) el CLI retorna exit code 1 (uso)."""
-    from bib2graph.cli import main
+def test_exit_code_1_sin_workspace(tmp_path: Path) -> None:
+    """Sin workspace disponible, resolve_library_path lanza UsageError (exit 1).
 
-    # main() sin argumentos → Click UsageError → exit 1
-    result = main()
-    assert result == 1
+    ADR 0029: --store y --workspace son ahora opcionales; la resolución ambiente
+    falla con UsageError (exit 1) cuando no hay workspace.json hacia arriba ni
+    B2G_WORKSPACE ni ningún flag.  resolve_library_path convierte la excepción.
+    """
+    from bib2graph.workspace import Workspace, WorkspaceNotFoundError
+
+    # Directorio sin workspace.json; sin env; cwd apunta al tmp vacío
+    with pytest.raises(WorkspaceNotFoundError, match="b2g init"):
+        Workspace.resolve(cwd=tmp_path, env={})
 
 
 @pytest.mark.unit

--- a/tests/unit/test_workspace.py
+++ b/tests/unit/test_workspace.py
@@ -1,0 +1,576 @@
+"""Tests TDD del Hito 9 workspace — ADR 0029.
+
+Casos cubiertos:
+1. ``b2g init <name>`` crea la estructura + workspace.json válido.
+2. ``b2g init .`` inicializa el cwd.
+3. Error si ya hay workspace.json.
+4. Resolución ambiente: (a) caminar hacia arriba encuentra workspace.json;
+   (b) B2G_WORKSPACE gana sobre cwd; (c) --workspace/--store gana sobre todo;
+   (d) sin nada → error accionable.
+5. --store suelto (modo degenerado) sigue funcionando (retrocompat).
+6. ``b2g status`` reporta el workspace resuelto.
+7. ``b2g build`` escribe en ``<workspace>/networks/`` y sella corpus_hash.
+
+Filosofía (AGENTS.md): se testean funciones núcleo, no el parser Click.
+Marcador: ``unit`` (DuckDB en tmp_path, sin red real).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pyarrow as pa
+import pytest
+
+from bib2graph.schemas import CORPUS_SCHEMA
+
+# ---------------------------------------------------------------------------
+# Helpers compartidos
+# ---------------------------------------------------------------------------
+
+
+def _make_corpus_row(
+    *, id: str, title: str = "Test", curation_status: str = "candidate"
+) -> dict[str, Any]:
+    """Fila mínima con schema completo."""
+    return {
+        "id": id,
+        "openalex_id": None,
+        "doi": None,
+        "title": title,
+        "year": 2020,
+        "abstract": None,
+        "source": None,
+        "language": "en",
+        "publisher": None,
+        "research_areas": None,
+        "is_seed": True,
+        "curation_status": curation_status,
+        "provenance": None,
+        "authors_raw": None,
+        "authors_id": None,
+        "authors_affiliations": None,
+        "keywords_raw": None,
+        "keywords_id": None,
+        "institutions_raw": None,
+        "institutions_id": None,
+        "references_id": None,
+        "references_doi": None,
+        "cited_by_id": None,
+    }
+
+
+def _seed_store(store_path: Path, rows: list[dict[str, Any]] | None = None) -> None:
+    """Puebla un store con filas mínimas."""
+    from bib2graph.corpus import Corpus
+    from bib2graph.stores.duckdb import DuckDBStore
+
+    if rows is None:
+        rows = [_make_corpus_row(id="P1"), _make_corpus_row(id="P2")]
+    table = pa.Table.from_pylist(rows, schema=CORPUS_SCHEMA)
+    corpus = Corpus.from_arrow(table)
+    store = DuckDBStore(store_path)
+    store.persist(corpus)
+
+
+# ---------------------------------------------------------------------------
+# 1. Workspace.init — scaffolding
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_workspace_init_crea_estructura(tmp_path: Path) -> None:
+    """Workspace.init crea carpeta, workspace.json, library.duckdb y subdirs."""
+    from bib2graph.workspace import LIBRARY_FILENAME, WORKSPACE_MANIFEST_FILE, Workspace
+
+    ws_dir = tmp_path / "mi-investigacion"
+    Workspace.init(ws_dir, "Mi investigación")
+
+    assert ws_dir.exists()
+    assert (ws_dir / WORKSPACE_MANIFEST_FILE).exists()
+    assert (ws_dir / LIBRARY_FILENAME).exists()
+    assert (ws_dir / "networks").exists()
+    assert (ws_dir / "snapshots").exists()
+    assert (ws_dir / "exports").exists()
+
+    # workspace.json es un JSON válido con los campos del manifest
+    raw = json.loads((ws_dir / WORKSPACE_MANIFEST_FILE).read_text(encoding="utf-8"))
+    assert raw["name"] == "Mi investigación"
+    assert "created_at" in raw
+    assert "bib2graph_version" in raw
+    assert raw["schema_version"] == "1"
+
+
+@pytest.mark.unit
+def test_workspace_init_retorna_workspace_con_paths_correctos(
+    tmp_path: Path,
+) -> None:
+    """Workspace.init retorna Workspace con library_path y dirs correctos."""
+    from bib2graph.workspace import Workspace
+
+    ws_dir = tmp_path / "estudio"
+    ws = Workspace.init(ws_dir, "Estudio")
+
+    assert ws.library_path == ws_dir / "library.duckdb"
+    assert ws.networks_dir == ws_dir / "networks"
+    assert ws.snapshots_dir == ws_dir / "snapshots"
+    assert ws.exports_dir == ws_dir / "exports"
+    assert ws.root == ws_dir
+
+
+@pytest.mark.unit
+def test_workspace_init_dot_inicializa_cwd(tmp_path: Path) -> None:
+    """Workspace.init en el directorio actual (.) lo inicializa como workspace."""
+    from bib2graph.cli.commands.init import run_init
+
+    data = run_init(tmp_path, tmp_path.name)
+
+    assert Path(data["workspace_dir"]).resolve() == tmp_path.resolve()
+    assert (tmp_path / "workspace.json").exists()
+    assert (tmp_path / "library.duckdb").exists()
+
+
+@pytest.mark.unit
+def test_workspace_init_falla_si_ya_existe(tmp_path: Path) -> None:
+    """Workspace.init falla con WorkspaceExistsError si ya hay workspace.json."""
+    from bib2graph.workspace import Workspace, WorkspaceExistsError
+
+    ws_dir = tmp_path / "existente"
+    Workspace.init(ws_dir, "Primera vez")
+
+    with pytest.raises(WorkspaceExistsError, match="Ya existe"):
+        Workspace.init(ws_dir, "Segunda vez")
+
+
+@pytest.mark.unit
+def test_run_init_error_accionable_si_ya_existe(tmp_path: Path) -> None:
+    """run_init lanza UsageError (exit 1) si el workspace ya existe."""
+    from bib2graph.cli._errors import UsageError
+    from bib2graph.cli.commands.init import run_init
+
+    ws_dir = tmp_path / "existente"
+    run_init(ws_dir, "Primera")
+
+    with pytest.raises(UsageError):
+        run_init(ws_dir, "Segunda")
+
+
+# ---------------------------------------------------------------------------
+# 2. WorkspaceManifest — validación Pydantic
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_workspace_manifest_tiene_schema_version_1() -> None:
+    """WorkspaceManifest tiene schema_version='1' por defecto."""
+    from bib2graph.workspace import WorkspaceManifest
+
+    m = WorkspaceManifest(name="test")
+    assert m.schema_version == "1"
+    assert m.name == "test"
+    assert m.created_at  # no vacío
+    assert m.bib2graph_version  # no vacío
+
+
+# ---------------------------------------------------------------------------
+# 3. Resolución ambiente — Workspace.resolve
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_resolve_workspace_flag_explícito(tmp_path: Path) -> None:
+    """--workspace explícito gana sobre cualquier otra fuente."""
+    from bib2graph.workspace import Workspace
+
+    ws_dir = tmp_path / "mi-ws"
+    Workspace.init(ws_dir, "test")
+
+    ws = Workspace.resolve(workspace=str(ws_dir))
+    assert ws.root == ws_dir.resolve()
+    assert ws.source == "flag"
+
+
+@pytest.mark.unit
+def test_resolve_store_flag_explícito_modo_degenerado(tmp_path: Path) -> None:
+    """--store explícito crea un workspace degenerado (sin root, sin manifest)."""
+    from bib2graph.workspace import Workspace
+
+    store_file = tmp_path / "mi.duckdb"
+    store_file.touch()
+
+    ws = Workspace.resolve(store=str(store_file))
+    assert ws.root is None
+    assert ws.library_path == store_file.resolve()
+    assert ws.manifest is None
+    assert ws.source == "degenerate"
+
+
+@pytest.mark.unit
+def test_resolve_workspace_flag_gana_sobre_env(tmp_path: Path) -> None:
+    """--workspace tiene precedencia sobre B2G_WORKSPACE."""
+    from bib2graph.workspace import Workspace
+
+    ws_flag = tmp_path / "flag-ws"
+    ws_env = tmp_path / "env-ws"
+    Workspace.init(ws_flag, "flag")
+    Workspace.init(ws_env, "env")
+
+    ws = Workspace.resolve(
+        workspace=str(ws_flag),
+        env={"B2G_WORKSPACE": str(ws_env)},
+    )
+    assert ws.root == ws_flag.resolve()
+    assert ws.source == "flag"
+
+
+@pytest.mark.unit
+def test_resolve_env_gana_sobre_cwd(tmp_path: Path) -> None:
+    """B2G_WORKSPACE tiene precedencia sobre la búsqueda desde cwd."""
+    from bib2graph.workspace import Workspace
+
+    ws_env = tmp_path / "env-ws"
+    ws_cwd = tmp_path / "cwd-ws"
+    Workspace.init(ws_env, "env")
+    Workspace.init(ws_cwd, "cwd")
+
+    ws = Workspace.resolve(
+        env={"B2G_WORKSPACE": str(ws_env)},
+        cwd=ws_cwd,
+    )
+    assert ws.root == ws_env.resolve()
+    assert ws.source == "env"
+
+
+@pytest.mark.unit
+def test_resolve_caminar_hacia_arriba(tmp_path: Path) -> None:
+    """Sin flags ni env, se camina hacia arriba desde cwd buscando workspace.json."""
+    from bib2graph.workspace import Workspace
+
+    ws_root = tmp_path / "proyecto"
+    Workspace.init(ws_root, "proyecto")
+
+    # Empezar desde un subdirectorio del workspace
+    subdir = ws_root / "networks" / "sub"
+    subdir.mkdir(parents=True, exist_ok=True)
+
+    ws = Workspace.resolve(cwd=subdir, env={})
+    assert ws.root == ws_root.resolve()
+    assert ws.source == "cwd"
+
+
+@pytest.mark.unit
+def test_resolve_sin_workspace_lanza_error_accionable(tmp_path: Path) -> None:
+    """Sin ningún workspace disponible, WorkspaceNotFoundError con sugerencia."""
+    from bib2graph.workspace import Workspace, WorkspaceNotFoundError
+
+    # tmp_path vacío sin workspace.json
+    with pytest.raises(WorkspaceNotFoundError, match="b2g init"):
+        Workspace.resolve(cwd=tmp_path, env={})
+
+
+@pytest.mark.unit
+def test_resolve_sin_workspace_mapea_a_usage_error(tmp_path: Path) -> None:
+    """resolve_library_path convierte WorkspaceNotFoundError → UsageError (exit 1).
+
+    Verificamos que la capa CLI convierte correctamente la excepción del seam.
+    Usamos monkeypatching de Workspace.resolve para aislar el comportamiento.
+    """
+    from unittest.mock import patch
+
+    from bib2graph.cli._errors import UsageError
+    from bib2graph.cli._store import resolve_library_path
+    from bib2graph.workspace import WorkspaceNotFoundError
+
+    def _raise(*args: object, **kwargs: object) -> None:
+        raise WorkspaceNotFoundError("no hay workspace")
+
+    with patch("bib2graph.workspace.Workspace.resolve", side_effect=_raise):
+        with pytest.raises(UsageError) as exc_info:
+            resolve_library_path({"workspace": None, "store": None})
+        assert exc_info.value.exit_code == 1
+
+
+@pytest.mark.unit
+def test_resolve_workspace_y_store_juntos_es_error(tmp_path: Path) -> None:
+    """--workspace y --store simultáneos lanzan error accionable (son mutuamente excluyentes).
+
+    Fija el comportamiento ante la colisión de flags: en vez de descartar
+    silenciosamente uno de los dos, se rechaza explícitamente con un mensaje
+    claro que guía al usuario.
+    """
+    from bib2graph.workspace import Workspace, WorkspaceNotFoundError
+
+    ws_dir = tmp_path / "ws"
+    Workspace.init(ws_dir, "test")
+    store_file = tmp_path / "mi.duckdb"
+    store_file.touch()
+
+    with pytest.raises(WorkspaceNotFoundError, match="mutuamente excluyentes"):
+        Workspace.resolve(workspace=str(ws_dir), store=str(store_file))
+
+
+@pytest.mark.unit
+def test_resolve_workspace_y_store_juntos_mapea_a_usage_error(tmp_path: Path) -> None:
+    """Colisión --workspace/--store → WorkspaceNotFoundError → UsageError (exit 1)."""
+    from bib2graph.cli._errors import UsageError
+    from bib2graph.cli._store import resolve_library_path
+    from bib2graph.workspace import Workspace
+
+    ws_dir = tmp_path / "ws"
+    Workspace.init(ws_dir, "test")
+    store_file = tmp_path / "mi.duckdb"
+    store_file.touch()
+
+    with pytest.raises(UsageError, match="mutuamente excluyentes"):
+        resolve_library_path({"workspace": str(ws_dir), "store": str(store_file)})
+
+
+# ---------------------------------------------------------------------------
+# 4. Retrocompat: --store suelto (modo degenerado)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_retrocompat_store_suelto_con_run_status(tmp_path: Path) -> None:
+    """--store archivo.duckdb suelto sigue funcionando (workspace degenerado)."""
+    from bib2graph.cli.commands.status import run_status
+
+    store_path = tmp_path / "mi.duckdb"
+    _seed_store(store_path)
+
+    # run_status toma directamente store_path (nivel núcleo)
+    data = run_status(store_path)
+    assert "loop_state" in data
+    assert data["total_papers"] == 2
+
+
+@pytest.mark.unit
+def test_retrocompat_resolve_store_library_path(tmp_path: Path) -> None:
+    """resolve_library_path con {'store': 'ruta.duckdb'} devuelve esa ruta."""
+    from bib2graph.cli._store import resolve_library_path
+
+    store_path = tmp_path / "mi.duckdb"
+    store_path.touch()
+
+    result = resolve_library_path({"workspace": None, "store": str(store_path)})
+    assert result == store_path.resolve()
+
+
+# ---------------------------------------------------------------------------
+# 5. b2g status muestra workspace resuelto
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_status_incluye_workspace_info(tmp_path: Path) -> None:
+    """status_cmd agrega campo 'workspace' con root y source al envelope."""
+    from bib2graph.cli._store import resolve_workspace
+    from bib2graph.cli.commands.status import run_status
+    from bib2graph.workspace import Workspace
+
+    ws_dir = tmp_path / "proyecto"
+    Workspace.init(ws_dir, "proyecto")
+    store_path = ws_dir / "library.duckdb"
+    _seed_store(store_path)
+
+    # Verificar que status devuelve datos base correctos
+    data = run_status(store_path)
+    assert "loop_state" in data
+    assert data["total_papers"] == 2
+
+    # Verificar que el workspace resuelto tiene la info correcta
+    ws = resolve_workspace({"workspace": str(ws_dir), "store": None})
+    assert ws.root == ws_dir.resolve()
+    assert ws.source == "flag"
+
+
+@pytest.mark.unit
+def test_status_workspace_info_en_ctx_obj(tmp_path: Path) -> None:
+    """El campo workspace se agrega cuando se usa resolve_workspace desde el CMD."""
+    from bib2graph.workspace import Workspace
+
+    ws_dir = tmp_path / "proyecto"
+    Workspace.init(ws_dir, "proyecto")
+    store_path = ws_dir / "library.duckdb"
+    _seed_store(store_path)
+
+    # Simular lo que haría status_cmd: resolver workspace + run_status
+    from bib2graph.cli._store import resolve_workspace
+    from bib2graph.cli.commands.status import run_status
+
+    ws = resolve_workspace({"workspace": str(ws_dir), "store": None})
+    data = run_status(ws.library_path)
+    # Agregar info del workspace tal como lo haría el cmd
+    data["workspace"] = {
+        "root": str(ws.root),
+        "source": ws.source,
+    }
+
+    assert data["workspace"]["root"] == str(ws_dir.resolve())
+    assert data["workspace"]["source"] == "flag"
+
+
+# ---------------------------------------------------------------------------
+# 6. build escribe en <workspace>/networks/ y sella corpus_hash
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_build_escribe_en_workspace_networks_dir(tmp_path: Path) -> None:
+    """run_build con out_dir explícito escribe artefactos en ese directorio."""
+    from bib2graph.cli.commands.build import run_build
+
+    store_path = tmp_path / "test.duckdb"
+    _seed_store(store_path)
+    networks_dir = tmp_path / "networks"
+
+    data = run_build(store_path, out_dir=networks_dir)
+
+    assert Path(data["artifacts_dir"]) == networks_dir
+    assert networks_dir.exists()
+
+
+@pytest.mark.unit
+def test_build_sella_corpus_hash(tmp_path: Path) -> None:
+    """run_build escribe .corpus_hash en el directorio networks/."""
+    from bib2graph.cli.commands.build import run_build
+
+    store_path = tmp_path / "test.duckdb"
+    _seed_store(store_path)
+    networks_dir = tmp_path / "networks"
+
+    data = run_build(store_path, out_dir=networks_dir)
+
+    hash_file = networks_dir / ".corpus_hash"
+    assert hash_file.exists()
+
+    stored_hash = hash_file.read_text(encoding="utf-8").strip()
+    assert stored_hash == data["corpus_hash"]
+    assert len(stored_hash) > 0
+
+
+@pytest.mark.unit
+def test_build_corpus_hash_en_envelope(tmp_path: Path) -> None:
+    """run_build incluye corpus_hash en el resultado."""
+    from bib2graph.cli.commands.build import run_build
+
+    store_path = tmp_path / "test.duckdb"
+    _seed_store(store_path)
+
+    data = run_build(store_path)
+
+    assert "corpus_hash" in data
+    assert isinstance(data["corpus_hash"], str)
+    assert len(data["corpus_hash"]) > 0
+
+
+@pytest.mark.unit
+def test_build_corpus_hash_es_estable(tmp_path: Path) -> None:
+    """El corpus_hash del build es igual al que produce compute_corpus_hash."""
+    from bib2graph.backends.memory import compute_corpus_hash
+    from bib2graph.cli.commands.build import run_build
+    from bib2graph.stores.duckdb import DuckDBStore
+
+    store_path = tmp_path / "test.duckdb"
+    _seed_store(store_path)
+
+    data = run_build(store_path)
+
+    # Verificar contra el hash computado directamente
+    store = DuckDBStore(store_path)
+    corpus = store.load()
+    expected_hash = compute_corpus_hash(corpus.to_arrow())
+
+    assert data["corpus_hash"] == expected_hash
+
+
+@pytest.mark.unit
+def test_build_en_workspace_usa_networks_dir(tmp_path: Path) -> None:
+    """build_cmd usa ws.networks_dir cuando el workspace es completo."""
+    from bib2graph.workspace import Workspace
+
+    ws_dir = tmp_path / "proyecto"
+    ws = Workspace.init(ws_dir, "proyecto")
+
+    # Poblar la library
+    _seed_store(ws.library_path)
+
+    # run_build con out_dir = ws.networks_dir
+    from bib2graph.cli.commands.build import run_build
+
+    data = run_build(ws.library_path, out_dir=ws.networks_dir)
+
+    assert Path(data["artifacts_dir"]).resolve() == ws.networks_dir.resolve()
+    assert (ws.networks_dir / ".corpus_hash").exists()
+
+
+# ---------------------------------------------------------------------------
+# 7. Workspace.open — abrir workspace existente
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_workspace_open_lee_manifest(tmp_path: Path) -> None:
+    """Workspace.open lee el manifest desde workspace.json."""
+    from bib2graph.workspace import Workspace
+
+    ws_dir = tmp_path / "ws"
+    Workspace.init(ws_dir, "Mi estudio")
+
+    ws2 = Workspace.open(ws_dir)
+    assert ws2.manifest is not None
+    assert ws2.manifest.name == "Mi estudio"
+    assert ws2.root == ws_dir.resolve()
+
+
+@pytest.mark.unit
+def test_workspace_open_falla_sin_manifest(tmp_path: Path) -> None:
+    """Workspace.open lanza WorkspaceNotFoundError si no hay workspace.json."""
+    from bib2graph.workspace import Workspace, WorkspaceNotFoundError
+
+    carpeta_sin_ws = tmp_path / "sin-workspace"
+    carpeta_sin_ws.mkdir()
+
+    with pytest.raises(WorkspaceNotFoundError):
+        Workspace.open(carpeta_sin_ws)
+
+
+# ---------------------------------------------------------------------------
+# 8. Workspace.to_dict — serialización para envelope JSON
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_workspace_to_dict_completo(tmp_path: Path) -> None:
+    """Workspace.to_dict incluye todas las claves esperadas."""
+    from bib2graph.workspace import Workspace
+
+    ws_dir = tmp_path / "ws"
+    ws = Workspace.init(ws_dir, "test")
+
+    d = ws.to_dict()
+    assert d["root"] == str(ws_dir.resolve())
+    assert "library_path" in d
+    assert "networks_dir" in d
+    assert "snapshots_dir" in d
+    assert "exports_dir" in d
+    assert d["source"] == "init"
+    assert d["manifest"] is not None
+    assert d["manifest"]["name"] == "test"
+
+
+@pytest.mark.unit
+def test_workspace_to_dict_degenerado(tmp_path: Path) -> None:
+    """Workspace degenerado (store suelto) tiene root=None en to_dict."""
+    from bib2graph.workspace import Workspace
+
+    store_file = tmp_path / "mi.duckdb"
+    store_file.touch()
+
+    ws = Workspace.resolve(store=str(store_file))
+    d = ws.to_dict()
+    assert d["root"] is None
+    assert d["manifest"] is None
+    assert "library_path" in d


### PR DESCRIPTION
Fundación workspace: investigación = carpeta (workspace.json + library.duckdb + networks/snapshots/exports). `b2g init`, resolución ambiente (`--store` opcional + `--workspace`), sello `.corpus_hash`, retrocompat del .duckdb suelto. ADR 0029 AS-BUILT + docs sincronizados. verifier PASA, **416 tests**, 0 enlaces rotos. Cierra #38/#39 (parte de #32).