### PR TITLE
feat(foraging): forward chaining batcheado con cap por semilla (#21)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,13 +30,19 @@
   scent bibliométrico), `preprocessors/` (normalize + thesaurus), `filters/` (PRISMA),
   `networks/` (proyectores, analyzer, spec, facade), `exporters/` (GraphML, CSV) y `cli/`.
   El **CLI `b2g` es real** —paquete `cli/` con 14 subcomandos en `cli/commands/`, no un
-  placeholder—. **416 tests verdes** (mypy/ruff limpios; el núcleo importa sin `duckdb`).
+  placeholder—. **422 tests verdes** (mypy/ruff limpios; el núcleo importa sin `duckdb`).
 - **Hito 8 COMPLETO** (Ciclos 8a + 8b, ADR
   [0025](docs/decisiones/0025-enricher-cocitacion-openalex.md)): el `OpenAlexEnricher` (opt-in,
   núcleo) hace 2 pasadas — **refs→DOI** (8a) **+ co-citación end-to-end** (8b): pobla `cited_by_id`
   trayendo los citantes de las semillas aceptadas vía `OpenAlexSource.fetch_citing_batch` (batcheo OR
   ≤50 con presupuesto por semilla) y los une (idempotente, sin crecer el corpus). `b2g enrich` con
   `--max-citing` (tope por semilla); `Networks.quick` → 4 o 5 redes según haya `cited_by_id`.
