### PR TITLE
feat(networks): tabla de clusters a CSV (#31)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,10 @@
   scent bibliométrico), `preprocessors/` (normalize + thesaurus), `filters/` (PRISMA),
   `networks/` (proyectores, analyzer, spec, facade), `exporters/` (GraphML, CSV) y `cli/`.
   El **CLI `b2g` es real** —paquete `cli/` con 15 subcomandos en `cli/commands/`, no un
-  placeholder—. **476 tests verdes** (mypy/ruff limpios; el núcleo importa sin `duckdb`).
+  placeholder—. **498 tests verdes** (mypy/ruff limpios; el núcleo importa sin `duckdb`). Entre las
+  redes, la **composición de comunidades es exportable**: `networks/cluster_table` (función pura)
+  resume cada comunidad de una red de paper en una fila y `b2g build` la escribe como `clusters.csv`
+  (#31, AS-BUILT 2026-06-17; ver `docs/API.md` §7.2).
 - **Hito 8 COMPLETO** (Ciclos 8a + 8b, ADR
   [0025](docs/decisiones/0025-enricher-cocitacion-openalex.md)): el `OpenAlexEnricher` (opt-in,
   núcleo) hace 2 pasadas — **refs→DOI** (8a) **+ co-citación end-to-end** (8b): pobla `cited_by_id`
@@ -267,7 +270,7 @@ src/bib2graph/
   filters/             # filtros de inclusión/exclusión con conteo PRISMA (núcleo)
   enrichers/           # OpenAlexEnricher opt-in, NÚCLEO (Hito 8 ✅: refs→DOI 8a + co-citación 8b → pobla cited_by_id);
                        # Enricher Protocol; S2 ([s2]) reservado para señal adicional, NO el Enricher (ADR 0025)
-  networks/            # Projector, Analyzer, NetworkSpec, NetworkArtifact, Networks
+  networks/            # Projector, Analyzer, NetworkSpec, NetworkArtifact, Networks, cluster_table (#31)
   exporters/           # GraphML, CSV
   stores/              # DuckDBStore (núcleo, por defecto: biblioteca viva);
                        # ParquetStore (export); ZoteroStore ([zotero], V1.1);

--- a/docs/API.md
+++ b/docs/API.md
@@ -65,6 +65,13 @@
 > `facade.py:_build_artifact`); los proyectores **siguen puros** (ADR 0014). Cierra el hueco de la
 > Nota 09 B3 (redes con id crudo, ilegibles en Gephi/VOSviewer).
 >
+> **Sincronizado con la tabla de clusters — #31 (AS-BUILT, 2026-06-17):** se agregó la función pura
+> **`cluster_table(table, artifact)`** (§7.2, `networks/clusters.py`, re-exportada desde
+> `networks/__init__.py`): resume cada comunidad de una red de **paper** (coupling/cocitación) en una
+> fila (tamaño, conteos de curación, rango de años, top autores/keywords). **`b2g build`** ahora escribe
+> `<workspace>/networks/<kind>/clusters.csv` (listas con separador `|`) cuando la red tiene comunidades,
+> y el envelope `--json` suma `clusters_csv` **condicional** por red (§9/§convenciones CLI).
+>
 > **Sincronizado con el workspace — ADR [0029](decisiones/0029-workspace-por-investigacion.md)
 > (AS-BUILT, 2026-06-16):** la unidad de persistencia es un **workspace = carpeta** (`workspace.json`
 > + `library.duckdb` + `networks/`/`snapshots/`/`exports/`). `--store` pasó a **opcional** y se agregó
@@ -189,7 +196,11 @@ vive en su `library.duckdb`; el CLI es stateful **vía archivo**, no vía proces
 **`build` y `export` separados** (decisión del PO, ADR 0021 §B): `build` computa `Networks.quick`
 (4 redes) y escribe artefactos a `<store_dir>/networks/<kind>/` (+ transiciona a `BUILT`);
 `export --format graphml|csv --out-dir ...` **relee** esos artefactos y los serializa (sin
-transición).
+transición). **AS-BUILT #31 (2026-06-17):** `build` también escribe **`clusters.csv`** (tabla de
+resumen de comunidades, §7.2) en `<networks_dir>/<kind>/` **solo** para redes de **paper** con
+comunidades detectadas (listas con separador `|`); en el envelope `--json`, cada entrada de
+`data["networks"]` suma `clusters_csv` (ruta del archivo) **condicionalmente** —solo cuando ese
+archivo se generó—.
 
 **Transiciones automáticas del ciclo** (ADR 0021 §F; AS-BUILT R3): `seed`→`SEEDED`, `chain`→`FORAGED`,
 `filter`→`FILTERED`, `build`→`BUILT`, **`monitor`→`MONITORED`** (cleanup pre-v0.3);
@@ -959,6 +970,56 @@ es la única capa que sabe de labels.
 
 ---
 
