### PR TITLE
feat(sources/cli): seed --max-results + negaciones --exclude (#14/#30)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@
   scent bibliométrico), `preprocessors/` (normalize + thesaurus), `filters/` (PRISMA),
   `networks/` (proyectores, analyzer, spec, facade), `exporters/` (GraphML, CSV) y `cli/`.
   El **CLI `b2g` es real** —paquete `cli/` con 15 subcomandos en `cli/commands/`, no un
-  placeholder—. **459 tests verdes** (mypy/ruff limpios; el núcleo importa sin `duckdb`).
+  placeholder—. **476 tests verdes** (mypy/ruff limpios; el núcleo importa sin `duckdb`).
 - **Hito 8 COMPLETO** (Ciclos 8a + 8b, ADR
   [0025](docs/decisiones/0025-enricher-cocitacion-openalex.md)): el `OpenAlexEnricher` (opt-in,
   núcleo) hace 2 pasadas — **refs→DOI** (8a) **+ co-citación end-to-end** (8b): pobla `cited_by_id`
@@ -87,8 +87,15 @@
   ignorado al importar); `scent_score` best-effort, `cluster` diferido. **Curación transversal** (NO
   transiciona el `CycleState`). Cierra el hueco de la
   [Nota 09](docs/Notas/09-sesion-qa-prueba-ecologia-valoraciones.md) B4/B5/P1 (sin dump CSV ni reimport
-  en lote, la curación a escala no era viable). **459 tests verdes**, 15 subcomandos. Ver
+  en lote, la curación a escala no era viable). **476 tests verdes**, 15 subcomandos. Ver
   `docs/API.md` §convenciones CLI.