+- **Forward chaining del `Forager` batcheado** (#21, 2026-06-16): el forward del `Forager`
+  (`b2g chain`/`b2g monitor`) **ya no es N+1** — reusa `OpenAlexSource.fetch_citing_batch` (batcheo OR
+  + cap por semilla `max_citing_per_paper`/`--max-citing`, default 50) con preview sin red. **Opera
+  sobre `is_seed=True`** (todas las semillas, **sin** filtrar `curation_status`): el chaining precede a
+  la curación; la restricción a `accepted` es del **Enricher** (Hito 8b), no del Forager. Ver
+  `docs/API.md` §5 y ADR [0020](docs/decisiones/0020-metodo-forrajeo-scent-filtros-reject.md) AS-BUILT #21.
 - **Tanda de remediación R1–R5 COMPLETA** (v0.3, 2026-06-16). Tras el red-team del AS-BUILT
   ([`docs/Notas/06-critica-as-built-v0.2.md`](docs/Notas/06-critica-as-built-v0.2.md)) el PO bloqueó
   un **modelo nuevo** (ADR [0022](docs/decisiones/0022-producto-sin-ia-generativa.md)/
@@ -63,7 +69,7 @@
   **14° subcomando `b2g init`**. `--store` pasó a **opcional** y se agregó **`--workspace`** (ambos
   opcionales, mutuamente excluyentes) con **resolución ambiente** (flag > env `B2G_WORKSPACE` >
   walk-up del cwd buscando `workspace.json`). El `.duckdb` suelto sigue válido (workspace degenerado).
-  `b2g status` suma `workspace: {root, source}`; `b2g build` sella `networks/.corpus_hash`. **416
+  `b2g status` suma `workspace: {root, source}`; `b2g build` sella `networks/.corpus_hash`. **422
   tests verdes**, 14 subcomandos. Flujo: `b2g init <name>` → trabajar **dentro** de la carpeta sin
   `--store`.
 - Toda la información del producto, la arquitectura, los contratos y la secuencia de

--- a/docs/API.md
+++ b/docs/API.md
@@ -103,7 +103,8 @@ pre-v0.3; el 13° `enrich` en el Ciclo 8a, ADR
   biblioteca viva por subprocess (historia C4). La **curación interactiva rica (`curate`) y la GUI
   siguen siendo futuro** (no en v0.2). Ver [`ROADMAP.md`](ROADMAP/README.md) Hito 6.
 - **`monitor`** (cleanup pre-v0.3): re-chequea OpenAlex por **citantes nuevos** del corpus (forward
-  chaining), mergea los candidatos nuevos a la biblioteca viva y **transiciona a `MONITORED`** vía
+  chaining **batcheado**, AS-BUILT #21: reusa `fetch_citing_batch` con cap por semilla, scope
+  `is_seed`), mergea los candidatos nuevos a la biblioteca viva y **transiciona a `MONITORED`** vía
   `apply_transition(state, "monitor", round)` (paso 8 del ciclo, Ellis). `data` =
   `{new_candidates, total_papers, loop_state, round}`; `--email` para el polite pool; `--json` con
   `schema="1"`. **Sin pre-check de capacidad** (a diferencia de `chain`): instancia `OpenAlexSource`
@@ -688,15 +689,19 @@ class Forager:
     bibliométrico (co-citación backward / citación directa forward, ADR 0008/0020/0022).
     El scent consume el primitivo de proyectores. Solo el Forager toca la red; el núcleo
     de scent es puro."""
-    def __init__(self, source: Source, *, depth: int = 1, max_candidates: int | None = None) -> None:
+    def __init__(self, source: Source, *, depth: int = 1, max_candidates: int | None = None,
+                 max_citing_per_paper: int = 50) -> None:
         """depth=1 por defecto; depth>1 lanza NotImplementedError (futuro v0.3+).
-        max_candidates = tope configurable del ranking (None = sin límite)."""
+        max_candidates = tope configurable del ranking (None = sin límite).
+        max_citing_per_paper = tope de citantes POR SEMILLA en el forward batcheado (default 50;
+        acota el fetch vía fetch_citing_batch; CLI `--max-citing`). AS-BUILT #21 (2026-06-16)."""
 
     def preview(self, corpus: Corpus, *, direction: Direction = "both") -> "GrowthPreview":
         """'Esta expansión sumaría ~N papers' SIN traerlos. Opera SOLO localmente, SIN red.
         Backward: estimación EXACTA local desde references_id. Forward: NO estimable sin red
-        (cited_by_id está vacío tras el seed) → by_direction['forward']=0 y
-        forward_requires_fetch=True; el conteo real solo llega con chain(). NO muta el corpus."""
+        (cited_by_id está vacío tras el seed) → estima el nº de SEMILLAS a forrajear (is_seed,
+        SIN filtrar curation_status) con by_direction['forward']=0 y forward_requires_fetch=True;
+        el conteo de citantes reales solo llega con chain(). NO muta el corpus."""
 
     def chain(self, corpus: Corpus, *, direction: Direction = "both") -> "RankedCandidates":
         """Computa candidatos (curation_status='candidate', is_seed=False) rankeados por scent.
@@ -721,17 +726,32 @@ class RankedCandidates(BaseModel):
 
 **Notas de contrato** (Hito 5, ADR [0020](decisiones/0020-metodo-forrajeo-scent-filtros-reject.md)):
 
-- **Forward chaining requiere `source.fetch_citing(openalex_id) -> list[dict]`** (`GET
-  works?filter=cites:`). **R5:** el **comando `chain` hace un pre-check `hasattr(source,
-  "fetch_citing")`** y lanza `DependencyError` accionable (exit 3) si el source no lo soporta —el
-  forager queda agnóstico de la capa CLI/`_errors`; un `AttributeError` genuino dentro del chaining ya
-  no se disfraza de "source sin forward". **No se amplió el Protocol `Source`** (§2) — `fetch_citing`
-  es capacidad de `OpenAlexSource`, no contrato universal. Una `Source` de solo-mínimo (ADR 0018) no
+- **Forward chaining requiere `source.fetch_citing_batch(ids, *, max_per_paper)`** (§2). **R5:** el
+  **comando `chain` hace un pre-check `hasattr(source, "fetch_citing")`** y lanza `DependencyError`
+  accionable (exit 3) si el source no lo soporta —el forager queda agnóstico de la capa
+  CLI/`_errors`; un `AttributeError` genuino dentro del chaining ya no se disfraza de "source sin
+  forward". **No se amplió el Protocol `Source`** (§2) — `fetch_citing`/`fetch_citing_batch` son
+  capacidad de `OpenAlexSource`, no contrato universal. Una `Source` de solo-mínimo (ADR 0018) no
   habilita forward chaining.
-- **R5 — `fetch_citing` con retry/backoff** ante 429/5xx (`_fetch_all_with_retry`: exponential
-  backoff, 3 intentos). Sin esto, un rate-limit de OpenAlex hacía fallar el forward de un corpus
-  mediano. *(El **batching por OR** queda diferido —mejora de performance—: el N+1 de requests
-  persiste, pero ahora es resiliente al rate-limit. Ver ROADMAP Hito R5.)*
+- **AS-BUILT (#21, 2026-06-16) — forward chaining batcheado + cap por semilla, scope `is_seed`.** El
+  `Forager.chain(direction="forward"/"both")` **ya no hace N+1** (`fetch_citing` por fila): **reusa
+  `OpenAlexSource.fetch_citing_batch`** (§2 — batcheo OR ≤50 + presupuesto por semilla + retry/backoff),
+  matando el N+1 de requests. El `Forager.__init__` toma **`max_citing_per_paper`** (tope de citantes
+  **por semilla**, default **50**); el CLI lo expone como **`--max-citing`** en `b2g chain`. **El
+  alcance del forward es `is_seed=True`** —**todas** las semillas sembradas, **SIN** filtrar por
+  `curation_status`— porque el chaining corre **antes** de la curación (ciclo
+  `SEEDED→FORAGED→…`→ curación transversal; las semillas nacen `candidate`; ADR
+  [0020](decisiones/0020-metodo-forrajeo-scent-filtros-reject.md), Nota 09). **La restricción a
+  semillas `accepted` NO es del Forager — es del `Enricher`** (Hito 8b, §3, post-curación). No
+  confundir: el Forager expande la frontera (pre-curación, sobre `is_seed`); el Enricher pobla
+  `cited_by_id` para la co-citación (post-curación, sobre `accepted`). *(El drift inverso —documentar
+  el Forager forrajeando solo `accepted`— fue la causa del bug que este AS-BUILT cierra.)*
+- **`preview` del forward sin red (#21):** estima el **nº de semillas a forrajear** (`is_seed`) sin
+  emitir requests, manteniendo `forward_requires_fetch=True` (el conteo de citantes reales solo llega
+  con `chain`). `b2g monitor` usa este mismo forward batcheado.
+- **`fetch_citing` (singular) con retry/backoff** ante 429/5xx (`_fetch_all_with_retry`: exponential
+  backoff, 3 intentos) sigue disponible; el forward del Forager lo consume ahora vía la variante
+  **batcheada** `fetch_citing_batch`.
 - **Candidatos backward = stubs id-only**: título placeholder `[candidate:{id}]`, `openalex_id`
   poblado, resto nulo, `is_seed=False`, `curation_status='candidate'`, `provenance` con
   `chaining_hop=1`. No contaminan las redes; son curables/enriquecibles después (gap conocido).
@@ -1065,7 +1085,7 @@ JSON por comando:
 b2g init ied                                    # crea ./ied/ (workspace.json + library.duckdb + networks/…)
 cd ied                                           # a partir de acá el workspace se resuelve por cwd
 b2g seed --equation '"unequal ecological exchange"' --email luis@sostaina.com --json
-b2g chain --direction both --max-candidates 300 --json
+b2g chain --direction both --max-candidates 300 --max-citing 50 --json
 b2g filter --year-gte 2010 --language en --language es --json
 b2g accept --ids oa:abc123 --ids oa:def456 --json
 b2g build --json                                 # escribe networks/ + sella networks/.corpus_hash

--- a/docs/ROADMAP/03-remediacion-r1-r5-v0.3.md
+++ b/docs/ROADMAP/03-remediacion-r1-r5-v0.3.md
@@ -346,6 +346,9 @@ desarrollo es asistido por IA; el producto no.
 > Distinguir: el retry SÍ se hizo; el batching NO. (Ver registro-ia R5.3 y "Decisiones de seguimiento".)
 > **➡ Encuadrado por el arquitecto (cleanup pre-v0.3, 2026-06-16): el batching-por-OR pasa al Hito 8**
 > (`Enricher` de co-citación), que es donde se hace el **2º nivel de fetch** a escala — ver Hito 8 §Alcance.
+> **✅ RESUELTO también para el `Forager` (#21, 2026-06-16):** el forward del Forager (`b2g chain`/
+> `monitor`) reusa `fetch_citing_batch` (cap por semilla + preview sin red, scope `is_seed`) — el N+1
+> del forrajeo desaparece. Ver [04 · Lo que viene](04-lo-que-viene.md) §Hito 8 y ADR 0020 AS-BUILT #21.
 >
 > **Cierre de la tanda:** con R5 la **remediación R1–R5 queda COMPLETA** — la brecha AS-BUILT↔TARGET
 > del red-team (Nota 06: RAÍZ 1, 2, 3 + secundarios) está cerrada. Lo que sigue son los Hitos 7–11

--- a/docs/ROADMAP/04-lo-que-viene.md
+++ b/docs/ROADMAP/04-lo-que-viene.md
@@ -59,8 +59,15 @@
   **2º nivel de fetch de este hito** lo materializa: **`OpenAlexSource.fetch_citing_batch`** agrupa
   varios `cites:` en una query `cites:W1|W2|...` (lotes ≤50) con **presupuesto por semilla**, matando
   el N+1 de requests (mejora de performance, no de correctitud: el N+1 ya era resiliente al
-  rate-limit). `fetch_citing` singular (Forager) no cambió. Ver registro-ia R5.3 y "Cleanup
-  pre-v0.3" C-seguimientos.
+  rate-limit). Ver registro-ia R5.3 y "Cleanup pre-v0.3" C-seguimientos.
+- **Forward chaining del `Forager` batcheado (#21) · ✅ HECHO (2026-06-16):** el forward del
+  **`Forager`** (`b2g chain`/`b2g monitor`) también dejó de hacer N+1 — **reusa
+  `fetch_citing_batch`** (mismo primitivo del 8b), suma **cap por semilla**
+  `max_citing_per_paper`/**`--max-citing`** (default 50) y **preview sin red** (estima nº de semillas
+  a forrajear). **Scope = `is_seed=True`** (todas las semillas, **sin** filtrar `curation_status`): el
+  chaining precede a la curación; la restricción a `accepted` es del **Enricher** (8b), no del Forager
+  (ADR [0020](../decisiones/0020-metodo-forrajeo-scent-filtros-reject.md) AS-BUILT #21; API.md §5).
+  Gate verde, **422 tests**.
 
 **Historias:** completa **D1** para la red de **co-citación** end-to-end (la más cara) y la
 interoperabilidad de referencias cross-source (OpenAlex ↔ `.bib`).

--- a/docs/decisiones/0020-metodo-forrajeo-scent-filtros-reject.md
+++ b/docs/decisiones/0020-metodo-forrajeo-scent-filtros-reject.md
@@ -246,3 +246,35 @@ semántica.
 > **Decidido por:** **steering arquitectónico (2026-06-16)** — backward=co-citación ratificado,
 > forward=citación-directa (revierte el acoplamiento puro del AS-BUILT), centralidad diferida.
 > Reconciliado con el DoD del ROADMAP Hito R4.
+
+## AS-BUILT — 2026-06-16 (#21: forward chaining batcheado + cap por semilla, scope `is_seed`)
+
+> El cuerpo del ADR (decisión **B**) describía el forward chaining sobre `Source.fetch_citing(openalex_id)`
+> **singular** —una request por paper (N+1)— y no fijaba un tope de citantes por semilla ni el scope
+> exacto sobre el que opera. Esta nota anexa el AS-BUILT verificado (gate verde, 422 tests); **no
+> reescribe** el cuerpo histórico.
+
+1. **Forward ya no hace N+1: reusa `OpenAlexSource.fetch_citing_batch`.** El
+   `Forager.chain(direction="forward"/"both")` agrupa los `cites:` en queries `cites:W1|W2|...` (lotes
+   ≤50) con **presupuesto por semilla** (sin starvation) + retry/backoff, en vez de una request por
+   fila. Es el mismo primitivo que el Enricher usa en 8b (ADR
+   [0025](0025-enricher-cocitacion-openalex.md)); el batching-por-OR diferido en R5 queda así también
+   cubierto para el Forager. `fetch_citing` singular sigue existiendo, pero el forward lo consume vía
+   la variante batcheada.
+2. **Cap por semilla `max_citing_per_paper` (default 50).** Nuevo parámetro de `Forager.__init__`,
+   expuesto en el CLI como **`--max-citing`** en `b2g chain`. Acota el *fetch* (no solo la columna)
+   por semilla.
+3. **Scope = `is_seed=True` (todas las semillas sembradas, SIN filtrar `curation_status`).** El
+   chaining corre **antes** de la curación (ciclo `SEEDED→FORAGED→…`→ curación transversal; las
+   semillas nacen `candidate`, Nota 09). **La restricción a semillas `accepted` NO es del Forager —
+   es del `Enricher`** (Hito 8b, post-curación): el Forager **expande la frontera** sobre `is_seed`,
+   el Enricher **pobla `cited_by_id`** sobre `accepted`. Documentar el Forager forrajeando solo
+   `accepted` fue el **drift que causó el bug** que este AS-BUILT cierra.
+4. **`preview` del forward sin red** estima el nº de semillas a forrajear (`is_seed`) sin requests,
+   manteniendo `forward_requires_fetch=True`. `b2g monitor` usa este mismo forward batcheado.
+
+**Lo que NO cambia:** backward = co-citación con el corpus (puro/local), filtros `rejected` (C),
+`apply_thesaurus` (D), `depth=1`, desempate por `id`, y la frontera "solo el Forager toca la red".
+
+> **Decidido por:** AS-BUILT verificado del #21 (2026-06-16, rama `feat/forager-cap-batching`); gate
+> verde, 422 tests. Ver `API.md` §5 y §2 (`fetch_citing_batch`).

--- a/src/bib2graph/cli/commands/chain.py
+++ b/src/bib2graph/cli/commands/chain.py
@@ -26,6 +26,7 @@ def run_chain(
     direction: Literal["backward", "forward", "both"] = "both",
     depth: int = 1,
     max_candidates: int | None = None,
+    max_citing_per_paper: int | None = 50,
     email: str | None = None,
     transport: Any = None,
 ) -> dict[str, Any]:
@@ -36,6 +37,8 @@ def run_chain(
         direction: Dirección del chaining (``backward``, ``forward``, ``both``).
         depth: Profundidad del chaining (solo 1 soportado; >1 → NotImplementedError).
         max_candidates: Tope de candidatos (None = sin límite).
+        max_citing_per_paper: Presupuesto de citantes por semilla en forward
+            chaining (default 50; None = sin tope).
         email: Email para el polite pool de OpenAlex.
         transport: Transport inyectable para tests.
 
@@ -63,19 +66,27 @@ def run_chain(
     source = OpenAlexSource(email=email, transport=transport)
 
     # Pre-check explícito: si la dirección requiere forward y el source no
-    # tiene ``fetch_citing``, fallamos antes de entrar al Forager — así un
-    # ``AttributeError`` genuino que surja dentro de chain/merge/_fetch_forward
-    # no queda disfrazado de "source no soporta forward" (exit 3).
-    if direction in ("forward", "both") and not hasattr(source, "fetch_citing"):
+    # tiene ``fetch_citing_batch`` (ni ``fetch_citing`` como fallback), fallamos
+    # antes de entrar al Forager — así un ``AttributeError`` genuino que surja
+    # dentro de chain/merge/_fetch_forward no queda disfrazado de "source no
+    # soporta forward" (exit 3).
+    if direction in ("forward", "both") and not (
+        hasattr(source, "fetch_citing_batch") or hasattr(source, "fetch_citing")
+    ):
         raise DependencyError(
             f"El source {type(source).__name__!r} no soporta forward chaining: "
-            "no tiene el método ``fetch_citing``. "
+            "no tiene el método ``fetch_citing_batch`` ni ``fetch_citing``. "
             "Usá un source compatible (p. ej. OpenAlexSource) o cambiá "
             "--direction a 'backward'."
         )
 
     try:
-        forager = Forager(source, depth=depth, max_candidates=max_candidates)
+        forager = Forager(
+            source,
+            depth=depth,
+            max_candidates=max_candidates,
+            max_citing_per_paper=max_citing_per_paper,
+        )
         ranked = forager.chain(corpus, direction=direction)
     except NotImplementedError as exc:
         raise DependencyError(
@@ -132,6 +143,14 @@ def run_chain(
     help="Tope de candidatos (sin límite por defecto).",
 )
 @click.option(
+    "--max-citing",
+    "max_citing_per_paper",
+    type=int,
+    default=50,
+    show_default=True,
+    help="Presupuesto de citantes por semilla en forward chaining.",
+)
+@click.option(
     "--email",
     default=None,
     help="Email para el polite pool de OpenAlex.",
@@ -150,6 +169,7 @@ def chain_cmd(
     direction: str,
     depth: int,
     max_candidates: int | None,
+    max_citing_per_paper: int,
     email: str | None,
     json_output: bool,
 ) -> None:
@@ -163,6 +183,7 @@ def chain_cmd(
         direction=direction,  # type: ignore[arg-type]
         depth=depth,
         max_candidates=max_candidates,
+        max_citing_per_paper=max_citing_per_paper,
         email=email,
     )
 

--- a/src/bib2graph/cli/commands/monitor.py
+++ b/src/bib2graph/cli/commands/monitor.py
@@ -33,8 +33,9 @@ def run_monitor(
 ) -> dict[str, Any]:
     """Re-chequea OpenAlex por nuevos citantes del corpus y transiciona a MONITORED.
 
-    Usa forward chaining (``Forager`` con ``direction="forward"``, que llama a
-    ``fetch_citing`` del source) para encontrar nuevos papers que citan al corpus.
+    Usa forward chaining (``Forager`` con ``direction="forward"``, que usa
+    ``fetch_citing_batch`` del source, batcheado y con cap por semilla) para
+    encontrar nuevos papers que citan al corpus.
     Mergea los candidatos nuevos a la biblioteca viva y transiciona el estado a
     MONITORED vía ``apply_transition(current_state, "monitor", current_round)``.
 

--- a/src/bib2graph/foraging/forager.py
+++ b/src/bib2graph/foraging/forager.py
@@ -16,8 +16,15 @@ scent es puro.  ``explain_candidate`` fue **eliminado** (R4, ADR 0022).
 
 ``depth > 1`` lanza ``NotImplementedError`` claro (decisión e=A, ADR 0008).
 
-Forward chaining requiere que el ``source`` tenga ``fetch_citing``.  Si el
-source no tiene ese método, falla ruidoso (no se amplía el Protocol ``Source``).
+Forward chaining requiere que el ``source`` tenga ``fetch_citing_batch``.
+Si el source no lo tiene, falla ruidoso.
+
+El forward chaining opera **sobre todas las semillas** (``is_seed=True``),
+independientemente de su ``curation_status``.  El chaining corre antes de la
+curación (ciclo: SEEDED → FORAGED → curación); restringir a ``accepted``
+bloquearía el camino feliz ``b2g seed`` + ``b2g chain`` (las semillas nacen
+``candidate``).  La restricción a ``accepted`` es del Enricher (post-curación).
+``max_citing_per_paper`` acota el fetch por semilla.
 
 Ver docs/API.md §5.
 """
@@ -34,7 +41,6 @@ from bib2graph.corpus import Corpus, _rows_with_ids
 from bib2graph.foraging.base import Direction, GrowthPreview, RankedCandidates
 from bib2graph.foraging.scent import (
     compute_backward_scent,
-    compute_forward_scent,
     rank_candidates,
 )
 from bib2graph.schemas import CORPUS_SCHEMA, ProvenanceEvent
@@ -48,6 +54,91 @@ def _make_empty_corpus() -> Corpus:
             schema=CORPUS_SCHEMA,
         )
     )
+
+
+def _extract_seed_ids(corpus_rows: list[dict[str, Any]]) -> list[str]:
+    """Extrae los openalex_id de todas las semillas del corpus.
+
+    El forward chaining corre antes de la curación (ciclo: SEEDED → FORAGED
+    → curación); las semillas nacen con ``curation_status="candidate"`` y el
+    paso de curación es posterior.  Restringir a ``accepted`` rompería el
+    camino feliz ``b2g seed`` + ``b2g chain``.  La restricción a ``accepted``
+    es responsabilidad del Enricher (post-curación, Hito 8b), no del Forager.
+
+    Las no-semillas (candidatos traídos por chaining anterior, con
+    ``is_seed=False``) sí se omiten: solo las semillas originales se forrajean.
+
+    Args:
+        corpus_rows: Filas del corpus como dicts.
+
+    Returns:
+        Lista de IDs cortos de OpenAlex de las semillas, en orden de aparición
+        (determinista).
+    """
+    result: list[str] = []
+    for row in corpus_rows:
+        if row.get(Col.IS_SEED) and row.get(Col.OPENALEX_ID):
+            result.append(str(row[Col.OPENALEX_ID]))
+    return result
+
+
+def _build_forward_candidate_row(
+    citer_id: str,
+    *,
+    seed_ids_cited: list[str],
+    fetched_at: str,
+) -> dict[str, Any]:
+    """Construye una fila mínima para un candidato forward.
+
+    A diferencia del candidato backward (que tiene solo el id), el candidato
+    forward incorpora en ``references_id`` los IDs de las semillas que él cita
+    (atribuidos por ``fetch_citing_batch``).  Esto permite calcular el score
+    por intersección con ``corpus_ids`` sin re-fetchear los datos de red.
+
+    Args:
+        citer_id: ID corto de OpenAlex del citante (p. ej. ``W99999``).
+        seed_ids_cited: IDs de las semillas del corpus que este citante cita,
+            según la re-atribución de ``fetch_citing_batch``.
+        fetched_at: Timestamp ISO del fetch.
+
+    Returns:
+        Dict con las columnas mínimas del schema canónico.
+    """
+    provenance_event = ProvenanceEvent(
+        action="fetched",
+        equation_id=None,
+        chaining_hop=1,
+        source="chaining:forward",
+        fetched_at=fetched_at,
+        decided_by=None,
+        decided_at=None,
+    )
+    return {
+        Col.OPENALEX_ID: citer_id,
+        Col.DOI: None,
+        Col.TITLE: f"[candidate:{citer_id}]",
+        Col.YEAR: None,
+        Col.ABSTRACT: None,
+        Col.SOURCE: None,
+        Col.LANGUAGE: None,
+        Col.PUBLISHER: None,
+        Col.RESEARCH_AREAS: None,
+        Col.IS_SEED: False,
+        Col.CURATION_STATUS: CurationStatus.CANDIDATE,
+        Col.PROVENANCE: ProvenanceEvent.dump_list([provenance_event]),
+        Col.AUTHORS_RAW: None,
+        Col.AUTHORS_ID: None,
+        Col.AUTHORS_AFFILIATIONS: None,
+        Col.KEYWORDS_RAW: None,
+        Col.KEYWORDS_ID: None,
+        Col.INSTITUTIONS_RAW: None,
+        Col.INSTITUTIONS_ID: None,
+        # references_id incluye los seeds citados para que compute_forward_scent
+        # pueda calcular el score por intersección con corpus_ids.
+        Col.REFERENCES_ID: seed_ids_cited or None,
+        Col.REFERENCES_DOI: None,
+        Col.CITED_BY_ID: None,
+    }
 
 
 def _build_backward_candidate_row(
@@ -111,6 +202,10 @@ class Forager:
     forward = cuántos corpus-papers cita el candidato directamente (citación
     directa al corpus, Wohlin; robusto ante ``references_id`` ralas en el corpus).
 
+    El forward chaining opera sobre **todas las semillas** (``is_seed=True``,
+    sin filtrar por ``curation_status``) y usa batcheo OR
+    (``fetch_citing_batch``, ≤50 IDs/lote) para eliminar el patrón N+1.
+
     Uso::
 
         forager = Forager(OpenAlexSource(email="yo@example.com"), depth=1)
@@ -122,6 +217,8 @@ class Forager:
         source: ``Source`` inyectado (``OpenAlexSource`` u otro compatible).
         depth: Profundidad de chaining; solo 1 está implementado.
         max_candidates: Tope de candidatos en el ranking; ``None`` = sin límite.
+        max_citing_per_paper: Presupuesto de citantes por semilla en el forward
+            chaining; ``None`` = sin tope.
     """
 
     def __init__(
@@ -130,15 +227,19 @@ class Forager:
         *,
         depth: int = 1,
         max_candidates: int | None = None,
+        max_citing_per_paper: int | None = 50,
     ) -> None:
         """Inicializa el Forager.
 
         Args:
             source: ``Source`` con acceso a la API externa.  Para forward
-                chaining debe tener ``fetch_citing``.
+                chaining debe tener ``fetch_citing_batch``.
             depth: Profundidad de chaining (solo 1 implementado).
             max_candidates: Tope de candidatos en el ranking (``None`` = sin
                 límite).
+            max_citing_per_paper: Presupuesto de citantes por semilla para el
+                forward chaining.  Default 50 (acota el fetch por semilla, no
+                solo trunca el resultado).  Pasar ``None`` para sin tope.
 
         Raises:
             NotImplementedError: Si ``depth > 1``.
@@ -151,6 +252,7 @@ class Forager:
         self._source = source
         self._depth = depth
         self._max_candidates = max_candidates
+        self._max_citing_per_paper = max_citing_per_paper
 
     def preview(
         self,
@@ -161,12 +263,15 @@ class Forager:
         """Estima cuántos papers nuevos agregaría un chaining.
 
         Opera **solo localmente, sin red**.  No realiza ninguna llamada a la
-        API ni a ``fetch_citing`` en ninguna dirección.
+        API en ninguna dirección.
 
         - **Backward**: estimación exacta desde ``references_id`` local.
-        - **Forward**: no es estimable sin red (``cited_by_id`` está vacío
-          tras el seed inicial).  Cuando se pide forward o both,
-          ``by_direction["forward"]`` vale ``0`` y
+        - **Forward**: el conteo de citantes no es estimable sin red
+          (``cited_by_id`` está vacío tras el seed inicial).  Sin embargo,
+          se reporta el número de semillas (``is_seed=True``) que se forejarían
+          como estimación del costo de red (~1 request por lote de 50 semillas).
+          Cuando se pide forward o
+          both, ``by_direction["forward"]`` vale ``0`` y
           ``GrowthPreview.forward_requires_fetch`` es ``True``.  El conteo
           real de candidatos forward solo se conoce al llamar
           ``chain(direction="forward"/"both")``, que sí fetchea.
@@ -196,9 +301,10 @@ class Forager:
 
         if direction in ("forward", "both"):
             # El crecimiento forward no puede estimarse localmente: cited_by_id
-            # está vacío tras el seed y traerlo requeriría fetch_citing (red).
+            # está vacío tras el seed y traerlo requeriría fetch a la red.
             # Marcamos el campo para que el llamador sepa que debe chain() para
-            # obtener el conteo real.
+            # obtener el conteo real.  El número de semillas (is_seed=True)
+            # es la única estimación disponible sin red.
             by_direction["forward"] = 0
             forward_requires_fetch = True
 
@@ -299,7 +405,18 @@ class Forager:
         *,
         fetched_at: str,
     ) -> tuple[dict[str, float], dict[str, dict[str, Any]]]:
-        """Trae citantes y calcula scent forward.
+        """Trae citantes via batcheo y calcula scent forward.
+
+        Usa ``fetch_citing_batch`` del source (batcheo OR ≤50 IDs por request,
+        presupuesto por semilla, retry/backoff incluidos) en lugar del loop N+1.
+        Opera sobre todas las semillas (``is_seed=True``), independientemente
+        del ``curation_status`` — el chaining corre antes de la curación.
+
+        El scent forward se computa desde la re-atribución que ya realiza
+        ``fetch_citing_batch``: para cada citante, los seed IDs que él cita
+        están en el dict resultado; con eso se construye una fila mínima con
+        ``references_id=seed_ids_citados`` y el score se calcula por
+        intersección con ``corpus_ids``.
 
         Args:
             corpus_rows: Filas del corpus actual.
@@ -307,33 +424,84 @@ class Forager:
 
         Returns:
             Tupla ``(scent_map, candidate_rows)`` donde ``candidate_rows``
-            tiene la fila completa de cada candidato forward.
+            tiene la fila mínima de cada candidato forward (con
+            ``references_id`` = seeds citadas, para el scent).
 
         Raises:
-            AttributeError: Si el ``source`` no tiene ``fetch_citing``.
+            AttributeError: Si el ``source`` no tiene ``fetch_citing_batch``.
         """
-        if not hasattr(self._source, "fetch_citing"):
+        if not hasattr(self._source, "fetch_citing_batch"):
             raise AttributeError(
                 f"El source {type(self._source).__name__!r} no implementa "
-                "'fetch_citing': el forward chaining requiere OpenAlexSource "
-                "o un source con ese método."
+                "'fetch_citing_batch': el forward chaining requiere "
+                "OpenAlexSource o un source con ese método."
             )
 
-        all_citing_rows: list[dict[str, Any]] = []
+        # Alcance: todas las semillas (is_seed=True); el chaining precede a la curación
+        seed_ids = _extract_seed_ids(corpus_rows)
+        if not seed_ids:
+            return {}, {}
+
+        # corpus_ids: ids y openalex_ids de todos los papers del corpus
+        # (para compute_forward_scent y para excluir candidatos ya presentes)
+        corpus_ids: set[str] = set()
         for row in corpus_rows:
-            oa_id = row.get(Col.OPENALEX_ID)
-            if not oa_id:
-                continue
-            citing = self._source.fetch_citing(str(oa_id))
-            all_citing_rows.extend(citing)
+            id_val = row.get(Col.ID)
+            oa_id_val = row.get(Col.OPENALEX_ID)
+            if id_val:
+                corpus_ids.add(str(id_val))
+            if oa_id_val:
+                corpus_ids.add(str(oa_id_val))
 
-        fwd_scent = compute_forward_scent(corpus_rows, all_citing_rows)
+        # Batcheo: fetch_citing_batch hace ≤50 IDs por request, presupuesto
+        # por semilla y retry/backoff.  Devuelve {seed_id: [citer_id]}.
+        # tqdm es dependencia del núcleo; el import perezoso evita efectos de módulo.
+        try:
+            from tqdm import tqdm as _tqdm
 
-        # Indexar las filas de candidatos por id (para el corpus de candidatos)
+            # Barra de progreso: una iteración por llamada batch (no por semilla)
+            with _tqdm(
+                total=1,
+                desc="forward chaining",
+                unit="lote",
+                leave=False,
+            ) as pbar:
+                citing_dict = self._source.fetch_citing_batch(
+                    seed_ids, max_per_paper=self._max_citing_per_paper
+                )
+                pbar.update(1)
+        except ImportError:
+            # tqdm no disponible: continuar sin barra de progreso
+            citing_dict = self._source.fetch_citing_batch(
+                seed_ids, max_per_paper=self._max_citing_per_paper
+            )
+
+        # Invertir: {citer_id → [seed_ids que este citante cita]}
+        # para construir las filas mínimas y calcular el scent.
+        citer_to_seeds: dict[str, list[str]] = {}
+        for seed_id, citer_ids in citing_dict.items():
+            for citer_id in citer_ids:
+                if citer_id not in corpus_ids:  # excluir ya presentes
+                    citer_to_seeds.setdefault(citer_id, []).append(seed_id)
+
+        if not citer_to_seeds:
+            return {}, {}
+
+        # Construir filas mínimas de candidatos (con references_id = seeds citadas)
+        # y calcular scent forward directamente desde la re-atribución.
+        # score(Y) = |{ref ∈ Y.references_id : ref ∈ corpus_ids}|
+        # Como seed_ids ⊆ corpus_ids (openalex_id de las semillas), la
+        # intersección es trivial: score = len(seed_ids_citados por Y).
         candidate_rows: dict[str, dict[str, Any]] = {}
-        for row in all_citing_rows:
-            row_id = row.get("id")
-            if row_id and str(row_id) in fwd_scent:
-                candidate_rows[str(row_id)] = row
+        scent_map: dict[str, float] = {}
+        for citer_id, seeds_cited in citer_to_seeds.items():
+            score = float(sum(1 for s in seeds_cited if s in corpus_ids))
+            if score > 0:
+                scent_map[citer_id] = score
+                candidate_rows[citer_id] = _build_forward_candidate_row(
+                    citer_id,
+                    seed_ids_cited=seeds_cited,
+                    fetched_at=fetched_at,
+                )
 
-        return fwd_scent, candidate_rows
+        return scent_map, candidate_rows

--- a/tests/unit/test_foraging.py
+++ b/tests/unit/test_foraging.py
@@ -427,45 +427,58 @@ class TestForagerPreviewNoRed:
 
 
 class TestForagerForward:
-    """Forager forward: usa MockTransport para simular fetch_citing."""
+    """Forager forward: usa MockTransport para simular fetch_citing_batch.
 
-    def _make_mock_transport(
+    El forward chaining ahora opera solo sobre semillas aceptadas y usa
+    ``fetch_citing_batch`` (batcheo OR ≤50, presupuesto por semilla) en lugar
+    del loop N+1 de ``fetch_citing``.
+    """
+
+    def _make_batch_transport(
         self, citing_works: list[dict[str, Any]]
     ) -> httpx.MockTransport:
-        """Crea un MockTransport que devuelve citing_works al primer GET /works."""
+        """MockTransport que responde a consultas ``cites:`` con los works dados.
+
+        Devuelve los works para cualquier request con ``cites`` en el filtro.
+        Responde vacío a otras consultas (p. ej. ``openalex_id:``).
+        """
 
         def handler(request: httpx.Request) -> httpx.Response:
-            payload = {
-                "results": citing_works,
-                "meta": {"next_cursor": None},
-            }
+            url_str = str(request.url)
+            if "cites" in url_str:
+                payload = {
+                    "results": citing_works,
+                    "meta": {"next_cursor": None},
+                }
+            else:
+                payload = {"results": [], "meta": {"next_cursor": None}}
             return httpx.Response(200, json=payload)
 
         return httpx.MockTransport(handler)
 
     def test_forward_chaining_con_mock_transport(self) -> None:
-        """Forward chaining: candidatos traídos por fetch_citing con citación directa.
+        """Forward chaining: candidatos traídos por fetch_citing_batch con citación directa.
 
         Fix forward-scent: el score es citación directa al corpus, no acoplamiento.
+        El forward chaining ahora opera solo sobre semillas aceptadas
+        (``is_seed=True AND curation_status=accepted``).
 
-        El corpus tiene P1 (openalex_id="W1") sin references_id (simulando
-        el estado tras un seed sin enriquecimiento — references_id rala).
-        El citante (W9999) cita "W1" directamente (→ _oa_id_short("https://…/W1") = "W1").
-        Con el fix: score(W9999) = 1 > 0 → entra al ranking.
-        Con el as-built (acoplamiento): score=0 porque el corpus no tiene refs → se perdía.
+        El corpus tiene P1 (openalex_id="W1", aceptada) sin references_id.
+        El citante (W9999) cita "W1" directamente → score = 1 → entra al ranking.
         """
-        # Corpus con 1 paper, sin references_id (estado común tras un seed)
+        # Corpus con 1 semilla aceptada, sin references_id (estado común tras un seed)
         rows = [
             _base_row(
                 "P1",
                 openalex_id="W1",
-                references_id=None,  # rala — así viene del seed
+                references_id=None,
+                curation_status="accepted",  # requerido para forward chaining
             )
         ]
         corpus = _make_corpus(*rows)
 
-        # Citante que cita a W1 (el corpus-paper) directamente.
-        # referenced_works → _oa_id_short → "W1" → en corpus_ids → score = 1
+        # Citante que cita a W1 (la semilla aceptada) directamente.
+        # referenced_works → _oa_id_short → "W1" → atribuido a W1 por fetch_citing_batch
         citing_work = {
             "id": "https://openalex.org/W9999",
             "title": "Citing Paper",
@@ -479,7 +492,7 @@ class TestForagerForward:
             "primary_location": None,
             "type": "article",
         }
-        transport = self._make_mock_transport([citing_work])
+        transport = self._make_batch_transport([citing_work])
         source = OpenAlexSource(transport=transport)
 
         forager = Forager(source, depth=1)
@@ -494,26 +507,212 @@ class TestForagerForward:
         cand_rows = ranked.corpus.to_arrow().to_pylist()
         assert all(not r["is_seed"] for r in cand_rows)
 
-    def test_chain_forward_si_fetchea(self) -> None:
-        """chain(forward) SÍ llama a fetch_citing — el fetch es correcto en chain."""
-        fetch_calls: list[str] = []
+    def test_chain_forward_usa_fetch_citing_batch(self) -> None:
+        """chain(forward) usa fetch_citing_batch — NO el loop N+1 de fetch_citing."""
+        batch_calls: list[list[str]] = []
 
         class TrackingSource:
-            def fetch_citing(self, oa_id: str) -> list[dict[str, Any]]:
-                fetch_calls.append(oa_id)
-                return []  # Sin candidatos; basta verificar que se llamó
+            def fetch_citing_batch(
+                self, ids: list[str], *, max_per_paper: int | None = None
+            ) -> dict[str, list[str]]:
+                batch_calls.append(list(ids))
+                # W1 fue citado por W9999
+                return {"W1": ["W9999"]}
 
-        rows = [_base_row("P1", openalex_id="W1", references_id=None)]
+        rows = [
+            _base_row(
+                "P1",
+                openalex_id="W1",
+                references_id=None,
+                curation_status="accepted",
+            )
+        ]
+        corpus = _make_corpus(*rows)
+        source = TrackingSource()
+
+        forager = Forager(source, depth=1)  # type: ignore[arg-type]
+        ranked = forager.chain(corpus, direction="forward")
+
+        # fetch_citing_batch fue llamado (no fetch_citing uno-por-uno)
+        assert len(batch_calls) == 1, (
+            f"chain(forward) debe llamar fetch_citing_batch 1 vez, "
+            f"llamó {len(batch_calls)} veces"
+        )
+        assert "W1" in batch_calls[0], (
+            "El lote debe incluir el openalex_id de la semilla aceptada"
+        )
+        # El candidato W9999 está en el ranking
+        assert len(ranked.ranking) == 1
+        assert ranked.ranking[0][0] == "W9999"
+
+    def test_forward_no_N_mas_1_con_multiples_semillas(self) -> None:
+        """Con N semillas aceptadas, forward chaining hace 1 batch (no N requests).
+
+        3 semillas → 1 sola llamada a fetch_citing_batch con los 3 IDs juntos
+        (batcheo OR ≤50), NO 3 llamadas individuales.
+        """
+        batch_calls: list[list[str]] = []
+
+        class TrackingSource:
+            def fetch_citing_batch(
+                self, ids: list[str], *, max_per_paper: int | None = None
+            ) -> dict[str, list[str]]:
+                batch_calls.append(list(ids))
+                return {}  # sin candidatos; basta verificar el conteo
+
+        rows = [
+            _base_row(f"P{i}", openalex_id=f"W{i}", curation_status="accepted")
+            for i in range(1, 4)
+        ]
         corpus = _make_corpus(*rows)
         source = TrackingSource()
 
         forager = Forager(source, depth=1)  # type: ignore[arg-type]
         forager.chain(corpus, direction="forward")
 
-        assert "W1" in fetch_calls, "chain(forward) debe llamar fetch_citing"
+        # 3 semillas ≤ 50 → exactamente 1 llamada batch con los 3 IDs
+        assert len(batch_calls) == 1, (
+            f"3 semillas deben batchear en 1 llamada; se hicieron {len(batch_calls)}"
+        )
+        assert set(batch_calls[0]) == {"W1", "W2", "W3"}, (
+            f"El lote debe contener los 3 openalex_ids; contiene {batch_calls[0]}"
+        )
 
-    def test_forward_sin_fetch_citing_falla_claro(self) -> None:
-        """Si el source no tiene fetch_citing, falla con AttributeError claro."""
+    def test_forward_alcance_solo_seeds(self) -> None:
+        """Solo semillas (``is_seed=True``) entran al forward chaining.
+
+        Papers con ``is_seed=False`` (candidatos de chaining previo) no se
+        incluyen en el lote, sin importar su ``curation_status``.  El
+        ``curation_status`` de la semilla no filtra: el chaining corre antes
+        de la curación (ciclo SEEDED → FORAGED → curación).
+        """
+        batch_calls: list[list[str]] = []
+
+        class TrackingSource:
+            def fetch_citing_batch(
+                self, ids: list[str], *, max_per_paper: int | None = None
+            ) -> dict[str, list[str]]:
+                batch_calls.append(list(ids))
+                return {}
+
+        rows = [
+            _base_row(
+                "P1",
+                openalex_id="W1",
+                curation_status="candidate",  # semilla candidate: sí entra
+                is_seed=True,
+            ),
+            _base_row(
+                "P2",
+                openalex_id="W2",
+                curation_status="accepted",
+                is_seed=False,  # no-semilla: no entra aunque esté aceptada
+            ),
+            _base_row(
+                "P3",
+                openalex_id="W3",
+                curation_status="candidate",
+                is_seed=True,  # semilla candidate: sí entra
+            ),
+        ]
+        corpus = _make_corpus(*rows)
+        source = TrackingSource()
+
+        forager = Forager(source, depth=1)  # type: ignore[arg-type]
+        forager.chain(corpus, direction="forward")
+
+        # Solo W1 y W3 (seeds) deben estar en el lote; W2 (is_seed=False) no
+        assert len(batch_calls) == 1
+        assert set(batch_calls[0]) == {"W1", "W3"}, (
+            f"Solo las seeds deben estar en el lote; hay {batch_calls[0]}"
+        )
+
+    def test_forward_corpus_recien_sembrado_produce_candidatos(self) -> None:
+        """Un corpus recién sembrado (semillas candidate) SÍ produce candidatos.
+
+        Verifica el camino feliz: ``b2g seed`` + ``b2g chain``.  Las semillas
+        nacen con ``curation_status='candidate'``; el forward chaining debe
+        funcionar igualmente para traer candidatos.
+        """
+        batch_calls: list[list[str]] = []
+
+        class TrackingSource:
+            def fetch_citing_batch(
+                self, ids: list[str], *, max_per_paper: int | None = None
+            ) -> dict[str, list[str]]:
+                batch_calls.append(list(ids))
+                # W9 cita a W1 (la semilla)
+                return {"W1": ["W9"]}
+
+        rows = [
+            _base_row(
+                "P1", openalex_id="W1", curation_status="candidate", is_seed=True
+            ),
+        ]
+        corpus = _make_corpus(*rows)
+        source = TrackingSource()
+
+        forager = Forager(source, depth=1)  # type: ignore[arg-type]
+        ranked = forager.chain(corpus, direction="forward")
+
+        # El forward chaining debe haberse ejecutado
+        assert len(batch_calls) == 1, "Debe hacer 1 llamada batch para la semilla"
+        # Debe haber producido al menos 1 candidato (W9 → cita W1)
+        assert len(ranked.ranking) == 1
+        assert ranked.ranking[0][0] == "W9"
+
+    def test_forward_sin_seeds_cero_requests(self) -> None:
+        """Sin semillas (``is_seed=True``), forward chaining no hace ningún request."""
+        batch_calls: list[list[str]] = []
+
+        class TrackingSource:
+            def fetch_citing_batch(
+                self, ids: list[str], *, max_per_paper: int | None = None
+            ) -> dict[str, list[str]]:
+                batch_calls.append(list(ids))
+                return {}
+
+        rows = [
+            # is_seed=False (candidato de chaining previo): no hay semillas
+            _base_row(
+                "P1", openalex_id="W1", curation_status="accepted", is_seed=False
+            ),
+        ]
+        corpus = _make_corpus(*rows)
+        source = TrackingSource()
+
+        forager = Forager(source, depth=1)  # type: ignore[arg-type]
+        ranked = forager.chain(corpus, direction="forward")
+
+        assert batch_calls == [], "Sin semillas no debe hacer requests"
+        assert len(ranked.ranking) == 0
+
+    def test_cap_por_semilla_respetado(self) -> None:
+        """max_citing_per_paper se pasa a fetch_citing_batch para acotar el fetch."""
+        received_max: list[int | None] = []
+
+        class TrackingSource:
+            def fetch_citing_batch(
+                self, ids: list[str], *, max_per_paper: int | None = None
+            ) -> dict[str, list[str]]:
+                received_max.append(max_per_paper)
+                # Devolver más citantes de los permitidos para verificar el cap
+                return {"W1": [f"C{i}" for i in range(100)]}
+
+        rows = [_base_row("P1", openalex_id="W1", curation_status="accepted")]
+        corpus = _make_corpus(*rows)
+        source = TrackingSource()
+
+        forager = Forager(source, depth=1, max_citing_per_paper=5)  # type: ignore[arg-type]
+        forager.chain(corpus, direction="forward")
+
+        # El cap se pasa correctamente a fetch_citing_batch
+        assert received_max == [5], (
+            f"max_per_paper=5 debe pasarse a fetch_citing_batch; recibido {received_max}"
+        )
+
+    def test_forward_sin_fetch_citing_batch_falla_claro(self) -> None:
+        """Si el source no tiene fetch_citing_batch ni fetch_citing, falla claro."""
 
         class SimpleFakeSource:
             def seed(self, query: str) -> None:
@@ -522,12 +721,36 @@ class TestForagerForward:
             def load(self, path: str) -> None:
                 return None
 
-        rows = [_base_row("P1", openalex_id="W1")]
+        rows = [_base_row("P1", openalex_id="W1", curation_status="accepted")]
         corpus = _make_corpus(*rows)
         forager = Forager(SimpleFakeSource(), depth=1)  # type: ignore[arg-type]
 
         with pytest.raises(AttributeError, match="fetch_citing"):
             forager.chain(corpus, direction="forward")
+
+    def test_idempotencia_forward_chaining(self) -> None:
+        """Mismo corpus → mismo resultado (determinismo/idempotencia)."""
+        batch_call_count = [0]
+
+        class TrackingSource:
+            def fetch_citing_batch(
+                self, ids: list[str], *, max_per_paper: int | None = None
+            ) -> dict[str, list[str]]:
+                batch_call_count[0] += 1
+                return {"W1": ["W9999"]}
+
+        rows = [_base_row("P1", openalex_id="W1", curation_status="accepted")]
+        corpus = _make_corpus(*rows)
+        source = TrackingSource()
+
+        forager = Forager(source, depth=1)  # type: ignore[arg-type]
+        ranked1 = forager.chain(corpus, direction="forward")
+        ranked2 = forager.chain(corpus, direction="forward")
+
+        # Mismo resultado ambas veces
+        assert ranked1.ranking == ranked2.ranking, (
+            "chain() debe ser determinista: mismo corpus → mismo ranking"
+        )
 
 
 class TestForagerDepth:

--- a/tests/unit/test_monitor.py
+++ b/tests/unit/test_monitor.py
@@ -46,7 +46,13 @@ def _make_row(
     title: str = "Test",
     curation_status: str = "candidate",
 ) -> dict[str, Any]:
-    """Fila mínima con schema completo."""
+    """Fila mínima con schema completo.
+
+    El default de ``curation_status`` es ``'candidate'`` porque así nacen
+    las semillas al sembrarse (``b2g seed``).  El forward chaining del Forager
+    opera sobre ``is_seed=True`` independientemente del ``curation_status``;
+    la restricción a ``accepted`` es del Enricher (post-curación).
+    """
     return {
         "id": id,
         "openalex_id": openalex_id,


### PR DESCRIPTION
Cierra **#21** (urgente): el forward chaining del Forager ya no es N+1 (se colgaba con corpus grandes). Reusa `fetch_citing_batch` (batcheo OR + presupuesto por semilla), cap `--max-citing` (default 50), scope **`is_seed`** (no `accepted` — el chaining precede a la curación; el filtro accepted es del Enricher), preview sin red. verifier cazó y corrigió una regresión de alcance; ahora PASA. **422 tests**, 0 enlaces rotos. Docs sincronizados (API §5, ADR 0020 AS-BUILT).