+## 7.2 Núcleo — `cluster_table` (resumen de comunidades, v1, AS-BUILT #31)
+
+`bib2graph.networks.cluster_table` es una **función pura** que cruza los nodos de una red con el
+corpus para producir **una fila de resumen por comunidad**. Es el insumo tabular de la composición de
+clusters (quién/qué/cuándo cae en cada comunidad), legible offline (Excel/Calc) y la base del
+`clusters.csv` que escribe `b2g build` (§convenciones CLI).
+
+```python
+def cluster_table(table: pa.Table, artifact: NetworkArtifact) -> list[dict[str, Any]]:
+    """Una fila por comunidad de `artifact.communities`. Función pura (sin red, sin duckdb).
+    Cruza nodo→fila por Col.ID (id canónico), NUNCA por openalex_id. Devuelve [] si el kind
+    no es de paper o si no hay comunidades. Orden determinista por `cluster` ascendente."""
+```
+
+`networks/__init__.py` re-exporta `cluster_table`.
+
+**Restricción a redes de paper (V1):** solo aplica a los kinds cuyo nodo es un `Col.ID`
+(`bibliographic_coupling` / `cocitation`); para redes de **autor/keyword/institución** las comunidades
+agrupan entidades distintas a papers y la misma tabla no tiene sentido en V1 → devuelve `[]` (no
+crash). Si `artifact.communities is None` también devuelve `[]`.
+
+**Columnas de cada fila** (orden estable):
+
+| Columna | Tipo | Origen |
+|---|---|---|
+| `cluster` | `int` | id de comunidad |
+| `size` | `int` | nº de nodos en la comunidad (incluye nodos sin match en el corpus) |
+| `seed_count` | `int` | nodos con `is_seed=True` |
+| `candidate_count` | `int` | nodos con `curation_status='candidate'` |
+| `accepted_count` | `int` | nodos con `curation_status='accepted'` |
+| `year_min` / `year_max` | `int \| None` | rango de año (`None` si ningún nodo tiene año) |
+| `year_mean` | `float \| None` | media de año redondeada a 1 decimal (`None` si no hay años) |
+| `top_authors` | `list[str]` | hasta 5 autores más frecuentes, de **`authors_raw`** |
+| `top_keywords` | `list[str]` | hasta 5 keywords más frecuentes, de **`keywords_id`** (post-thesaurus) |
+
+**Notas de contrato** (#31, AS-BUILT 2026-06-17):
+
+- **Cruce por `Col.ID`, no `openalex_id`** (lección B6 de la
+  [Nota 09](Notas/09-sesion-qa-prueba-ecologia-valoraciones.md)): el nodo del grafo **es** un `Col.ID`
+  (`oa:…`); indexar por `openalex_id` (`W…`) daría 0 cruces. Un nodo sin match en el corpus **suma al
+  `size`** pero no aporta año/autores/keywords.
+- **Determinista** (ADR [0017](decisiones/0017-reproducibilidad-historia-snapshot.md)): el top de
+  autores/keywords se ordena por **`(-frecuencia, nombre alfabético ascendente)`** — desempate
+  explícito que hace el resultado reproducible **independiente** del método de clustering
+  (louvain/label_prop/greedy) y de `PYTHONHASHSEED`.
+- **Pura:** sin red, sin `duckdb`; opera sobre `corpus.to_arrow()` + el `NetworkArtifact`. Combina con
+  `community_composition` (§8, % por categoría) que mira el atributo, no la composición bibliográfica.
+
+---
+
 ## 8. Núcleo — `Analyzer` (funciones puras, v1)
 
 ```python
@@ -984,7 +1045,8 @@ def assortativity(g: nx.Graph, *, attribute: str | None = None,
     en el output como disclaimer ('fácil pero consciente'). Validado en el sandbox IED."""
 
 def community_composition(g: nx.Graph, communities: dict, attribute: str) -> dict:
-    """% de cada categoría del atributo dentro de cada comunidad."""
+    """% de cada categoría del atributo dentro de cada comunidad.
+    (Composición bibliográfica de las comunidades de una red de paper → `cluster_table`, §7.2.)"""
 
 def cocitation_quality_report(corpus: Corpus, g: nx.Graph, *,
                               thresholds: "QualityThresholds | None" = None) -> dict:
@@ -1028,6 +1090,11 @@ class CsvExporter: ...       # v1 — nodos.csv + aristas.csv para pandas
 - **`GraphMLExporter`** escribe esos atributos como node attributes, **omite** los atributos con
   valor `None` (Gephi / `nx.write_graphml` no los admiten) y **no muta** el grafo original (opera
   sobre una copia).
+- **`clusters.csv` (AS-BUILT #31):** además de `network.graphml` + `metrics.json`, **`b2g build`**
+  escribe `<networks_dir>/<kind>/clusters.csv` cuando la red es de **paper** y tiene comunidades
+  (`cluster_table` no vacío, §7.2). Una fila por comunidad; las columnas de lista (`top_authors`/
+  `top_keywords`) se serializan **con separador `|`**. No lo emite un `Exporter` —lo arma el comando
+  `build` a partir de `cluster_table`—; las redes sin comunidades o no-paper no generan el archivo.
 
 ---
 

--- a/docs/ROADMAP/04-lo-que-viene.md
+++ b/docs/ROADMAP/04-lo-que-viene.md
@@ -194,6 +194,19 @@ No se prometen ni se cablean clientes que no se usan.
   devuelven artefactos **decorados**; los proyectores **siguen puros** (ADR
   [0014](../decisiones/0014-proyeccion-redes-pesos-asortatividad.md) AS-BUILT #25). Reemplaza el
   workaround local `_label_for_kind` de `prueba/06_redes_y_grafos.py`. Ver API.md §7.1.
+- **Tabla de clusters a CSV (#31) · ✅ HECHO (2026-06-17):** las redes salían con comunidades en el
+  GraphML pero sin una vista tabular legible de **qué cae en cada cluster** (composición por comunidad).
+  Se agregó la **función pura `cluster_table(table, artifact)`** (`networks/clusters.py`, re-exportada
+  desde `networks/__init__.py`): una fila por comunidad con `cluster, size, seed_count, candidate_count,
+  accepted_count, year_min, year_max, year_mean, top_authors, top_keywords`. **Solo redes de paper**
+  (coupling/cocitación; redes de autor/keyword/institución → `[]`, no crash). Cruza nodo→fila por
+  **`Col.ID`** (lección B6 de la [Nota 09](../Notas/09-sesion-qa-prueba-ecologia-valoraciones.md), no
+  `openalex_id`); `top_authors` de `authors_raw`, `top_keywords` de `keywords_id`. **Determinista**
+  (desempate `(-freq, nombre alfabético)`, reproducible cross-`PYTHONHASHSEED` y entre métodos de
+  clustering; ADR [0017](../decisiones/0017-reproducibilidad-historia-snapshot.md)). **`b2g build`**
+  escribe `<networks_dir>/<kind>/clusters.csv` (listas con separador `|`) cuando la red tiene
+  comunidades, y el envelope `--json` suma `clusters_csv` **condicional** por red. Gate verde, **498
+  tests**. Ver `API.md` §7.2 + §9 + §convenciones CLI.
 - **Workspace por investigación · ✅ HECHO (2026-06-16, ADR
   [0029](../decisiones/0029-workspace-por-investigacion.md); issues #32/#38/#39):** cada investigación
   = una carpeta auto-contenida (`workspace.json` + `library.duckdb` + `networks/`/`snapshots/`/

--- a/src/bib2graph/cli/commands/build.py
+++ b/src/bib2graph/cli/commands/build.py
@@ -14,6 +14,8 @@ ADR 0029 — sellado por corpus_hash:
 Los artefactos se escriben en ``<networks_dir>/<kind>/``:
   - ``network.graphml``: el grafo en formato GraphML.
   - ``metrics.json``: métricas de red calculadas.
+  - ``clusters.csv``: tabla de resumen de comunidades (solo redes de paper
+    con comunidades detectadas, issue #31).
 """
 
 from __future__ import annotations
@@ -42,6 +44,8 @@ def run_build(
 
     Usa ``Networks.quick`` para las 4 redes principales (coupling, co-autoría,
     institución, co-word). Escribe GraphML + metrics.json por red.
+    Para redes de paper con comunidades detectadas escribe también clusters.csv
+    (tabla de resumen de comunidades, issue #31).
     Sella ``networks/.corpus_hash`` con el hash del corpus que las produjo.
     Transiciona a BUILT tras escribir con éxito.
 
@@ -57,8 +61,11 @@ def run_build(
         DependencyError: Si falta ``python-louvain``.
         StoreError: Si el store está bloqueado.
     """
+    import csv as _csv
+
     from bib2graph.cycle import apply_transition
     from bib2graph.exporters.graphml import GraphMLExporter
+    from bib2graph.networks.clusters import cluster_table
     from bib2graph.networks.facade import Networks
 
     store = open_store(store_path)
@@ -120,15 +127,49 @@ def run_build(
             encoding="utf-8",
         )
 
-        networks_info.append(
-            {
-                "kind": kind,
-                "nodes": art.graph.number_of_nodes(),
-                "edges": art.graph.number_of_edges(),
-                "graphml": str(kind_dir / "network.graphml"),
-                "metrics_json": str(metrics_path),
-            }
-        )
+        # Escribir clusters.csv para redes de paper con comunidades (issue #31).
+        # cluster_table devuelve [] si el kind no es de paper o no hay comunidades.
+        clusters_path: str | None = None
+        clusters = cluster_table(corpus.to_arrow(), art)
+        if clusters:
+            clusters_path = str(kind_dir / "clusters.csv")
+            with open(clusters_path, "w", newline="", encoding="utf-8") as _f:
+                _writer = _csv.DictWriter(
+                    _f,
+                    fieldnames=[
+                        "cluster",
+                        "size",
+                        "seed_count",
+                        "candidate_count",
+                        "accepted_count",
+                        "year_min",
+                        "year_max",
+                        "year_mean",
+                        "top_authors",
+                        "top_keywords",
+                    ],
+                )
+                _writer.writeheader()
+                for _row in clusters:
+                    # Serializar listas como cadena separada por "|"
+                    _writer.writerow(
+                        {
+                            **_row,
+                            "top_authors": "|".join(_row["top_authors"]),
+                            "top_keywords": "|".join(_row["top_keywords"]),
+                        }
+                    )
+
+        net_entry: dict[str, Any] = {
+            "kind": kind,
+            "nodes": art.graph.number_of_nodes(),
+            "edges": art.graph.number_of_edges(),
+            "graphml": str(kind_dir / "network.graphml"),
+            "metrics_json": str(metrics_path),
+        }
+        if clusters_path is not None:
+            net_entry["clusters_csv"] = clusters_path
+        networks_info.append(net_entry)
 
     # ADR 0029 — sellar con corpus_hash para detección de staleness.
     # El hash ya lo tiene el corpus vía Manifest/CorpusSnapshot; lo derivamos

--- a/src/bib2graph/networks/__init__.py
+++ b/src/bib2graph/networks/__init__.py
@@ -5,6 +5,7 @@ Reexporta los símbolos públicos del paquete de redes:
   - Analizadores (funciones puras + QualityThresholds).
   - ``NetworkArtifact`` y ``Networks`` (facade de alto nivel).
   - ``decorate`` / ``decorate_graph`` (capa de decoración de nodos, issue #25).
+  - ``cluster_table`` (tabla de resumen de comunidades por cluster, issue #31).
 
 Ver API.md §7-10.
 """
@@ -20,6 +21,7 @@ from bib2graph.networks.analyzer import (
     detect_communities,
     network_metrics,
 )
+from bib2graph.networks.clusters import cluster_table
 from bib2graph.networks.decorate import decorate, decorate_graph
 from bib2graph.networks.facade import Networks
 from bib2graph.networks.projectors import (
@@ -46,6 +48,7 @@ __all__ = [
     "QualityThresholds",
     "assortativity",
     "centrality",
+    "cluster_table",
     "cocitation_quality_report",
     "collect_item_to_papers",
     "community_composition",

--- a/src/bib2graph/networks/clusters.py
+++ b/src/bib2graph/networks/clusters.py
@@ -1,0 +1,215 @@
+"""clusters — tabla de comunidades para redes de paper.
+
+Función pura ``cluster_table`` que cruza nodos de una red bibliométrica
+(bibliographic_coupling / cocitation) con el corpus para producir una fila
+de resumen por comunidad: tamaño, conteos por estado de curación, rango de
+años, top autores y top keywords.
+
+Aplica SOLO a redes de paper (nodos = Col.ID canónico).
+Para redes de autor/keyword/institución las comunidades agrupan entidades
+distintas a papers; en V1 no tiene sentido la misma tabla — la función devuelve
+``[]`` con un aviso en el docstring (no crash).
+
+Lección B6 (Nota 09): cruzar por ``Col.ID`` (id canónico, ej. ``oa:abab…``),
+NUNCA por ``Col.OPENALEX_ID`` (``W…``). Un nodo del grafo ES un ``Col.ID``.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from statistics import mean
+from typing import TYPE_CHECKING, Any
+
+import pyarrow as pa
+
+from bib2graph.constants import Col, CurationStatus, NetworkKind
+
+if TYPE_CHECKING:
+    from bib2graph.networks.spec import NetworkArtifact
+
+# Kinds cuyo nodo es un paper id (Col.ID) — misma fuente que _PAPER_KINDS en decorate.py
+_PAPER_KINDS: frozenset[str] = frozenset(
+    {NetworkKind.BIBLIOGRAPHIC_COUPLING, NetworkKind.COCITATION}
+)
+
+# Cuántos autores/keywords mostrar en top_authors / top_keywords
+_TOP_N: int = 5
+
+
+def cluster_table(
+    table: pa.Table,
+    artifact: NetworkArtifact,
+) -> list[dict[str, Any]]:
+    """Construye una tabla de resumen de comunidades para redes de paper.
+
+    Para cada comunidad detectada en ``artifact.communities`` agrega una fila con:
+      - ``cluster``: id de comunidad (int).
+      - ``size``: número de nodos en la comunidad.
+      - ``seed_count``: nodos con ``is_seed=True``.
+      - ``candidate_count``: nodos con ``curation_status='candidate'``.
+      - ``accepted_count``: nodos con ``curation_status='accepted'``.
+      - ``year_min``, ``year_max``, ``year_mean``: rango y media de año.
+        ``year_mean`` es ``None`` si ningún nodo tiene año.
+      - ``top_authors``: lista con hasta 5 autores más frecuentes (authors_raw).
+      - ``top_keywords``: lista con hasta 5 keywords más frecuentes (keywords_id).
+
+    El cruce nodo→fila se hace por ``Col.ID`` (id canónico), NO por
+    ``Col.OPENALEX_ID``. Esta es la lección crítica de la Nota 09 B6:
+    el nodo del grafo ES un ``Col.ID``; usar ``openalex_id`` daría 0 cruces.
+
+    Comportamiento en casos límite:
+      - ``artifact.communities`` es ``None`` → devuelve ``[]``.
+      - ``artifact.spec.kind`` no es de paper → devuelve ``[]`` (no crash).
+      - Nodo sin match en el corpus → ese nodo no aporta datos de año/autores/
+        keywords pero SÍ suma al ``size``.
+      - Cluster con 0 años → ``year_min=None``, ``year_max=None``, ``year_mean=None``.
+
+    El orden de filas es determinista: clusters ordenados por ``cluster`` id.
+
+    Args:
+        table: Tabla Arrow canónica del Corpus (fuente de metadatos).
+        artifact: ``NetworkArtifact`` con ``graph``, ``communities`` y ``spec``.
+
+    Returns:
+        Lista de dicts ordenada por ``cluster``. Vacía si no aplica.
+    """
+    # Sólo aplica a redes de paper
+    if artifact.spec.kind not in _PAPER_KINDS:
+        return []
+
+    # Sin comunidades → sin tabla
+    if artifact.communities is None:
+        return []
+
+    communities: dict[Any, int] = artifact.communities
+
+    # --- Construir índice Col.ID → metadatos ---
+    # Lección B6: index por Col.ID, no por Col.OPENALEX_ID
+    paper_index = _build_paper_index(table)
+
+    # --- Agrupar nodos por comunidad ---
+    by_cluster: dict[int, list[Any]] = {}
+    for node, comm_id in communities.items():
+        cid = int(comm_id)
+        if cid not in by_cluster:
+            by_cluster[cid] = []
+        by_cluster[cid].append(node)
+
+    # --- Construir fila de resumen por cluster ---
+    rows: list[dict[str, Any]] = []
+    for comm_id in sorted(by_cluster):
+        nodes = by_cluster[comm_id]
+        size = len(nodes)
+
+        seed_count = 0
+        candidate_count = 0
+        accepted_count = 0
+        years: list[int] = []
+        author_counter: Counter[str] = Counter()
+        keyword_counter: Counter[str] = Counter()
+
+        for node in nodes:
+            key = str(node)
+            info = paper_index.get(key)
+            if info is None:
+                # Nodo sin match en el corpus: suma al size, no aporta datos
+                continue
+
+            if info.get("is_seed"):
+                seed_count += 1
+            status = info.get("curation_status")
+            if status == CurationStatus.CANDIDATE:
+                candidate_count += 1
+            elif status == CurationStatus.ACCEPTED:
+                accepted_count += 1
+
+            year = info.get("year")
+            if isinstance(year, int):
+                years.append(year)
+
+            for author in info.get("authors_raw") or []:
+                if author:
+                    author_counter[str(author)] += 1
+
+            for kw in info.get("keywords_id") or []:
+                if kw:
+                    keyword_counter[str(kw)] += 1
+
+        year_min: int | None = min(years) if years else None
+        year_max: int | None = max(years) if years else None
+        year_mean: float | None = round(mean(years), 1) if years else None
+
+        # Desempate explícito: orden primario por frecuencia descendente,
+        # secundario alfabético ascendente. Garantiza reproducibilidad
+        # independiente del método de clustering (louvain/label_prop/greedy)
+        # y de PYTHONHASHSEED (ADR 0017, DoD de reproducibilidad).
+        top_authors = [
+            a
+            for a, _ in sorted(author_counter.items(), key=lambda x: (-x[1], x[0]))[
+                :_TOP_N
+            ]
+        ]
+        top_keywords = [
+            k
+            for k, _ in sorted(keyword_counter.items(), key=lambda x: (-x[1], x[0]))[
+                :_TOP_N
+            ]
+        ]
+
+        rows.append(
+            {
+                "cluster": comm_id,
+                "size": size,
+                "seed_count": seed_count,
+                "candidate_count": candidate_count,
+                "accepted_count": accepted_count,
+                "year_min": year_min,
+                "year_max": year_max,
+                "year_mean": year_mean,
+                "top_authors": top_authors,
+                "top_keywords": top_keywords,
+            }
+        )
+
+    return rows
+
+
+def _build_paper_index(table: pa.Table) -> dict[str, dict[str, Any]]:
+    """Construye índice ``{Col.ID → metadatos}`` para cruce con nodos del grafo.
+
+    Incluye: year, is_seed, curation_status, authors_raw, keywords_id.
+
+    Args:
+        table: Tabla Arrow canónica del Corpus.
+
+    Returns:
+        Dict keyed por ``str(Col.ID)``; excluye filas con id ``None``.
+    """
+    ids = table.column(Col.ID).to_pylist()
+    years = table.column(Col.YEAR).to_pylist()
+    is_seeds = table.column(Col.IS_SEED).to_pylist()
+    statuses = table.column(Col.CURATION_STATUS).to_pylist()
+    authors_raw_col = table.column(Col.AUTHORS_RAW).to_pylist()
+    keywords_id_col = table.column(Col.KEYWORDS_ID).to_pylist()
+
+    index: dict[str, dict[str, Any]] = {}
+    for pid, year, is_seed, status, authors_raw, keywords_id in zip(
+        ids,
+        years,
+        is_seeds,
+        statuses,
+        authors_raw_col,
+        keywords_id_col,
+        strict=False,
+    ):
+        if pid is None:
+            continue
+        key = str(pid)
+        index[key] = {
+            "year": int(year) if year is not None else None,
+            "is_seed": bool(is_seed) if is_seed is not None else False,
+            "curation_status": str(status) if status is not None else None,
+            "authors_raw": authors_raw if isinstance(authors_raw, list) else [],
+            "keywords_id": keywords_id if isinstance(keywords_id, list) else [],
+        }
+    return index

--- a/tests/unit/test_clusters.py
+++ b/tests/unit/test_clusters.py
@@ -1,0 +1,622 @@
+"""Tests TDD para ``cluster_table`` y la integración con ``b2g build`` (#31).
+
+Casos cubiertos:
+
+1. ``cluster_table`` sobre corpus+grafo sintético con comunidades conocidas
+   produce filas con size/seed_count/year_*/top_authors/top_keywords correctos.
+2. Cruce por ``Col.ID`` (no ``openalex_id``) — test que fallaría si se usara
+   la columna equivocada (lección B6, Nota 09).
+3. Determinismo: mismo input → mismo output, mismo orden.
+4. Redes que no son de paper (author_collab/keyword/institution) → devuelve [].
+5. ``artifact.communities`` es None → devuelve [].
+6. Nodo sin match en el corpus → no crash; ese nodo suma al size.
+7. Cluster vacío de años → year_min/max/mean son None.
+8. ``b2g build`` escribe clusters.csv para red de paper con comunidades.
+9. ``b2g build`` no falla cuando la red no tiene comunidades.
+10. ``cluster_table`` es importable desde ``bib2graph.networks``.
+
+Marcador: ``unit`` (sin red, sin I/O).
+"""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+from typing import Any
+
+import networkx as nx
+import pyarrow as pa
+import pytest
+
+from bib2graph.constants import NetworkKind
+from bib2graph.networks.clusters import cluster_table
+from bib2graph.networks.spec import NetworkArtifact, NetworkSpec
+from bib2graph.schemas import CORPUS_SCHEMA
+
+# ---------------------------------------------------------------------------
+# Helpers de fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_row(
+    *,
+    id: str,
+    openalex_id: str | None = None,
+    year: int | None = None,
+    is_seed: bool = False,
+    curation_status: str = "candidate",
+    authors_raw: list[str] | None = None,
+    keywords_id: list[str] | None = None,
+    references_id: list[str] | None = None,
+) -> dict[str, Any]:
+    """Fila mínima con schema completo para tests."""
+    return {
+        "id": id,
+        "openalex_id": openalex_id,
+        "doi": None,
+        "title": f"Título de {id}",
+        "year": year,
+        "abstract": None,
+        "source": None,
+        "language": None,
+        "publisher": None,
+        "research_areas": None,
+        "is_seed": is_seed,
+        "curation_status": curation_status,
+        "provenance": None,
+        "authors_raw": authors_raw,
+        "authors_id": None,
+        "authors_affiliations": None,
+        "keywords_raw": None,
+        "keywords_id": keywords_id,
+        "institutions_raw": None,
+        "institutions_id": None,
+        "references_id": references_id,
+        "references_doi": None,
+        "cited_by_id": None,
+    }
+
+
+def _make_artifact(
+    *,
+    kind: str,
+    nodes: list[str],
+    edges: list[tuple[str, str]],
+    communities: dict[str, int] | None,
+) -> NetworkArtifact:
+    """Construye un NetworkArtifact sintético con grafo y comunidades dados."""
+    g: nx.Graph = nx.Graph()
+    g.add_nodes_from(nodes)
+    g.add_edges_from(edges)
+    spec = NetworkSpec(kind=kind, clustering=None)  # type: ignore[arg-type]
+    return NetworkArtifact(
+        graph=g,
+        metrics={},
+        communities=communities,
+        assortativity=None,
+        layout=None,
+        spec=spec,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Corpus de referencia para los tests principales
+#
+# 4 papers:
+#   P1: is_seed=True, accepted, year=2020, Autor A, Autor B, kw: ml, redes
+#   P2: is_seed=True, accepted, year=2021, Autor B, Autor C, kw: ml
+#   P3: is_seed=False, candidate, year=2022, Autor C, kw: redes, grafos
+#   P4: is_seed=False, candidate, year=2019, Autor A, kw: grafos
+#
+# Comunidades:
+#   Cluster 0: P1, P2   (seed_count=2, accepted=2, candidate=0, years=[2020,2021])
+#   Cluster 1: P3, P4   (seed_count=0, candidate=2, years=[2022,2019])
+# ---------------------------------------------------------------------------
+
+_ROWS = [
+    _make_row(
+        id="P1",
+        openalex_id="W111",
+        year=2020,
+        is_seed=True,
+        curation_status="accepted",
+        authors_raw=["Autor A", "Autor B"],
+        keywords_id=["ml", "redes"],
+        references_id=["R1", "R2"],
+    ),
+    _make_row(
+        id="P2",
+        openalex_id="W222",
+        year=2021,
+        is_seed=True,
+        curation_status="accepted",
+        authors_raw=["Autor B", "Autor C"],
+        keywords_id=["ml"],
+        references_id=["R1", "R3"],
+    ),
+    _make_row(
+        id="P3",
+        openalex_id="W333",
+        year=2022,
+        is_seed=False,
+        curation_status="candidate",
+        authors_raw=["Autor C"],
+        keywords_id=["redes", "grafos"],
+        references_id=["R2", "R3"],
+    ),
+    _make_row(
+        id="P4",
+        openalex_id="W444",
+        year=2019,
+        is_seed=False,
+        curation_status="candidate",
+        authors_raw=["Autor A"],
+        keywords_id=["grafos"],
+        references_id=["R4"],
+    ),
+]
+
+_TABLE = pa.Table.from_pylist(_ROWS, schema=CORPUS_SCHEMA)
+
+# Comunidades: cluster 0 → P1, P2; cluster 1 → P3, P4
+_COMMUNITIES: dict[str, int] = {"P1": 0, "P2": 0, "P3": 1, "P4": 1}
+
+_ARTIFACT = _make_artifact(
+    kind=NetworkKind.BIBLIOGRAPHIC_COUPLING,
+    nodes=["P1", "P2", "P3", "P4"],
+    edges=[("P1", "P2"), ("P3", "P4")],
+    communities=_COMMUNITIES,
+)
+
+
+# ---------------------------------------------------------------------------
+# 1. Filas por cluster — valores calculados a mano
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_cluster_table_produce_dos_filas() -> None:
+    """cluster_table devuelve una fila por comunidad (2 comunidades = 2 filas)."""
+    rows = cluster_table(_TABLE, _ARTIFACT)
+    assert len(rows) == 2
+
+
+@pytest.mark.unit
+def test_cluster_table_cluster_0_size() -> None:
+    """Cluster 0 tiene size=2 (P1 + P2)."""
+    rows = cluster_table(_TABLE, _ARTIFACT)
+    c0 = next(r for r in rows if r["cluster"] == 0)
+    assert c0["size"] == 2
+
+
+@pytest.mark.unit
+def test_cluster_table_cluster_0_seed_count() -> None:
+    """Cluster 0: seed_count=2 (ambos son semillas)."""
+    rows = cluster_table(_TABLE, _ARTIFACT)
+    c0 = next(r for r in rows if r["cluster"] == 0)
+    assert c0["seed_count"] == 2
+
+
+@pytest.mark.unit
+def test_cluster_table_cluster_0_accepted_count() -> None:
+    """Cluster 0: accepted_count=2, candidate_count=0."""
+    rows = cluster_table(_TABLE, _ARTIFACT)
+    c0 = next(r for r in rows if r["cluster"] == 0)
+    assert c0["accepted_count"] == 2
+    assert c0["candidate_count"] == 0
+
+
+@pytest.mark.unit
+def test_cluster_table_cluster_0_years() -> None:
+    """Cluster 0: year_min=2020, year_max=2021, year_mean=2020.5."""
+    rows = cluster_table(_TABLE, _ARTIFACT)
+    c0 = next(r for r in rows if r["cluster"] == 0)
+    assert c0["year_min"] == 2020
+    assert c0["year_max"] == 2021
+    assert c0["year_mean"] == 2020.5
+
+
+@pytest.mark.unit
+def test_cluster_table_cluster_1_candidate_count() -> None:
+    """Cluster 1: candidate_count=2, seed_count=0, accepted_count=0."""
+    rows = cluster_table(_TABLE, _ARTIFACT)
+    c1 = next(r for r in rows if r["cluster"] == 1)
+    assert c1["candidate_count"] == 2
+    assert c1["seed_count"] == 0
+    assert c1["accepted_count"] == 0
+
+
+@pytest.mark.unit
+def test_cluster_table_cluster_1_years() -> None:
+    """Cluster 1: year_min=2019, year_max=2022."""
+    rows = cluster_table(_TABLE, _ARTIFACT)
+    c1 = next(r for r in rows if r["cluster"] == 1)
+    assert c1["year_min"] == 2019
+    assert c1["year_max"] == 2022
+
+
+@pytest.mark.unit
+def test_cluster_table_top_authors_cluster_0() -> None:
+    """Cluster 0: top_authors incluye 'Autor B' (aparece 2 veces) como primero."""
+    rows = cluster_table(_TABLE, _ARTIFACT)
+    c0 = next(r for r in rows if r["cluster"] == 0)
+    # Autor B aparece en P1 y P2 → debe ser el más frecuente
+    assert "Autor B" in c0["top_authors"]
+    assert c0["top_authors"][0] == "Autor B"
+
+
+@pytest.mark.unit
+def test_cluster_table_top_keywords_cluster_0() -> None:
+    """Cluster 0: top_keywords incluye 'ml' (aparece 2 veces) como primero."""
+    rows = cluster_table(_TABLE, _ARTIFACT)
+    c0 = next(r for r in rows if r["cluster"] == 0)
+    assert "ml" in c0["top_keywords"]
+    assert c0["top_keywords"][0] == "ml"
+
+
+# ---------------------------------------------------------------------------
+# 2. Cruce por Col.ID, no por openalex_id (lección B6)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_cruce_por_col_id_no_openalex_id() -> None:
+    """El cruce usa Col.ID ('P1'…) no openalex_id ('W111'…).
+
+    Si se cruzara por openalex_id, los nodos del grafo (P1,P2,P3,P4) nunca
+    matchearían con 'W111','W222'… → size contaría 4 nodos pero
+    seed_count/accepted/years/authors/keywords serían todos 0/[].
+
+    Aquí verificamos que los datos de corpus SÍ lleguen al resultado,
+    lo que confirma que el cruce es por Col.ID.
+    """
+    rows = cluster_table(_TABLE, _ARTIFACT)
+    # Debe haber datos reales, no vacíos
+    total_seeds = sum(r["seed_count"] for r in rows)
+    total_accepted = sum(r["accepted_count"] for r in rows)
+    # Con cruce por Col.ID: total_seeds=2, total_accepted=2
+    # Con cruce por openalex_id: todo sería 0
+    assert total_seeds == 2, (
+        f"seed_count esperado=2, obtenido={total_seeds}. "
+        "Posible error: cruce por openalex_id en lugar de Col.ID."
+    )
+    assert total_accepted == 2
+
+
+# ---------------------------------------------------------------------------
+# 3. Determinismo
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_cluster_table_determinismo() -> None:
+    """Mismo input → mismo output en dos llamadas independientes."""
+    rows1 = cluster_table(_TABLE, _ARTIFACT)
+    rows2 = cluster_table(_TABLE, _ARTIFACT)
+    assert rows1 == rows2
+
+
+@pytest.mark.unit
+def test_cluster_table_orden_por_cluster_id() -> None:
+    """Las filas están ordenadas por cluster id (ascendente)."""
+    rows = cluster_table(_TABLE, _ARTIFACT)
+    cluster_ids = [r["cluster"] for r in rows]
+    assert cluster_ids == sorted(cluster_ids)
+
+
+@pytest.mark.unit
+def test_top_authors_desempate_alfabetico() -> None:
+    """Ante empate de frecuencia, top_authors ordena alfabéticamente (ADR 0017).
+
+    Este test cubriría el caso donde dos autores tienen la misma frecuencia;
+    el desempate debe ser determinista (alfabético) independientemente del
+    orden de nodo o de PYTHONHASHSEED.
+    """
+    # P_X y P_Y tienen referencias compartidas → hay arista entre ellos.
+    # Autor A aparece en P_X → count 1.
+    # Autor B y Autor C aparecen en P_Y → count 1 cada uno.
+    # Empate entre A, B y C: orden esperado alfabético (A, B, C).
+    rows_empate = [
+        _make_row(
+            id="P_X",
+            year=2020,
+            is_seed=True,
+            curation_status="accepted",
+            authors_raw=["Autor A"],
+            keywords_id=["kw_z", "kw_a"],
+            references_id=["R_shared"],
+        ),
+        _make_row(
+            id="P_Y",
+            year=2021,
+            is_seed=False,
+            curation_status="candidate",
+            authors_raw=["Autor B", "Autor C"],
+            keywords_id=["kw_m", "kw_a"],
+            references_id=["R_shared"],
+        ),
+    ]
+    table_empate = pa.Table.from_pylist(rows_empate, schema=CORPUS_SCHEMA)
+    art_empate = _make_artifact(
+        kind=NetworkKind.BIBLIOGRAPHIC_COUPLING,
+        nodes=["P_X", "P_Y"],
+        edges=[("P_X", "P_Y")],
+        communities={"P_X": 0, "P_Y": 0},
+    )
+    result = cluster_table(table_empate, art_empate)
+    assert len(result) == 1
+    c0 = result[0]
+
+    # top_authors: A(1), B(1), C(1) → desempate alfabético → [A, B, C]
+    assert c0["top_authors"] == ["Autor A", "Autor B", "Autor C"], (
+        f"Desempate alfabético fallido: {c0['top_authors']!r}"
+    )
+
+    # top_keywords: kw_a aparece 2 veces (en ambos papers), kw_m y kw_z una vez.
+    # kw_a primero (count 2), luego kw_m y kw_z empatados (count 1) → [kw_a, kw_m, kw_z]
+    assert c0["top_keywords"][0] == "kw_a", (
+        f"kw_a debería ser primera (count=2): {c0['top_keywords']!r}"
+    )
+    # Empate entre kw_m y kw_z → desempate alfabético → kw_m antes que kw_z
+    assert c0["top_keywords"][1] == "kw_m", (
+        f"Desempate alfabético en keywords fallido: {c0['top_keywords']!r}"
+    )
+    assert c0["top_keywords"][2] == "kw_z"
+
+
+# ---------------------------------------------------------------------------
+# 4. Redes que no son de paper → []
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_cluster_table_autor_devuelve_vacio() -> None:
+    """Para author_collab cluster_table devuelve []."""
+    art = _make_artifact(
+        kind=NetworkKind.AUTHOR_COLLAB,
+        nodes=["auth_1", "auth_2"],
+        edges=[("auth_1", "auth_2")],
+        communities={"auth_1": 0, "auth_2": 1},
+    )
+    assert cluster_table(_TABLE, art) == []
+
+
+@pytest.mark.unit
+def test_cluster_table_keyword_devuelve_vacio() -> None:
+    """Para keyword_cooccurrence cluster_table devuelve []."""
+    art = _make_artifact(
+        kind=NetworkKind.KEYWORD_COOCCURRENCE,
+        nodes=["ml", "redes"],
+        edges=[("ml", "redes")],
+        communities={"ml": 0, "redes": 0},
+    )
+    assert cluster_table(_TABLE, art) == []
+
+
+@pytest.mark.unit
+def test_cluster_table_institution_devuelve_vacio() -> None:
+    """Para institution_collab cluster_table devuelve []."""
+    art = _make_artifact(
+        kind=NetworkKind.INSTITUTION_COLLAB,
+        nodes=["inst_a", "inst_b"],
+        edges=[("inst_a", "inst_b")],
+        communities={"inst_a": 0, "inst_b": 0},
+    )
+    assert cluster_table(_TABLE, art) == []
+
+
+# ---------------------------------------------------------------------------
+# 5. Communities None → []
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_cluster_table_sin_communities_devuelve_vacio() -> None:
+    """artifact.communities=None → cluster_table devuelve []."""
+    art = _make_artifact(
+        kind=NetworkKind.BIBLIOGRAPHIC_COUPLING,
+        nodes=["P1", "P2"],
+        edges=[("P1", "P2")],
+        communities=None,
+    )
+    assert cluster_table(_TABLE, art) == []
+
+
+# ---------------------------------------------------------------------------
+# 6. Nodo sin match en corpus → no crash
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_nodo_sin_match_en_corpus_no_crash() -> None:
+    """Un nodo 'NOID' sin match en el corpus no provoca crash.
+
+    El nodo suma al size pero no aporta datos bibliográficos.
+    """
+    art = _make_artifact(
+        kind=NetworkKind.BIBLIOGRAPHIC_COUPLING,
+        nodes=["P1", "NOID"],
+        edges=[("P1", "NOID")],
+        communities={"P1": 0, "NOID": 0},
+    )
+    rows = cluster_table(_TABLE, art)
+    assert len(rows) == 1
+    c0 = rows[0]
+    # size = 2 (P1 + NOID), pero seed_count solo de P1
+    assert c0["size"] == 2
+    assert c0["seed_count"] == 1  # solo P1 es semilla
+
+
+# ---------------------------------------------------------------------------
+# 7. Cluster sin años → year_min/max/mean None
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_cluster_sin_anios_year_none() -> None:
+    """Si ningún nodo del cluster tiene año, year_min/max/mean son None."""
+    rows_sin_year = [
+        _make_row(
+            id="SY1",
+            year=None,
+            is_seed=True,
+            curation_status="candidate",
+            references_id=["R_x"],
+        ),
+        _make_row(
+            id="SY2",
+            year=None,
+            is_seed=False,
+            curation_status="candidate",
+            references_id=["R_x"],
+        ),
+    ]
+    table_sin_year = pa.Table.from_pylist(rows_sin_year, schema=CORPUS_SCHEMA)
+    art = _make_artifact(
+        kind=NetworkKind.BIBLIOGRAPHIC_COUPLING,
+        nodes=["SY1", "SY2"],
+        edges=[("SY1", "SY2")],
+        communities={"SY1": 0, "SY2": 0},
+    )
+    rows = cluster_table(table_sin_year, art)
+    assert len(rows) == 1
+    c0 = rows[0]
+    assert c0["year_min"] is None
+    assert c0["year_max"] is None
+    assert c0["year_mean"] is None
+
+
+# ---------------------------------------------------------------------------
+# 8. Integración con b2g build: escribe clusters.csv para red de paper
+# ---------------------------------------------------------------------------
+
+
+def _seed_store(store_path: Path, rows: list[dict[str, Any]]) -> None:
+    """Puebla un DuckDBStore temporal con las filas dadas."""
+    from bib2graph.corpus import Corpus
+    from bib2graph.stores.duckdb import DuckDBStore
+
+    table = pa.Table.from_pylist(rows, schema=CORPUS_SCHEMA)
+    corpus = Corpus.from_arrow(table)
+    store = DuckDBStore(store_path)
+    store.persist(corpus)
+
+
+@pytest.mark.unit
+def test_build_escribe_clusters_csv(tmp_path: Path) -> None:
+    """run_build escribe clusters.csv en el directorio de la red de acoplamiento."""
+    from bib2graph.cli.commands.build import run_build
+
+    store_path = tmp_path / "lib.duckdb"
+    # Corpus con referencias compartidas → grafo de coupling no vacío
+    rows = [
+        _make_row(
+            id="oa:A1",
+            year=2020,
+            is_seed=True,
+            curation_status="accepted",
+            authors_raw=["Autor X"],
+            keywords_id=["kw1"],
+            references_id=["R1", "R2"],
+        ),
+        _make_row(
+            id="oa:A2",
+            year=2021,
+            is_seed=True,
+            curation_status="accepted",
+            authors_raw=["Autor Y"],
+            keywords_id=["kw1", "kw2"],
+            references_id=["R1", "R3"],
+        ),
+        _make_row(
+            id="oa:A3",
+            year=2022,
+            is_seed=False,
+            curation_status="candidate",
+            authors_raw=["Autor Z"],
+            keywords_id=["kw2"],
+            references_id=["R2", "R3"],
+        ),
+    ]
+    _seed_store(store_path, rows)
+
+    out_dir = tmp_path / "networks"
+    run_build(store_path, out_dir=out_dir)
+
+    clusters_csv = out_dir / "bibliographic_coupling" / "clusters.csv"
+    assert clusters_csv.exists(), (
+        "clusters.csv no fue creado para bibliographic_coupling"
+    )
+
+    with open(clusters_csv, encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        csv_rows = list(reader)
+
+    # Debe haber al menos 1 fila (puede haber múltiples clusters)
+    assert len(csv_rows) >= 1
+
+    # Las columnas esperadas deben existir
+    expected_cols = {
+        "cluster",
+        "size",
+        "seed_count",
+        "candidate_count",
+        "accepted_count",
+        "year_min",
+        "year_max",
+        "year_mean",
+        "top_authors",
+        "top_keywords",
+    }
+    assert expected_cols.issubset(set(reader.fieldnames or []))
+
+
+@pytest.mark.unit
+def test_build_no_falla_sin_comunidades(tmp_path: Path) -> None:
+    """run_build no falla cuando la red de coupling no produce aristas.
+
+    Un corpus con 0 referencias compartidas → grafo vacío → comunidades vacías
+    → cluster_table devuelve [] → no se escribe clusters.csv, pero tampoco falla.
+    """
+    from bib2graph.cli.commands.build import run_build
+
+    store_path = tmp_path / "lib.duckdb"
+    # Corpus sin referencias compartidas → grafo de coupling vacío (sin aristas)
+    rows = [
+        _make_row(
+            id="oa:B1",
+            year=2020,
+            is_seed=True,
+            curation_status="candidate",
+            references_id=["R_solo_1"],
+        ),
+        _make_row(
+            id="oa:B2",
+            year=2021,
+            is_seed=False,
+            curation_status="candidate",
+            references_id=["R_solo_2"],
+        ),
+    ]
+    _seed_store(store_path, rows)
+
+    out_dir = tmp_path / "networks"
+    result = run_build(store_path, out_dir=out_dir)
+    assert "networks" in result
+    assert result["networks_built"] >= 1
+    # clusters.csv puede o no existir, pero run_build no debe fallar
+    coupling_dir = out_dir / "bibliographic_coupling"
+    assert coupling_dir.exists()
+
+
+# ---------------------------------------------------------------------------
+# 9. cluster_table importable desde bib2graph.networks
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_cluster_table_importable_desde_networks() -> None:
+    """cluster_table es importable desde el paquete bib2graph.networks."""
+    from bib2graph.networks import cluster_table as ct
+
+    assert callable(ct)


### PR DESCRIPTION
Cierra **#31**: `cluster_table` (puro) agrega por comunidad (redes de paper); `b2g build` escribe `clusters.csv`. Cruce por `Col.ID` (lección B6), determinista (desempate -freq/nombre). verifier **PASA** (cazó+corrigió un no-determinismo de empates). **498 tests**, 0 enlaces rotos. Docs: API §7.2/§9.