+- **Ergonomía de `b2g seed` (#14 + #30, 2026-06-16):** **`--max-results INT`** propaga a
+  `OpenAlexSource(max_results=...)` (sin flag = default 200) para explorar con muestras chicas;
+  **`--exclude TEXT`** (repetible) son negaciones quirúrgicas que agregan
+  `AND NOT title_and_abstract.search:"<término>"` por término al filtro y se **reportan en el
+  `translation_report`** del `SeedResult` (query visible, ignorado con `--native`). Cierra el síntoma
+  B1 de la [Nota 09](docs/Notas/09-sesion-qa-prueba-ecologia-valoraciones.md). **476 tests verdes**.
+  Ver `docs/API.md` §2 + §convenciones CLI.
 - Toda la información del producto, la arquitectura, los contratos y la secuencia de
   construcción está en `docs/`. **Leer `docs/ROADMAP/` antes de tocar nada**: cada hito declara
   qué historias del PRD §7 cumple, sus criterios de aceptación (DoD) y los tests TDD que se

--- a/docs/API.md
+++ b/docs/API.md
@@ -113,6 +113,12 @@ pre-v0.3; el 13° `enrich` en el Ciclo 8a, ADR
   `schema="1"`. **AS-BUILT workspace (ADR 0029):** `status` suma el campo aditivo
   `workspace: {root, source}` (la raíz resuelta y de dónde salió — flag/env/cwd); `schema="1"`
   intacto. `inspect`, `validate`.
+- **`seed`** (flags ergonómicos, #14 + #30): **`--max-results INT`** propaga a
+  `OpenAlexSource(max_results=...)` —sin flag, el default del source = 200— para exploración con
+  muestras chicas (Nota 09 B1). **`--exclude TEXT`** (repetible) son **negaciones quirúrgicas**:
+  cada término agrega `AND NOT title_and_abstract.search:"<término>"` al filtro y queda en el
+  `translation_report` del `SeedResult` (ejercicio consciente, query visible). Ignorado con
+  `--native` (query cruda).
 - **`accept`** / **`reject`** (decisión del PO, ADR 0021 §A): curación programática por `--ids`,
   ahora **subcomandos CLI de primera clase** (no solo API de librería), para que un agente cure la
   biblioteca viva por subprocess (historia C4). **AS-BUILT #22/#26:** la curación **a escala** ya no es
@@ -520,22 +526,26 @@ class Source(Protocol):
     Debe entregar el MÍNIMO UNIVERSAL (id, title, year, authors_raw, keywords_raw); el
     enriquecimiento (refs/citantes/afiliaciones/instituciones) es OPCIONAL (ADR 0018)."""
 
-    def seed(self, query: str) -> "SeedResult":
+    def seed(self, query: str, *, exclude: list[str] | None = None) -> "SeedResult":
         """Siembra desde una ecuación de búsqueda. Devuelve el Corpus + la query ejecutada
         y el reporte de traducción (qué mapeó, qué se aproximó, qué se descartó).
-        Una Source que no siembra por ecuación (p. ej. BibtexSource) lanza NotImplementedError."""
+        `exclude` (negaciones quirúrgicas, opcional): cada término agrega
+        `AND NOT title_and_abstract.search:"<término>"` al filtro y se REPORTA en el
+        translation_report (query visible, ejercicio consciente). Las comillas internas del
+        término se sanean. Ignorado con `native=True` (query cruda). Una Source que no siembra
+        por ecuación (p. ej. BibtexSource) lanza NotImplementedError."""
     def load(self, path: str) -> Corpus:
         """Siembra desde un archivo (export/pearls). is_seed=True."""
 
 class SeedResult(BaseModel):
     corpus: Corpus
     executed_query: str        # la query OpenAlex EXACTA ejecutada (consciencia, ADR 0007)
-    translation_report: list[str]   # mapeos limpios / aproximados / descartados (p. ej. NEAR no soportado)
+    translation_report: list[str]   # mapeos limpios / aproximados / descartados (p. ej. NEAR no soportado) + negaciones aplicadas (exclude, #30)
 ```
 
 | Implementación | Estado | Notas |
 |----------------|--------|-------|
-| `OpenAlexSource` | **v1 (construido, Hito 4)** | **Referencia/backbone**, sobre `httpx`. Entrega mínimo + enriquecimiento: refs inline + afiliaciones per-autor + instituciones; `cited_by_id` queda **diferido** al chaining/`Enricher` (no se trae en el seed). Traducción **passthrough** —envuelve la ecuación en `title_and_abstract.search:(...)` y **reporta** los límites WoS (NEAR/comodín/tags) sin traducirlos; el traductor WoS→OpenAlex es v0.2. Flag `native=True` (query cruda). Credenciales inyectadas (arg → `OPENALEX_API_KEY` → `~/.openalex/credentials` → polite pool; ADR 0012). Cursor paging con tope `max_results=200`. Puebla `Manifest.openalex_version` (header o fecha del fetch; ADR 0017). `transport` inyectable (tests con `MockTransport`, sin red en CI). |
+| `OpenAlexSource` | **v1 (construido, Hito 4)** | **Referencia/backbone**, sobre `httpx`. Entrega mínimo + enriquecimiento: refs inline + afiliaciones per-autor + instituciones; `cited_by_id` queda **diferido** al chaining/`Enricher` (no se trae en el seed). Traducción **passthrough** —envuelve la ecuación en `title_and_abstract.search:(...)` y **reporta** los límites WoS (NEAR/comodín/tags) sin traducirlos; el traductor WoS→OpenAlex es v0.2. Flag `native=True` (query cruda). **Negaciones (`exclude`, #30):** `seed(..., exclude=[...])` y `_translate(exclude=...)` agregan `AND NOT title_and_abstract.search:"<término>"` por término al filtro y lo **reportan en el `translation_report`** (query visible); comillas internas saneadas; **ignorado con `native=True`**. *(La sintaxis NOT no se validó contra la API real —mock—; es plausible/coherente con el passthrough.)* Credenciales inyectadas (arg → `OPENALEX_API_KEY` → `~/.openalex/credentials` → polite pool; ADR 0012). Cursor paging con tope `max_results` (param de `__init__`, default 200; **`b2g seed --max-results INT`** lo propaga para exploración con muestras chicas, Nota 09 B1). Puebla `Manifest.openalex_version` (header o fecha del fetch; ADR 0017). `transport` inyectable (tests con `MockTransport`, sin red en CI). |
 | `BibtexSource` | **v1, secundaria (construido, Hito 4)** | Sembrar desde *pearls* vía `load()`. Extra **`[bibtex]`** (import perezoso de `bibtexparser`, ADR 0005); acceso defensivo (fix del bug T1: campos faltantes sin `KeyError`). Mínimo universal. `seed()` lanza `NotImplementedError` (BibTeX no siembra por ecuación). **R5:** un `.bib` con error de parseo grave → `ValueError` accionable (antes lo tragaba en silencio); un `.bib` sin entradas válidas / con entradas omitidas por falta de título → `UserWarning` (no no-op silencioso). Carga bulk con `from_arrow`. |
 | `ScieloSource` / `RedalycSource` / `LaReferenciaSource` | futuro | Fuentes regionales, mínimo universal. Declaradas, no implementadas (ADR 0018). |
 | `RisSource` / `CsvSource` | futuro | No implementados. |
@@ -1187,7 +1197,9 @@ JSON por comando:
 ```bash
 b2g init ied                                    # crea ./ied/ (workspace.json + library.duckdb + networks/…)
 cd ied                                           # a partir de acá el workspace se resuelve por cwd
-b2g seed --equation '"unequal ecological exchange"' --email luis@sostaina.com --json
+b2g seed --equation '"unequal ecological exchange"' --max-results 50 \
+         --exclude "blockchain" --exclude "machine learning" \
+         --email luis@sostaina.com --json   # --max-results: muestra chica · --exclude (repetible): negaciones, quedan en el translation_report
 b2g chain --direction both --max-candidates 300 --max-citing 50 --json
 b2g filter --year-gte 2010 --language en --language es --json
 b2g accept --ids oa:abc123 --ids oa:def456 --json

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -135,7 +135,10 @@ No es una herramienta para usuario final no técnico: no hay GUI ni servicio web
 - **Consciente, no caja negra.** La ecuación de búsqueda es **ciudadana de primera clase**: se
   traduce a una query OpenAlex, se **muestra la query exacta ejecutada** y un **reporte de
   traducción** (qué mapeó limpio, qué se aproximó, qué se descartó). Eso *es* el ejercicio
-  bibliotecario y lo que hace el resultado reportable (PRISMA / vom Brocke).
+  bibliotecario y lo que hace el resultado reportable (PRISMA / vom Brocke). Las **exclusiones
+  quirúrgicas** (`b2g seed --exclude`, negaciones `AND NOT …` por término) son parte de ese
+  ejercicio consciente: quedan en el reporte de traducción, no se aplican en silencio. Para
+  exploración con muestras chicas, `--max-results` acota el fetch.
 - **Biblioteca viva, no mapa one-shot.** El corpus se cura y crece en el tiempo (berry growing),
   persistido en DuckDB. El investigador **posee** su colección.
 - **Forrajeo asistido.** Chaining backward/forward sobre OpenAlex, con candidatos **rankeados
@@ -170,7 +173,10 @@ No es una herramienta para usuario final no técnico: no hay GUI ni servicio web
   parciales y lo **reportan** (no fallan). El **reporte de cobertura/calidad** por seed/source se
   **declara** como contrato en V1 y se concreta en **v0.2+**.
 - **Traducción** de la ecuación a query OpenAlex con **query ejecutada visible + reporte de
-  traducción**, ambas **registradas** con la corrida.
+  traducción**, ambas **registradas** con la corrida. Incluye **negaciones quirúrgicas**
+  (`b2g seed --exclude`, repetible: `AND NOT title_and_abstract.search:"…"` por término) que se
+  **reportan en el reporte de traducción** (ejercicio consciente, no silencioso), y
+  **`--max-results`** para acotar el fetch en exploración con muestras chicas.
 - **Chaining asistido** backward/forward sobre OpenAlex; **profundidad 1 por defecto**, opt-in a
   2, con **preview de crecimiento** ("esta expansión sumaría ~N papers") y **tope** configurable.
 - **Ranking por estructura** (acoplamiento/co-citación, centralidad) de los candidatos —

--- a/docs/ROADMAP/04-lo-que-viene.md
+++ b/docs/ROADMAP/04-lo-que-viene.md
@@ -222,6 +222,17 @@ No se prometen ni se cablean clientes que no se usan.
   best-effort (vacío hasta que el Forager guarde scent en provenance) y `cluster` diferido (integración
   con redes). Gate verde, **459 tests**. Ver `API.md` §convenciones CLI.
 
+- **Ergonomía de `b2g seed` (#14 `--max-results` + #30 `--exclude`) · ✅ HECHO (2026-06-16):** dos
+  flags que afinan el seed sin tocar el contrato `Source`. **`--max-results INT` (#14)** propaga a
+  `OpenAlexSource(max_results=...)` (sin flag = default del source, 200) para explorar con muestras
+  chicas (síntoma B1 de la [Nota 09](../Notas/09-sesion-qa-prueba-ecologia-valoraciones.md)).
+  **`--exclude TEXT` repetible (#30)** son **negaciones quirúrgicas**: `seed(..., exclude=[...])` y
+  `_translate(exclude=...)` agregan `AND NOT title_and_abstract.search:"<término>"` por término al
+  filtro y las **reportan en el `translation_report`** del `SeedResult` (ejercicio consciente, query
+  visible); comillas internas saneadas; **ignorado con `native=True`**. *(La sintaxis NOT no se validó
+  contra la API real —mock—; plausible/coherente con el passthrough.)* Gate verde, **476 tests**. Ver
+  `API.md` §2 + §convenciones CLI.
+
 > **RETIRADO del producto (ADR [0022](../decisiones/0022-producto-sin-ia-generativa.md), 2026-06-15):**
 > el **fallback fuzzy/semántico del thesaurus por LLM** y la **"máquina de tensiones"** (la antigua
 > "inserción de IA nº2") **ya no son costuras futuras: se borran**. El producto **no usa IA

--- a/src/bib2graph/cli/commands/seed.py
+++ b/src/bib2graph/cli/commands/seed.py
@@ -31,6 +31,8 @@ def run_seed(
     native: bool = False,
     email: str | None = None,
     transport: Any = None,
+    max_results: int | None = None,
+    exclude: list[str] | None = None,
 ) -> dict[str, Any]:
     """Siembra el corpus desde OpenAlex y persiste en el store.
 
@@ -43,6 +45,10 @@ def run_seed(
         native: Si es ``True``, pasa la ecuación cruda a OpenAlex sin traducir.
         email: Email para el polite pool de OpenAlex.
         transport: Transport inyectable para tests (``httpx.MockTransport``).
+        max_results: Tope de resultados a traer de OpenAlex (#14).  ``None``
+            usa el default del source (200).
+        exclude: Términos a excluir del título/abstract vía ``AND NOT`` (#30).
+            ``None`` o lista vacía = sin exclusiones.
 
     Returns:
         Dict con ``executed_query``, ``translation_report``, ``papers_added``.
@@ -72,9 +78,14 @@ def run_seed(
         # Primera siembra
         new_state, new_round = apply_transition(None, "seed", current_round)
 
+    # Construir kwargs opcionales para OpenAlexSource
+    source_kwargs: dict[str, Any] = {"email": email, "transport": transport}
+    if max_results is not None:
+        source_kwargs["max_results"] = max_results
+
     try:
-        source = OpenAlexSource(email=email, transport=transport)
-        result = source.seed(equation, native=native)
+        source = OpenAlexSource(**source_kwargs)
+        result = source.seed(equation, native=native, exclude=exclude)
     except ImportError as exc:
         raise NetworkError(
             f"Error importando httpx: {exc}. Verificá la instalación del núcleo."
@@ -119,6 +130,22 @@ def run_seed(
     help="Email para el polite pool de OpenAlex (recomendado).",
 )
 @click.option(
+    "--max-results",
+    "max_results",
+    type=int,
+    default=None,
+    help="Tope de resultados a traer de OpenAlex (default: 200).",
+)
+@click.option(
+    "--exclude",
+    "exclude",
+    multiple=True,
+    help=(
+        "Término a excluir del título/abstract (repetible). "
+        'Cada valor agrega AND NOT title_and_abstract.search:"…" al filtro.'
+    ),
+)
+@click.option(
     "--json",
     "json_output",
     is_flag=True,
@@ -132,6 +159,8 @@ def seed_cmd(
     equation: str,
     native: bool,
     email: str | None,
+    max_results: int | None,
+    exclude: tuple[str, ...],
     json_output: bool,
 ) -> None:
     """Siembra el corpus desde una ecuación de búsqueda en OpenAlex.
@@ -139,7 +168,14 @@ def seed_cmd(
     Tras el seed, el estado del lazo transiciona a SEEDED.
     """
     store_path = resolve_library_path(ctx.obj)
-    data = run_seed(store_path, equation, native=native, email=email)
+    data = run_seed(
+        store_path,
+        equation,
+        native=native,
+        email=email,
+        max_results=max_results,
+        exclude=list(exclude) if exclude else None,
+    )
 
     if json_output:
         envelope = build_envelope(

--- a/src/bib2graph/sources/openalex.py
+++ b/src/bib2graph/sources/openalex.py
@@ -78,19 +78,32 @@ _RETRY_BACKOFF_BASE: float = 1.0  # segundos; duplica por cada intento
 # ---------------------------------------------------------------------------
 
 
-def _translate(query: str, *, native: bool = False) -> tuple[str, list[str]]:
+def _translate(
+    query: str,
+    *,
+    native: bool = False,
+    exclude: list[str] | None = None,
+) -> tuple[str, list[str]]:
     """Traduce una ecuación WoS-style a una query OpenAlex ejecutable.
 
-    Si ``native=True`` pasa la query cruda sin ningún procesamiento.
+    Si ``native=True`` pasa la query cruda sin ningún procesamiento (las
+    exclusiones se ignoran en modo nativo).
 
     Detecta y reporta límites de OpenAlex (ADR 0007) sin abortar:
     - ``NEAR/n``: proximidad no soportada.
     - Comodín ``*``: comportamiento distinto al de WoS.
     - Tags de campo WoS (``TS=``, ``AB=``, ``AU=``…): no mapean 1:1.
 
+    Las exclusiones (``exclude``) añaden cláusulas
+    ``AND NOT title_and_abstract.search:"<término>"`` al final del filtro y
+    se reportan en el translation_report para transparencia (PRD §4).
+
     Args:
         query: Ecuación de búsqueda.
         native: Si es ``True``, no traducir; usar query cruda.
+        exclude: Lista de términos a excluir de título/abstract.  Cada uno
+            genera una cláusula ``AND NOT title_and_abstract.search:"…"``.
+            ``None`` o lista vacía = sin exclusiones.
 
     Returns:
         Tupla ``(executed_query, translation_report)``.
@@ -119,6 +132,22 @@ def _translate(query: str, *, native: bool = False) -> tuple[str, list[str]]:
 
     # Envolver en el filtro de OpenAlex (PASSTHROUGH)
     executed = f"title_and_abstract.search:({query})"
+
+    # Negaciones: cada término excluido agrega una cláusula AND NOT (#30).
+    # Las comillas internas se eliminan para no romper la frase entrecomillada
+    # en el filtro de OpenAlex (un `"` embebido cierra la frase antes de tiempo).
+    terms = [t.strip().replace('"', "") for t in (exclude or []) if t and t.strip()]
+    if terms:
+        not_clauses = " ".join(
+            f'AND NOT title_and_abstract.search:"{t}"' for t in terms
+        )
+        executed = f"{executed} {not_clauses}"
+        report.append(
+            f"Exclusiones aplicadas ({len(terms)}): "
+            + ", ".join(f'"{t}"' for t in terms)
+            + ". Cláusulas AND NOT añadidas al filtro de OpenAlex."
+        )
+
     return executed, report
 
 
@@ -437,7 +466,13 @@ class OpenAlexSource:
     # API pública
     # ------------------------------------------------------------------
 
-    def seed(self, query: str, *, native: bool = False) -> SeedResult:
+    def seed(
+        self,
+        query: str,
+        *,
+        native: bool = False,
+        exclude: list[str] | None = None,
+    ) -> SeedResult:
         """Siembra un ``Corpus`` desde una ecuación de búsqueda.
 
         ``cited_by_id`` queda ``[]`` en el corpus sembrado: OpenAlex no lo
@@ -447,11 +482,15 @@ class OpenAlexSource:
         Args:
             query: Ecuación de búsqueda (WoS-style o nativa OpenAlex).
             native: Si es ``True``, pasa la query cruda sin traducción.
+            exclude: Lista de términos a excluir de título/abstract (#30).
+                Cada término genera ``AND NOT title_and_abstract.search:"…"``.
 
         Returns:
             ``SeedResult`` con el corpus, la query ejecutada y el reporte.
         """
-        executed_query, translation_report = _translate(query, native=native)
+        executed_query, translation_report = _translate(
+            query, native=native, exclude=exclude
+        )
         equation_id = f"eq-{datetime.now(UTC).strftime('%Y%m%dT%H%M%S')}"
         fetched_at = datetime.now(UTC).isoformat()
 

--- a/tests/unit/test_sources.py
+++ b/tests/unit/test_sources.py
@@ -602,3 +602,249 @@ def test_with_manifest_mismo_corpus_hash() -> None:
     result = corpus.with_manifest(nuevo_manifest)
 
     assert _compute_corpus_hash(corpus.table) == _compute_corpus_hash(result.table)
+
+
+# ---------------------------------------------------------------------------
+# #14 — max_results: el source respeta el tope al paginar
+# ---------------------------------------------------------------------------
+
+
+def _make_handler_paged(
+    works: list[dict[str, Any]], *, page_size: int = 2
+) -> httpx.MockTransport:
+    """MockTransport que devuelve ``works`` en páginas de ``page_size``.
+
+    Permite verificar que ``max_results`` corta la paginación antes de agotar
+    todos los works disponibles cuando el tope es menor que el total.
+    """
+    pages: list[list[dict[str, Any]]] = []
+    for i in range(0, len(works), page_size):
+        pages.append(works[i : i + page_size])
+    # Añadir página vacía al final para señalar fin de paginación
+    pages.append([])
+    call_count: list[int] = [0]
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        idx = call_count[0]
+        call_count[0] += 1
+        page = pages[idx] if idx < len(pages) else []
+        has_next = idx < len(pages) - 2  # hay más páginas no vacías
+        body = {
+            "results": page,
+            "meta": {
+                "count": len(works),
+                "next_cursor": "cursor_next" if has_next else None,
+            },
+        }
+        return httpx.Response(
+            200,
+            json=body,
+            headers={"x-openalex-api-version": "2026-05-01"},
+        )
+
+    return httpx.MockTransport(handler)
+
+
+@pytest.mark.unit
+def test_max_results_propagado_al_source() -> None:
+    """``OpenAlexSource(max_results=N)`` almacena el valor en ``_max_results``."""
+    source = OpenAlexSource(max_results=30)
+    assert source._max_results == 30
+
+
+@pytest.mark.unit
+def test_max_results_default_es_200() -> None:
+    """Sin ``max_results`` explícito, el default es 200."""
+    source = OpenAlexSource()
+    assert source._max_results == 200
+
+
+@pytest.mark.unit
+def test_seed_max_results_corta_resultados() -> None:
+    """``seed()`` con ``max_results=1`` devuelve a lo sumo 1 paper."""
+    works = _load_fixture_works()
+    # Fixture tiene al menos 2 works; con max_results=1 solo llega 1
+    assert len(works) >= 2
+
+    transport = _make_handler_paged(works, page_size=2)
+    source = OpenAlexSource(max_results=1, transport=transport)
+    result = source.seed("ecological exchange")
+
+    assert len(result.corpus) == 1
+
+
+@pytest.mark.unit
+def test_seed_max_results_trae_todos_si_hay_menos() -> None:
+    """Si el total de works < max_results, se traen todos."""
+    works = _load_fixture_works()
+    transport = _make_handler(works)
+    source = OpenAlexSource(max_results=9999, transport=transport)
+    result = source.seed("ecological exchange")
+
+    assert len(result.corpus) == len(works)
+
+
+# ---------------------------------------------------------------------------
+# #30 — negaciones / exclusiones en _translate y seed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_translate_sin_exclusiones_comportamiento_actual() -> None:
+    """Sin ``exclude``, el comportamiento es idéntico al actual (sin AND NOT)."""
+    query = '"unequal exchange" OR trade'
+    executed, _report = _translate(query)
+
+    assert executed == f"title_and_abstract.search:({query})"
+    # Sin exclusiones no aparece AND NOT
+    assert "AND NOT" not in executed
+
+
+@pytest.mark.unit
+def test_translate_con_una_exclusion() -> None:
+    """Un término excluido → cláusula ``AND NOT title_and_abstract.search:"…"``."""
+    query = "sistémico AND complejidad"
+    executed, _report = _translate(query, exclude=["machine learning"])
+
+    assert 'AND NOT title_and_abstract.search:"machine learning"' in executed
+    # El prefijo sigue siendo el wrapping correcto
+    assert executed.startswith(f"title_and_abstract.search:({query})")
+
+
+@pytest.mark.unit
+def test_translate_con_multiples_exclusiones() -> None:
+    """Múltiples exclusiones → una cláusula AND NOT por cada término."""
+    query = "sujeto AND sistema"
+    terms = ["machine learning", "algorithm", "lupus"]
+    executed, _report = _translate(query, exclude=terms)
+
+    for term in terms:
+        assert f'AND NOT title_and_abstract.search:"{term}"' in executed
+
+
+@pytest.mark.unit
+def test_translate_exclusiones_en_translation_report() -> None:
+    """Las exclusiones aparecen listadas en el ``translation_report``."""
+    _, report = _translate(
+        "ecological exchange", exclude=["machine learning", "algorithm"]
+    )
+
+    assert len(report) >= 1
+    # El report debe mencionar explícitamente las exclusiones
+    combined = " ".join(report)
+    assert "machine learning" in combined
+    assert "algorithm" in combined
+
+
+@pytest.mark.unit
+def test_translate_exclusion_lista_vacia_sin_efecto() -> None:
+    """``exclude=[]`` equivale a sin exclusiones."""
+    query = "ecological exchange"
+    executed_sin, report_sin = _translate(query)
+    executed_con, report_con = _translate(query, exclude=[])
+
+    assert executed_sin == executed_con
+    assert report_sin == report_con
+
+
+@pytest.mark.unit
+def test_translate_exclusion_none_sin_efecto() -> None:
+    """``exclude=None`` equivale a sin exclusiones."""
+    query = "ecological exchange"
+    executed_sin, _ = _translate(query)
+    executed_con, _ = _translate(query, exclude=None)
+
+    assert executed_sin == executed_con
+
+
+@pytest.mark.unit
+def test_seed_exclude_en_query_ejecutada() -> None:
+    """``seed(..., exclude=[...])`` refleja las cláusulas NOT en ``executed_query``."""
+    works = _load_fixture_works()
+    transport = _make_handler(works)
+    source = OpenAlexSource(transport=transport)
+
+    result = source.seed("sistémico", exclude=["machine learning"])
+
+    assert (
+        'AND NOT title_and_abstract.search:"machine learning"' in result.executed_query
+    )
+
+
+@pytest.mark.unit
+def test_seed_exclude_multiples_en_query_ejecutada() -> None:
+    """Múltiples términos excluidos aparecen todos en la query ejecutada."""
+    works = _load_fixture_works()
+    transport = _make_handler(works)
+    source = OpenAlexSource(transport=transport)
+
+    terms = ["machine learning", "algorithm"]
+    result = source.seed("sujeto", exclude=terms)
+
+    for term in terms:
+        assert f'AND NOT title_and_abstract.search:"{term}"' in result.executed_query
+
+
+@pytest.mark.unit
+def test_seed_exclude_en_translation_report() -> None:
+    """Los términos excluidos se mencionan en el ``translation_report``."""
+    works = _load_fixture_works()
+    transport = _make_handler(works)
+    source = OpenAlexSource(transport=transport)
+
+    result = source.seed("complejidad", exclude=["machine learning"])
+
+    combined = " ".join(result.translation_report)
+    assert "machine learning" in combined
+
+
+@pytest.mark.unit
+def test_seed_sin_exclude_comportamiento_intacto() -> None:
+    """Sin ``exclude``, la query sigue siendo solo el wrapping PASSTHROUGH."""
+    works = _load_fixture_works()
+    transport = _make_handler(works)
+    source = OpenAlexSource(transport=transport)
+
+    query = '"unequal exchange" AND trade'
+    result = source.seed(query)
+
+    assert result.executed_query == f"title_and_abstract.search:({query})"
+    assert "AND NOT" not in result.executed_query
+
+
+@pytest.mark.unit
+def test_translate_native_ignora_exclude() -> None:
+    """Con ``native=True`` las exclusiones se ignoran: la query pasa cruda sin AND NOT."""
+    query = "title.search:ecologia"
+    executed, report = _translate(query, native=True, exclude=["machine learning"])
+
+    assert executed == query
+    assert "AND NOT" not in executed
+    # El report indica modo nativo pero no menciona exclusiones
+    assert any("nativa" in r.lower() for r in report)
+
+
+@pytest.mark.unit
+def test_seed_native_ignora_exclude() -> None:
+    """``seed(native=True, exclude=[...])`` no añade AND NOT a la query ejecutada."""
+    works = _load_fixture_works()
+    transport = _make_handler(works)
+    source = OpenAlexSource(transport=transport)
+
+    query = "title.search:ecologia"
+    result = source.seed(query, native=True, exclude=["machine learning", "algorithm"])
+
+    assert result.executed_query == query
+    assert "AND NOT" not in result.executed_query
+
+
+@pytest.mark.unit
+def test_translate_exclude_strip_comillas_internas() -> None:
+    """Comillas embebidas en un término se eliminan para no romper la frase OpenAlex."""
+    executed, _report = _translate("ecologia", exclude=['"machine learning"'])
+
+    # Las comillas del término se eliminaron; la frase externa queda bien formada
+    assert 'AND NOT title_and_abstract.search:"machine learning"' in executed
+    # No debe haber comilla suelta que cierre la frase antes de tiempo
+    after_not = executed.split("AND NOT title_and_abstract.search:")[1]
+    assert after_not.count('"') == 2  # exactamente apertura y cierre


### PR DESCRIPTION
Cierra **#14** (`b2g seed --max-results` para muestras chicas) y **#30** (`--exclude` repetible → cláusulas `AND NOT` reportadas en el translation_report; ignorado en `native`; comillas saneadas). verifier **PASA**, **476 tests**, 0 enlaces rotos. Docs: API §2, PRD §4.