### PR TITLE
feat(networks): capa decorate — labels legibles en nodos (#25)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@
   scent bibliométrico), `preprocessors/` (normalize + thesaurus), `filters/` (PRISMA),
   `networks/` (proyectores, analyzer, spec, facade), `exporters/` (GraphML, CSV) y `cli/`.
   El **CLI `b2g` es real** —paquete `cli/` con 14 subcomandos en `cli/commands/`, no un
-  placeholder—. **422 tests verdes** (mypy/ruff limpios; el núcleo importa sin `duckdb`).
+  placeholder—. **437 tests verdes** (mypy/ruff limpios; el núcleo importa sin `duckdb`).
 - **Hito 8 COMPLETO** (Ciclos 8a + 8b, ADR
   [0025](docs/decisiones/0025-enricher-cocitacion-openalex.md)): el `OpenAlexEnricher` (opt-in,
   núcleo) hace 2 pasadas — **refs→DOI** (8a) **+ co-citación end-to-end** (8b): pobla `cited_by_id`
@@ -43,6 +43,11 @@
   sobre `is_seed=True`** (todas las semillas, **sin** filtrar `curation_status`): el chaining precede a
   la curación; la restricción a `accepted` es del **Enricher** (Hito 8b), no del Forager. Ver
   `docs/API.md` §5 y ADR [0020](docs/decisiones/0020-metodo-forrajeo-scent-filtros-reject.md) AS-BUILT #21.
+- **Labels legibles en las redes** (#25, 2026-06-16): las redes ahora salen con `label` legible
+  (más `year`/`is_seed`/`curation_status`/`degree_centrality`/`community`) vía la nueva **capa
+  frontera `decorate`** (`networks/decorate.py`), aplicada en `facade.py:_build_artifact`; `b2g
+  build`/`export` exportan grafos legibles en Gephi/VOSviewer. Los proyectores **siguen puros** (ADR
+  0014). Cierra el hueco de la Nota 09 B3 (redes con id crudo). Ver `docs/API.md` §7.1.
 - **Tanda de remediación R1–R5 COMPLETA** (v0.3, 2026-06-16). Tras el red-team del AS-BUILT
   ([`docs/Notas/06-critica-as-built-v0.2.md`](docs/Notas/06-critica-as-built-v0.2.md)) el PO bloqueó
   un **modelo nuevo** (ADR [0022](docs/decisiones/0022-producto-sin-ia-generativa.md)/

--- a/docs/API.md
+++ b/docs/API.md
@@ -58,6 +58,13 @@
 > `OpenAlexSource.fetch_citing_batch`, §2) y `Networks.quick` devuelve **4 o 5 redes** según haya
 > `cited_by_id` (§10). Flag `--max-citing`. **Hito 8 completo.**
 >
+> **Sincronizado con labels/decorate — #25 (AS-BUILT, 2026-06-16):** se agregó la **capa frontera
+> `decorate`** (§7.1, `networks/decorate.py`) entre los proyectores puros (§7) y el export/GUI:
+> inyecta `label` legible + atributos de nodo (`year`/`is_seed`/`curation_status`/`degree_centrality`/
+> `community`) en los nodos. `Networks.quick`/`build` devuelven artefactos **decorados** (cableado en
+> `facade.py:_build_artifact`); los proyectores **siguen puros** (ADR 0014). Cierra el hueco de la
+> Nota 09 B3 (redes con id crudo, ilegibles en Gephi/VOSviewer).
+>
 > **Sincronizado con el workspace — ADR [0029](decisiones/0029-workspace-por-investigacion.md)
 > (AS-BUILT, 2026-06-16):** la unidad de persistencia es un **workspace = carpeta** (`workspace.json`
 > + `library.duckdb` + `networks/`/`snapshots/`/`exports/`). `--store` pasó a **opcional** y se agregó
@@ -849,6 +856,62 @@ completo** (crítica #2). La **co-citación** es la más cara (segundo nivel de 
   **completa es end-to-end** (Hito 8 ✅): `b2g enrich` (8b) puebla `cited_by_id` con el 2º nivel de
   fetch del `OpenAlexEnricher` (ADR 0007/0025), y `Networks.quick` la incluye cuando esa columna
   está poblada (§10).
+- **Los proyectores siguen PUROS — NO setean atributos de nodo** (ADR 0014, AS-BUILT #25): producen
+  un `nx.Graph` con **ids crudos** como nodos (`oa:…`, `I185261750`, un ORCID), **sin** `label`. La
+  legibilidad (label + atributos) la inyecta la **capa `decorate` (§7.1)**, que es la **frontera**
+  entre la proyección pura y el export/GUI. Esta separación es deliberada (ADR 0014).
+
+---
+
+## 7.1 Frontera — `decorate` (label legible + atributos de nodo, v1, AS-BUILT #25)
+
+`bib2graph.networks.decorate` es la **capa de frontera** entre los proyectores puros (§7) y los
+exportadores (§9) / la GUI. Los proyectores devuelven grafos con **ids crudos** como nodos y **sin
+atributos**; `decorate` transforma esos ids en **labels legibles** e inyecta atributos de
+curación/comunidad/centralidad. Cierra el hueco de la Nota 09 B3 (las redes salían con `id` crudo,
+ilegibles en Gephi/VOSviewer/Cytoscape).
+
+```python
+LABEL_MAX_CHARS: int = 60   # tope del label de paper; título largo → truncado + "..."
+
+def decorate_graph(graph: nx.Graph, table: pa.Table, kind: str, *,
+                   communities: dict[Any, int] | None = None) -> None:
+    """Inyecta label + atributos en los nodos del grafo IN-PLACE (no copia; el llamador/
+    exporter copia si necesita preservar el original). No muta el corpus ni la tabla.
+    Determinista; no importa duckdb (núcleo puro)."""
+
+def decorate(artifact: NetworkArtifact, table: pa.Table) -> None:
+    """Atajo sobre decorate_graph: extrae kind y communities del NetworkArtifact.
+    Es el punto de integración en facade.py (_build_artifact)."""
+```
+
+`networks/__init__.py` re-exporta `decorate`/`decorate_graph`.
+
+**Atributos de nodo inyectados:**
+
+| Atributo | Kinds | Origen |
+|---|---|---|
+| `label` | todos | string legible (mapeo por kind, abajo) |
+| `degree_centrality` | todos | `float`, vía `nx.degree_centrality` |
+| `year` | paper (coupling/cocitation) | `int` (ausente si `None` en el corpus) |
+| `is_seed` | paper | `bool` |
+| `curation_status` | paper | `string` |
+| `community` | todos | `int`, **solo** si se provee `artifact.communities` |
+
+**Mapeo de `label` por `NetworkKind`:**
+
+| Kind | Nodo | `label` |
+|---|---|---|
+| `bibliographic_coupling` / `cocitation` | paper (`id`) | `"título (año)"`, truncado a `LABEL_MAX_CHARS` (60) + `"..."`; fallback al id crudo si no hay título |
+| `author_collab` | `authors_id` | `authors_raw` correlativo al `authors_id` (fallback al id) |
+| `institution_collab` | `institutions_id` | `institutions_raw` correlativo (fallback al id) |
+| `keyword_cooccurrence` | `keywords_id` | la keyword (ya legible) |
+| (kind desconocido) | — | fallback al id crudo (extensible, no falla) |
+
+**Cableado:** `decorate` se aplica en `facade.py:_build_artifact`, de modo que `Networks.quick` /
+`Networks.build` (§10) ya devuelven **artefactos decorados** y `b2g build`/`export` salen con `label`
+legible sin pasos extra. **Los proyectores (§7) NO se tocan** (siguen puros, ADR 0014): la decoración
+es la única capa que sabe de labels.
 
 ---
 
@@ -916,7 +979,8 @@ class CsvExporter: ...       # v1 — nodos.csv + aristas.csv para pandas
 
 - **`CsvExporter`** escribe `aristas.csv` (`source,target,weight`) y `nodos.csv` (`id,label` +
   atributos de nodo + métricas de `results` —degree/betweenness/community— unidas por id). Orden
-  de filas determinista.
+  de filas determinista. El `label` (y `year`/`is_seed`/`curation_status`/`community`) lo inyecta la
+  capa `decorate` (§7.1) antes del export, no el exporter.
 - **`GraphMLExporter`** escribe esos atributos como node attributes, **omite** los atributos con
   valor `None` (Gephi / `nx.write_graphml` no los admiten) y **no muta** el grafo original (opera
   sobre una copia).
@@ -955,7 +1019,8 @@ class Networks:
         """Arma las specs razonables y devuelve sus artefactos (caso 'investigador, baja
         fricción'). Devuelve **4 o 5 redes**: coupling (full), co-autoría, institución, co-word
         siempre; la **co-citación** se incluye (→5) cuando el corpus tiene `cited_by_id` poblado
-        (tras `b2g enrich`, Hito 8b) y se **omite graceful** (log) si está vacío (→4)."""
+        (tras `b2g enrich`, Hito 8b) y se **omite graceful** (log) si está vacío (→4).
+        Los artefactos vienen **decorados** (label legible + atributos de nodo, §7.1)."""
 ```
 
 **Modo quick** (v1) cubre baja fricción; **modo spec** (v0.2, YAML) cubre el pipeline declarativo
@@ -972,6 +1037,10 @@ versionable.
 - **`NetworkSpec` es un hook mínimo en v1** (modelo Pydantic ya consumido por `build`/`quick`); la
   carga desde YAML y la validación avanzada son del Hito 9. El símbolo público re-exportado desde
   `bib2graph` es `NetworkArtifact` (no `NetworkSpec`, que se importa desde `bib2graph.networks`).
+- **AS-BUILT #25 — artefactos decorados:** `_build_artifact` (en `facade.py`) aplica `decorate`
+  (§7.1) sobre el grafo, así que `build`/`quick` devuelven artefactos con `label` legible + atributos
+  de nodo (`year`/`is_seed`/`curation_status`/`degree_centrality`/`community`) listos para el export
+  y la GUI. Los proyectores (§7) siguen puros (ADR 0014).
 
 ---
 

--- a/docs/ROADMAP/04-lo-que-viene.md
+++ b/docs/ROADMAP/04-lo-que-viene.md
@@ -184,6 +184,16 @@ No se prometen ni se cablean clientes que no se usan.
 
 ## Backlog / ideas pendientes (sin hito ni DoD todavía)
 
+- **Labels legibles en los nodos de las redes (#25) · ✅ HECHO (2026-06-16):** las redes salían con
+  `id` crudo (`oa:…`, `I185261750`, un ORCID), ilegibles en Gephi/VOSviewer/Cytoscape (síntoma B3 de
+  la [Nota 09](../Notas/09-sesion-qa-prueba-ecologia-valoraciones.md)). Se agregó la **capa frontera
+  `decorate`** (`networks/decorate.py`: `decorate_graph`/`decorate`) entre los proyectores puros y el
+  export/GUI, aplicada en `facade.py:_build_artifact`: inyecta `label` legible (mapeo por
+  `NetworkKind`; paper → `"título (año)"` truncado a `LABEL_MAX_CHARS`=60) + atributos de nodo
+  (`year`/`is_seed`/`curation_status`/`degree_centrality`/`community`). `Networks.quick`/`build`
+  devuelven artefactos **decorados**; los proyectores **siguen puros** (ADR
+  [0014](../decisiones/0014-proyeccion-redes-pesos-asortatividad.md) AS-BUILT #25). Reemplaza el
+  workaround local `_label_for_kind` de `prueba/06_redes_y_grafos.py`. Ver API.md §7.1.
 - **Workspace por investigación · ✅ HECHO (2026-06-16, ADR
   [0029](../decisiones/0029-workspace-por-investigacion.md); issues #32/#38/#39):** cada investigación
   = una carpeta auto-contenida (`workspace.json` + `library.duckdb` + `networks/`/`snapshots/`/

--- a/docs/decisiones/0014-proyeccion-redes-pesos-asortatividad.md
+++ b/docs/decisiones/0014-proyeccion-redes-pesos-asortatividad.md
@@ -96,3 +96,23 @@ aproximación al número de países. El output marca el proxy con un disclaimer.
 - **Peso crudo, no normalizado:** simple y predecible, pero comparar densidades entre redes de
   distinto tamaño exige cuidado. Migrar a un peso normalizado (Salton/Jaccard) sería aditivo y
   reversible (parámetro extra del proyector), no rompe el contrato actual.
+
+## AS-BUILT — capa `decorate` separada de los proyectores (2026-06-16, #25)
+
+Al implementar el label legible en los nodos (#25; síntoma en la Nota 09 B3: las redes salían con
+`id` crudo —`oa:…`, `I185261750`, un ORCID— ilegibles en Gephi/VOSviewer/Cytoscape) se **confirmó
+la pureza de los proyectores de D2**: los proyectores (`networks/projectors.py`) **siguen siendo
+funciones puras sobre `pa.Table`** y **NO setean ningún atributo de nodo** (devuelven el grafo con
+ids crudos, sin `label`).
+
+La legibilidad y los atributos para export/GUI viven en una **capa de frontera separada**,
+`bib2graph.networks.decorate` (`decorate_graph`/`decorate`), aplicada en `facade.py:_build_artifact`
+—no en los proyectores—. Inyecta en los nodos: `label` (mapeo por `NetworkKind`: paper →
+`"título (año)"` truncado a `LABEL_MAX_CHARS`=60; autor/institución → nombre `*_raw` correlativo;
+keyword → la keyword), `degree_centrality` (todos) y, para paper, `year`/`is_seed`/`curation_status`;
+`community` opcional desde `artifact.communities`. Así `Networks.quick`/`build` devuelven artefactos
+**decorados** sin contaminar el núcleo puro de proyección. Contrato en API.md §7.1.
+
+Esta separación es coherente con D2 (el proyector solo decide qué entidad es el nodo) y con la
+convención del repo "núcleo puro vs frontera": la proyección no sabe de presentación. (Nota
+aditiva; no modifica la decisión original.)

--- a/src/bib2graph/networks/__init__.py
+++ b/src/bib2graph/networks/__init__.py
@@ -4,6 +4,7 @@ Reexporta los símbolos públicos del paquete de redes:
   - Proyectores (5 implementaciones + constante MIN_WEIGHT_DEFAULT).
   - Analizadores (funciones puras + QualityThresholds).
   - ``NetworkArtifact`` y ``Networks`` (facade de alto nivel).
+  - ``decorate`` / ``decorate_graph`` (capa de decoración de nodos, issue #25).
 
 Ver API.md §7-10.
 """
@@ -19,6 +20,7 @@ from bib2graph.networks.analyzer import (
     detect_communities,
     network_metrics,
 )
+from bib2graph.networks.decorate import decorate, decorate_graph
 from bib2graph.networks.facade import Networks
 from bib2graph.networks.projectors import (
     MIN_WEIGHT_DEFAULT,
@@ -47,6 +49,8 @@ __all__ = [
     "cocitation_quality_report",
     "collect_item_to_papers",
     "community_composition",
+    "decorate",
+    "decorate_graph",
     "detect_communities",
     "network_metrics",
 ]

--- a/src/bib2graph/networks/decorate.py
+++ b/src/bib2graph/networks/decorate.py
@@ -1,0 +1,282 @@
+"""decorate — inyección de label legible y atributos en los nodos de un grafo.
+
+Capa frontera entre proyectores puros y exportadores. Los proyectores producen
+``nx.Graph`` con ids crudos como nodos; ``decorate`` transforma esos ids en
+labels legibles (título, nombre de autor, keyword) y agrega atributos de
+curación/comunidad/centralidad.
+
+Reglas de diseño:
+- No muta el corpus ni la tabla Arrow.
+- Muta el grafo IN-PLACE (la copia ya la hace el llamador o el exporter).
+- Determinista: mismo corpus + mismo artifact → mismos atributos.
+- No importa duckdb (núcleo puro).
+
+Mapeo de label por ``NetworkKind``:
+  - ``bibliographic_coupling`` / ``cocitation``: nodo = paper id (Col.ID).
+    Label = ``"título (año)"`` (hasta LABEL_MAX_CHARS caracteres + "...").
+    Atributos extra: ``year``, ``is_seed``, ``curation_status``.
+  - ``author_collab``: nodo = authors_id. Label = nombre de author_raw
+    correlativo si es posible, si no el propio id.
+  - ``institution_collab``: nodo = institutions_id. Label = nombre de
+    institutions_raw correlativo si es posible.
+  - ``keyword_cooccurrence``: nodo = keywords_id. La keyword normalizada ya
+    es legible; se usa directamente como label.
+
+Atributos universales (todos los kinds):
+  - ``label``: string legible (ver mapeo arriba).
+  - ``degree_centrality``: float calculado con ``nx.degree_centrality``.
+
+Atributos adicionales de paper (coupling/cocitation):
+  - ``year``: int o ausente si None.
+  - ``is_seed``: bool.
+  - ``curation_status``: string.
+
+Atributo de comunidad (si se provee ``communities``):
+  - ``community``: int.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import networkx as nx
+import pyarrow as pa
+
+from bib2graph.constants import Col, NetworkKind
+
+if TYPE_CHECKING:
+    from bib2graph.networks.spec import NetworkArtifact
+
+    # nx.Graph es genérico solo en los stubs de types-networkx, no en runtime.
+    _Graph = nx.Graph[Any, Any, Any]
+else:
+    _Graph = nx.Graph
+
+# Límite de caracteres para el label de paper (título largo truncado)
+LABEL_MAX_CHARS: int = 60
+
+# Kinds de red cuyo nodo es un paper (Col.ID)
+_PAPER_KINDS: frozenset[str] = frozenset(
+    {NetworkKind.BIBLIOGRAPHIC_COUPLING, NetworkKind.COCITATION}
+)
+
+
+# ---------------------------------------------------------------------------
+# Índices internos: construidos una sola vez por llamada a decorate_graph
+# ---------------------------------------------------------------------------
+
+
+def _build_paper_index(table: pa.Table) -> dict[str, dict[str, object]]:
+    """Construye un índice ``{paper_id → {label, year, is_seed, curation_status}}``.
+
+    El label de paper es ``"título (año)"`` truncado a ``LABEL_MAX_CHARS`` chars.
+
+    Args:
+        table: Tabla Arrow canónica del Corpus.
+
+    Returns:
+        Dict con una entrada por fila; solo incluye papers con id no-None.
+    """
+    ids = table.column(Col.ID).to_pylist()
+    titles = table.column(Col.TITLE).to_pylist()
+    years = table.column(Col.YEAR).to_pylist()
+    is_seeds = table.column(Col.IS_SEED).to_pylist()
+    statuses = table.column(Col.CURATION_STATUS).to_pylist()
+
+    index: dict[str, dict[str, object]] = {}
+    for pid, title, year, is_seed, status in zip(
+        ids, titles, years, is_seeds, statuses, strict=False
+    ):
+        if pid is None:
+            continue
+        key = str(pid)
+        # Construir label
+        if title:
+            label = str(title)
+            if year is not None:
+                label = f"{label} ({year})"
+            if len(label) > LABEL_MAX_CHARS:
+                label = label[:LABEL_MAX_CHARS] + "..."
+        else:
+            label = key  # fallback al id crudo si no hay título
+
+        index[key] = {
+            "label": label,
+            "year": int(year) if year is not None else None,
+            "is_seed": bool(is_seed) if is_seed is not None else False,
+            "curation_status": str(status) if status is not None else None,
+        }
+    return index
+
+
+def _build_author_index(table: pa.Table) -> dict[str, str]:
+    """Construye un índice ``{authors_id → nombre display (authors_raw)}``.
+
+    Alinea ``authors_id[i]`` con ``authors_raw[i]`` de cada fila. Si el índice
+    ``i`` está fuera de rango en ``authors_raw``, se usa el propio id como label.
+
+    Args:
+        table: Tabla Arrow canónica del Corpus.
+
+    Returns:
+        Dict ``{author_id_str: display_name_str}``.
+    """
+    ids_col = table.column(Col.AUTHORS_ID).to_pylist()
+    raw_col = table.column(Col.AUTHORS_RAW).to_pylist()
+
+    index: dict[str, str] = {}
+    for ids, raws in zip(ids_col, raw_col, strict=False):
+        if not ids or not isinstance(ids, list):
+            continue
+        raw_list = raws if isinstance(raws, list) else []
+        for i, author_id in enumerate(ids):
+            if author_id is None:
+                continue
+            key = str(author_id)
+            if key not in index:
+                # Usar el nombre raw correlativo si existe
+                name = raw_list[i] if i < len(raw_list) and raw_list[i] else key
+                index[key] = str(name)
+    return index
+
+
+def _build_institution_index(table: pa.Table) -> dict[str, str]:
+    """Construye un índice ``{institutions_id → nombre display (institutions_raw)}``.
+
+    Alinea ``institutions_id[i]`` con ``institutions_raw[i]`` de cada fila.
+
+    Args:
+        table: Tabla Arrow canónica del Corpus.
+
+    Returns:
+        Dict ``{institution_id_str: display_name_str}``.
+    """
+    ids_col = table.column(Col.INSTITUTIONS_ID).to_pylist()
+    raw_col = table.column(Col.INSTITUTIONS_RAW).to_pylist()
+
+    index: dict[str, str] = {}
+    for ids, raws in zip(ids_col, raw_col, strict=False):
+        if not ids or not isinstance(ids, list):
+            continue
+        raw_list = raws if isinstance(raws, list) else []
+        for i, inst_id in enumerate(ids):
+            if inst_id is None:
+                continue
+            key = str(inst_id)
+            if key not in index:
+                name = raw_list[i] if i < len(raw_list) and raw_list[i] else key
+                index[key] = str(name)
+    return index
+
+
+# ---------------------------------------------------------------------------
+# API pública
+# ---------------------------------------------------------------------------
+
+
+def decorate_graph(
+    graph: _Graph,
+    table: pa.Table,
+    kind: str,
+    *,
+    communities: dict[Any, int] | None = None,
+) -> None:
+    """Inyecta atributos legibles en los nodos del grafo IN-PLACE.
+
+    No copia el grafo; el llamador debe copiar antes si necesita preservar
+    el original (``graph.copy()``).
+
+    Atributos inyectados siempre:
+      - ``label``: string legible según el kind (ver docstring del módulo).
+      - ``degree_centrality``: float.
+
+    Atributos adicionales para redes de paper (coupling/cocitation):
+      - ``year``: int o ausente si None en el corpus.
+      - ``is_seed``: bool.
+      - ``curation_status``: string.
+
+    Atributo de comunidad (si se provee ``communities``):
+      - ``community``: int.
+
+    Args:
+        graph: Grafo NetworkX a decorar (modificado in-place).
+        table: Tabla Arrow del Corpus (fuente de metadatos).
+        kind: ``NetworkKind`` de la red (determina el mapeo de label).
+        communities: Dict opcional ``{nodo: int}`` de la detección de
+            comunidades. Si es None, no se escribe el atributo ``community``.
+    """
+    if graph.number_of_nodes() == 0:
+        return
+
+    # Centralidad de grado (una sola llamada, determinista)
+    deg_centrality: dict[Any, float] = nx.degree_centrality(graph)
+
+    # Construir índices según kind
+    if kind in _PAPER_KINDS:
+        paper_index = _build_paper_index(table)
+        for node in graph.nodes():
+            key = str(node)
+            info = paper_index.get(key, {})
+            graph.nodes[node]["label"] = str(info.get("label", key))
+            graph.nodes[node]["degree_centrality"] = deg_centrality.get(node, 0.0)
+            # Atributos extra de paper: solo si están disponibles
+            year = info.get("year")
+            if isinstance(year, int):
+                graph.nodes[node]["year"] = year
+            is_seed = info.get("is_seed")
+            if isinstance(is_seed, bool):
+                graph.nodes[node]["is_seed"] = is_seed
+            curation = info.get("curation_status")
+            if curation is not None:
+                graph.nodes[node]["curation_status"] = str(curation)
+
+    elif kind == NetworkKind.AUTHOR_COLLAB:
+        author_index = _build_author_index(table)
+        for node in graph.nodes():
+            key = str(node)
+            graph.nodes[node]["label"] = author_index.get(key, key)
+            graph.nodes[node]["degree_centrality"] = deg_centrality.get(node, 0.0)
+
+    elif kind == NetworkKind.INSTITUTION_COLLAB:
+        inst_index = _build_institution_index(table)
+        for node in graph.nodes():
+            key = str(node)
+            graph.nodes[node]["label"] = inst_index.get(key, key)
+            graph.nodes[node]["degree_centrality"] = deg_centrality.get(node, 0.0)
+
+    elif kind == NetworkKind.KEYWORD_COOCCURRENCE:
+        # La keyword normalizada ya es legible; se usa directamente como label.
+        for node in graph.nodes():
+            graph.nodes[node]["label"] = str(node)
+            graph.nodes[node]["degree_centrality"] = deg_centrality.get(node, 0.0)
+
+    else:
+        # Kind desconocido: fallback al id crudo (no fallar; es extensible)
+        for node in graph.nodes():
+            graph.nodes[node]["label"] = str(node)
+            graph.nodes[node]["degree_centrality"] = deg_centrality.get(node, 0.0)
+
+    # Comunidades (opcional, todos los kinds)
+    if communities is not None:
+        for node, comm_id in communities.items():
+            if graph.has_node(node):
+                graph.nodes[node]["community"] = int(comm_id)
+
+
+def decorate(artifact: NetworkArtifact, table: pa.Table) -> None:
+    """Decora el grafo del artefacto IN-PLACE con labels y atributos de nodo.
+
+    Atajo sobre ``decorate_graph`` que extrae kind y communities del
+    ``NetworkArtifact`` directamente.  Es el punto de integración en
+    ``facade.py``.
+
+    Args:
+        artifact: ``NetworkArtifact`` cuyo ``graph`` se decorará in-place.
+        table: Tabla Arrow del Corpus (fuente de metadatos).
+    """
+    decorate_graph(
+        artifact.graph,
+        table,
+        artifact.spec.kind,
+        communities=artifact.communities,
+    )

--- a/src/bib2graph/networks/facade.py
+++ b/src/bib2graph/networks/facade.py
@@ -20,6 +20,7 @@ import networkx as nx
 
 from bib2graph.constants import NetworkKind
 from bib2graph.networks.analyzer import detect_communities, network_metrics
+from bib2graph.networks.decorate import decorate
 from bib2graph.networks.projectors import (
     AuthorCollaborationProjector,
     BibliographicCouplingProjector,
@@ -163,7 +164,7 @@ def _build_artifact(corpus: Corpus, spec: NetworkSpec) -> NetworkArtifact:
         except ImportError:
             raise  # dep faltante: fallar fuerte (lección 7, AGENTS.md)
 
-    return NetworkArtifact(
+    artifact = NetworkArtifact(
         graph=g,
         metrics=metrics,
         communities=communities,
@@ -171,6 +172,14 @@ def _build_artifact(corpus: Corpus, spec: NetworkSpec) -> NetworkArtifact:
         layout=None,
         spec=spec,
     )
+
+    # Decorar el grafo con labels legibles y atributos de nodo (issue #25).
+    # Se hace aquí, en la frontera de construcción, para que todos los
+    # exportadores (GraphML, CSV) y el CLI reciban artefactos ya decorados
+    # sin necesitar conocer el corpus.
+    decorate(artifact, table)
+
+    return artifact
 
 
 class Networks:

--- a/tests/unit/test_decorate.py
+++ b/tests/unit/test_decorate.py
@@ -1,0 +1,473 @@
+"""Tests de la capa decorate — issue #25.
+
+Verifica:
+- ``decorate_graph`` inyecta ``label`` correcto por ``NetworkKind``.
+- Atributos ``year``/``is_seed``/``curation_status``/``degree_centrality`` presentes
+  en nodos de paper.
+- Atributo ``community`` presente cuando se pasa ``communities``.
+- Round-trip GraphML: exportar grafo decorado → releer → nodos tienen ``label``
+  legible (no el id crudo).
+- Los proyectores siguen puros (sin ``label``) — la decoración es aparte.
+- Determinismo: mismo corpus → mismos atributos.
+
+Marcador: ``unit`` (sin red, sin I/O).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import networkx as nx
+import pyarrow as pa
+import pytest
+
+from bib2graph.constants import NetworkKind
+from bib2graph.corpus import Corpus
+from bib2graph.networks.decorate import LABEL_MAX_CHARS, decorate, decorate_graph
+from bib2graph.networks.facade import Networks
+from bib2graph.networks.projectors import (
+    AuthorCollaborationProjector,
+    BibliographicCouplingProjector,
+    KeywordCoOccurrenceProjector,
+)
+from bib2graph.networks.spec import NetworkSpec
+from bib2graph.schemas import CORPUS_SCHEMA
+
+# ---------------------------------------------------------------------------
+# Fixture — corpus sintético con datos suficientes para todos los kinds
+# ---------------------------------------------------------------------------
+
+
+def _make_table() -> pa.Table:
+    """Tabla Arrow sintética con 3 papers que comparten referencias, autores y keywords."""
+    rows = [
+        {
+            "id": "P0",
+            "openalex_id": None,
+            "doi": None,
+            "title": "Artículo cero",
+            "year": 2020,
+            "abstract": None,
+            "source": None,
+            "language": None,
+            "publisher": None,
+            "research_areas": None,
+            "is_seed": True,
+            "curation_status": "accepted",
+            "provenance": None,
+            "authors_raw": ["Autor Uno", "Autor Dos"],
+            "authors_id": ["auth_1", "auth_2"],
+            "authors_affiliations": None,
+            "keywords_raw": None,
+            "keywords_id": ["machine_learning", "redes"],
+            "institutions_raw": ["Univ. A"],
+            "institutions_id": ["inst_a"],
+            "references_id": ["R_shared", "R_x"],
+            "references_doi": None,
+            "cited_by_id": None,
+        },
+        {
+            "id": "P1",
+            "openalex_id": None,
+            "doi": None,
+            "title": "Artículo uno",
+            "year": 2021,
+            "abstract": None,
+            "source": None,
+            "language": None,
+            "publisher": None,
+            "research_areas": None,
+            "is_seed": True,
+            "curation_status": "candidate",
+            "provenance": None,
+            "authors_raw": ["Autor Uno", "Autor Tres"],
+            "authors_id": ["auth_1", "auth_3"],
+            "authors_affiliations": None,
+            "keywords_raw": None,
+            "keywords_id": ["machine_learning", "grafos"],
+            "institutions_raw": ["Univ. B"],
+            "institutions_id": ["inst_b"],
+            "references_id": ["R_shared", "R_y"],
+            "references_doi": None,
+            "cited_by_id": None,
+        },
+        {
+            "id": "P2",
+            "openalex_id": None,
+            "doi": None,
+            "title": "Artículo dos",
+            "year": 2022,
+            "abstract": None,
+            "source": None,
+            "language": None,
+            "publisher": None,
+            "research_areas": None,
+            "is_seed": False,
+            "curation_status": "rejected",
+            "provenance": None,
+            "authors_raw": ["Autor Dos", "Autor Tres"],
+            "authors_id": ["auth_2", "auth_3"],
+            "authors_affiliations": None,
+            "keywords_raw": None,
+            "keywords_id": ["redes", "grafos"],
+            "institutions_raw": ["Univ. A", "Univ. B"],
+            "institutions_id": ["inst_a", "inst_b"],
+            "references_id": ["R_shared", "R_z"],
+            "references_doi": None,
+            "cited_by_id": None,
+        },
+    ]
+    return pa.Table.from_pylist(rows, schema=CORPUS_SCHEMA)
+
+
+def _make_corpus() -> Corpus:
+    return Corpus.from_arrow(_make_table())
+
+
+# ---------------------------------------------------------------------------
+# label por kind — un caso por tipo
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_label_paper_titulo_anio() -> None:
+    """Nodo paper → label = 'título (año)'."""
+    table = _make_table()
+    projector = BibliographicCouplingProjector()
+    g = projector.project(table)
+    # Los 3 papers comparten R_shared → hay aristas; P0-P1, P0-P2, P1-P2
+    assert g.number_of_nodes() > 0, "el grafo de acoplamiento debe tener nodos"
+
+    decorate_graph(g, table, NetworkKind.BIBLIOGRAPHIC_COUPLING)
+
+    for node in g.nodes():
+        label = g.nodes[node]["label"]
+        # El label nunca debe ser el id crudo (ej. "P0")
+        assert label != str(node), f"label crudo en nodo {node!r}: {label!r}"
+        # Debe contener el año entre paréntesis
+        assert "(" in label and ")" in label, f"label sin año: {label!r}"
+
+
+@pytest.mark.unit
+def test_label_autor_nombre() -> None:
+    """Nodo autor → label = nombre display (authors_raw correlativo)."""
+    table = _make_table()
+    projector = AuthorCollaborationProjector()
+    g = projector.project(table)
+    assert g.number_of_nodes() > 0
+
+    decorate_graph(g, table, NetworkKind.AUTHOR_COLLAB)
+
+    # auth_1 aparece en P0 y P1; authors_raw[0] = "Autor Uno"
+    assert "auth_1" in g.nodes
+    label = g.nodes["auth_1"]["label"]
+    assert label == "Autor Uno", f"label inesperado: {label!r}"
+
+
+@pytest.mark.unit
+def test_label_keyword_es_la_keyword() -> None:
+    """Nodo keyword → label = la keyword misma (keywords_id ya es legible)."""
+    table = _make_table()
+    projector = KeywordCoOccurrenceProjector()
+    g = projector.project(table)
+    assert g.number_of_nodes() > 0
+
+    decorate_graph(g, table, NetworkKind.KEYWORD_COOCCURRENCE)
+
+    for node in g.nodes():
+        label = g.nodes[node]["label"]
+        # Para keywords el label debe ser idéntico al nodo (es la keyword)
+        assert label == str(node), (
+            f"label de keyword no coincide: {label!r} vs {node!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Atributos extra en nodos de paper
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_atributos_extra_en_nodos_paper() -> None:
+    """Nodos de red de paper tienen year, is_seed, curation_status, degree_centrality."""
+    table = _make_table()
+    projector = BibliographicCouplingProjector()
+    g = projector.project(table)
+
+    decorate_graph(g, table, NetworkKind.BIBLIOGRAPHIC_COUPLING)
+
+    for node in g.nodes():
+        attrs = g.nodes[node]
+        assert "year" in attrs, f"year falta en nodo {node!r}"
+        assert isinstance(attrs["year"], int)
+        assert "is_seed" in attrs, f"is_seed falta en nodo {node!r}"
+        assert isinstance(attrs["is_seed"], bool)
+        assert "curation_status" in attrs, f"curation_status falta en nodo {node!r}"
+        assert "degree_centrality" in attrs, f"degree_centrality falta en nodo {node!r}"
+        assert isinstance(attrs["degree_centrality"], float)
+
+
+@pytest.mark.unit
+def test_atributo_community_presente() -> None:
+    """El atributo community se inyecta cuando se pasa communities."""
+    table = _make_table()
+    projector = BibliographicCouplingProjector()
+    g = projector.project(table)
+
+    # Comunidades sintéticas
+    communities = {node: idx % 2 for idx, node in enumerate(g.nodes())}
+    decorate_graph(
+        g, table, NetworkKind.BIBLIOGRAPHIC_COUPLING, communities=communities
+    )
+
+    for node in g.nodes():
+        assert "community" in g.nodes[node], f"community falta en nodo {node!r}"
+        assert isinstance(g.nodes[node]["community"], int)
+
+
+@pytest.mark.unit
+def test_sin_community_sin_atributo() -> None:
+    """Sin communities=None, el atributo community no aparece en los nodos."""
+    table = _make_table()
+    projector = BibliographicCouplingProjector()
+    g = projector.project(table)
+
+    decorate_graph(g, table, NetworkKind.BIBLIOGRAPHIC_COUPLING, communities=None)
+
+    for node in g.nodes():
+        assert "community" not in g.nodes[node], f"community inesperado en {node!r}"
+
+
+# ---------------------------------------------------------------------------
+# Round-trip GraphML
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_round_trip_graphml_label_legible(tmp_path: Path) -> None:
+    """Exportar grafo decorado → releer GraphML → nodos tienen label legible."""
+    table = _make_table()
+    projector = BibliographicCouplingProjector()
+    g = projector.project(table)
+    decorate_graph(g, table, NetworkKind.BIBLIOGRAPHIC_COUPLING)
+
+    # Exportar
+    out_file = tmp_path / "network.graphml"
+    nx.write_graphml(g, str(out_file))
+
+    # Releer
+    g2 = nx.read_graphml(str(out_file))
+
+    for _node_id, data in g2.nodes(data=True):
+        label = data.get("label", "")
+        # El label no debe ser el id crudo; debe contener año
+        assert "(" in label, f"label sin año tras round-trip: {label!r}"
+        assert ")" in label
+
+
+# ---------------------------------------------------------------------------
+# Proyectores siguen puros (sin label)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_proyectores_son_puros_sin_label() -> None:
+    """BibliographicCouplingProjector.project() NO setea label en los nodos.
+
+    La decoración es responsabilidad exclusiva de decorate_graph, no del
+    proyector (separación de capas, issue #25).
+    """
+    table = _make_table()
+    projector = BibliographicCouplingProjector()
+    g = projector.project(table)
+
+    for node in g.nodes():
+        assert "label" not in g.nodes[node], (
+            f"Proyector no debe setear label; lo encontró en nodo {node!r}"
+        )
+
+
+@pytest.mark.unit
+def test_proyector_autor_puro_sin_label() -> None:
+    """AuthorCollaborationProjector.project() NO setea label en los nodos."""
+    table = _make_table()
+    projector = AuthorCollaborationProjector()
+    g = projector.project(table)
+
+    for node in g.nodes():
+        assert "label" not in g.nodes[node], (
+            f"Proyector no debe setear label; lo encontró en nodo {node!r}"
+        )
+
+
+@pytest.mark.unit
+def test_proyector_keyword_puro_sin_label() -> None:
+    """KeywordCoOccurrenceProjector.project() NO setea label en los nodos."""
+    table = _make_table()
+    projector = KeywordCoOccurrenceProjector()
+    g = projector.project(table)
+
+    for node in g.nodes():
+        assert "label" not in g.nodes[node], (
+            f"Proyector no debe setear label; lo encontró en nodo {node!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Determinismo
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_decorate_es_determinista() -> None:
+    """Mismo corpus → mismos atributos de nodo (dos llamadas independientes)."""
+    table = _make_table()
+
+    projector = BibliographicCouplingProjector()
+
+    g1 = projector.project(table)
+    decorate_graph(g1, table, NetworkKind.BIBLIOGRAPHIC_COUPLING)
+
+    g2 = projector.project(table)
+    decorate_graph(g2, table, NetworkKind.BIBLIOGRAPHIC_COUPLING)
+
+    for node in g1.nodes():
+        assert g1.nodes[node] == g2.nodes[node], (
+            f"Atributos no deterministas en nodo {node!r}: "
+            f"{g1.nodes[node]!r} vs {g2.nodes[node]!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Integración: Networks.quick produce artefactos decorados
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_networks_quick_artefactos_decorados() -> None:
+    """Networks.quick devuelve artefactos con label en todos los nodos."""
+    corpus = _make_corpus()
+    artifacts = Networks.quick(corpus)
+
+    for art in artifacts:
+        for node in art.graph.nodes():
+            assert "label" in art.graph.nodes[node], (
+                f"Nodo {node!r} sin label en red {art.spec.kind!r}"
+            )
+
+
+@pytest.mark.unit
+def test_networks_build_artefacto_decorado() -> None:
+    """Networks.build produce un artefacto con label en todos los nodos."""
+    corpus = _make_corpus()
+    spec = NetworkSpec(kind=NetworkKind.AUTHOR_COLLAB, clustering=None)
+    art = Networks.build(corpus, spec)
+
+    for node in art.graph.nodes():
+        assert "label" in art.graph.nodes[node], (
+            f"Nodo {node!r} sin label tras Networks.build"
+        )
+
+
+# ---------------------------------------------------------------------------
+# decorate (función de alto nivel sobre NetworkArtifact)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_decorate_sobre_artifact() -> None:
+    """decorate(artifact, table) decora el grafo del artifact correctamente."""
+    from bib2graph.networks.spec import NetworkArtifact, NetworkSpec
+
+    table = _make_table()
+    projector = BibliographicCouplingProjector()
+    g = projector.project(table)
+
+    spec = NetworkSpec(kind=NetworkKind.BIBLIOGRAPHIC_COUPLING, clustering=None)
+    artifact = NetworkArtifact(
+        graph=g,
+        metrics={},
+        communities=None,
+        assortativity=None,
+        layout=None,
+        spec=spec,
+    )
+
+    decorate(artifact, table)
+
+    for node in artifact.graph.nodes():
+        assert "label" in artifact.graph.nodes[node]
+
+
+# ---------------------------------------------------------------------------
+# Truncado de título largo
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_label_paper_truncado_si_titulo_largo() -> None:
+    """Labels de paper con título largo se truncan a LABEL_MAX_CHARS + '...'."""
+    titulo_largo = "A" * (LABEL_MAX_CHARS + 20)
+    rows = [
+        {
+            "id": "PL",
+            "openalex_id": None,
+            "doi": None,
+            "title": titulo_largo,
+            "year": 2023,
+            "abstract": None,
+            "source": None,
+            "language": None,
+            "publisher": None,
+            "research_areas": None,
+            "is_seed": True,
+            "curation_status": "accepted",
+            "provenance": None,
+            "authors_raw": None,
+            "authors_id": ["auth_x"],
+            "authors_affiliations": None,
+            "keywords_raw": None,
+            "keywords_id": None,
+            "institutions_raw": None,
+            "institutions_id": None,
+            "references_id": ["R_only"],
+            "references_doi": None,
+            "cited_by_id": None,
+        },
+        {
+            "id": "PL2",
+            "openalex_id": None,
+            "doi": None,
+            "title": "Otro",
+            "year": 2023,
+            "abstract": None,
+            "source": None,
+            "language": None,
+            "publisher": None,
+            "research_areas": None,
+            "is_seed": True,
+            "curation_status": "accepted",
+            "provenance": None,
+            "authors_raw": None,
+            "authors_id": ["auth_y"],
+            "authors_affiliations": None,
+            "keywords_raw": None,
+            "keywords_id": None,
+            "institutions_raw": None,
+            "institutions_id": None,
+            "references_id": ["R_only"],
+            "references_doi": None,
+            "cited_by_id": None,
+        },
+    ]
+    table = pa.Table.from_pylist(rows, schema=CORPUS_SCHEMA)
+    projector = BibliographicCouplingProjector()
+    g = projector.project(table)
+    assert "PL" in g.nodes
+
+    decorate_graph(g, table, NetworkKind.BIBLIOGRAPHIC_COUPLING)
+
+    label = g.nodes["PL"]["label"]
+    assert label.endswith("..."), f"label largo no truncado: {label!r}"
+    # El label truncado tiene exactamente LABEL_MAX_CHARS chars + "..."
+    assert len(label) == LABEL_MAX_CHARS + 3


### PR DESCRIPTION
Cierra **#25**: las redes ahora salen con `label` legible + atributos (year/is_seed/curation_status/community/degree_centrality) vía una capa `decorate` de frontera (`networks/decorate.py`), cableada en `facade._build_artifact`. Los proyectores siguen **puros** (ADR 0014). Round-trip GraphML verificado. verifier **PASA**, **437 tests**, 0 enlaces rotos. Docs: API.md §7.1, ADR 0014 AS-BUILT.