### PR TITLE
feat(networks): capa declarativa NetworkSpec YAML + b2g networks (Hito 9)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,8 @@
 > (Enricher OpenAlex: refs→DOI + co-citación end-to-end) **y Hito 7 COMPLETO** (dedup fuzzy
 > determinista `rapidfuzz`, extra `[dedup]`), tras el red-team de la Nota 06 y el modelo
 > nuevo (ADR 0022/0023; el producto **no usa IA generativa** — el desarrollo SÍ es asistido por IA,
-> pero el scent es bibliométrico determinista). **Próximo: Hito 9 (`NetworkSpec` YAML).** Ver
+> pero el scent es bibliométrico determinista) **y el Hito 9 COMPLETO** (capa declarativa
+> `NetworkSpec` YAML: `load_specs` + `resolution` + 16° subcomando `b2g networks`). Ver
 > `docs/ROADMAP/` y "Estado actual" abajo. El diseño objetivo vive en
 > `docs/ARCHITECTURE.md`; los contratos
 > públicos en `docs/API.md`; el producto en `docs/PRD.md`; las reglas que motivan este código en
@@ -29,11 +30,21 @@
   (`DuckDBStore`), `sources/` (`OpenAlexSource`, `BibtexSource`), `foraging/` (`Forager`,
   scent bibliométrico), `preprocessors/` (normalize + thesaurus), `filters/` (PRISMA),
   `networks/` (proyectores, analyzer, spec, facade), `exporters/` (GraphML, CSV) y `cli/`.
-  El **CLI `b2g` es real** —paquete `cli/` con 15 subcomandos en `cli/commands/`, no un
-  placeholder—. **498 tests verdes** (mypy/ruff limpios; el núcleo importa sin `duckdb`). Entre las
+  El **CLI `b2g` es real** —paquete `cli/` con 16 subcomandos en `cli/commands/`, no un
+  placeholder (el 16° `b2g networks` es la capa declarativa YAML del Hito 9, abajo)—.
+  **516 tests verdes** (mypy/ruff limpios; el núcleo importa sin `duckdb`). Entre las
   redes, la **composición de comunidades es exportable**: `networks/cluster_table` (función pura)
   resume cada comunidad de una red de paper en una fila y `b2g build` la escribe como `clusters.csv`
   (#31, AS-BUILT 2026-06-17; ver `docs/API.md` §7.2).
+- **Hito 9 COMPLETO — capa declarativa `NetworkSpec` YAML** (AS-BUILT 2026-06-17): `NetworkSpec`
+  (`networks/spec.py`) suma el campo **`resolution: float = 1.0`** (resolución de Louvain, **fuera del
+  `corpus_hash`** → seed intacto) y **`extra="forbid"`**. Nueva función **`load_specs(path)`**
+  (re-exportada desde `networks/`; esquema raíz `networks:`, errores accionables citando archivo +
+  `red #<idx>` + campo). **16° subcomando `b2g networks --spec <yaml>`** (`cli/commands/networks.py`):
+  carga el YAML → `Networks.build` por red → escribe artefactos con el helper compartido
+  `_write_artifacts` (mismos GraphML + metrics.json + clusters.csv que `build`); **NO** transiciona el
+  `CycleState` ni sella `.corpus_hash` (transversal al lazo, como `enrich`/`curate`). `pyyaml` pasó a
+  dependencia del núcleo (import perezoso). **516 tests verdes**. Ver `docs/API.md` §10.
 - **Hito 8 COMPLETO** (Ciclos 8a + 8b, ADR
   [0025](docs/decisiones/0025-enricher-cocitacion-openalex.md)): el `OpenAlexEnricher` (opt-in,
   núcleo) hace 2 pasadas — **refs→DOI** (8a) **+ co-citación end-to-end** (8b): pobla `cited_by_id`
@@ -270,14 +281,16 @@ src/bib2graph/
   filters/             # filtros de inclusión/exclusión con conteo PRISMA (núcleo)
   enrichers/           # OpenAlexEnricher opt-in, NÚCLEO (Hito 8 ✅: refs→DOI 8a + co-citación 8b → pobla cited_by_id);
                        # Enricher Protocol; S2 ([s2]) reservado para señal adicional, NO el Enricher (ADR 0025)
-  networks/            # Projector, Analyzer, NetworkSpec, NetworkArtifact, Networks, cluster_table (#31)
+  networks/            # Projector, Analyzer, NetworkSpec (resolution + extra="forbid"), load_specs (YAML, Hito 9),
+                       # NetworkArtifact, Networks, cluster_table (#31)
   exporters/           # GraphML, CSV
   stores/              # DuckDBStore (núcleo, por defecto: biblioteca viva);
                        # ParquetStore (export); ZoteroStore ([zotero], V1.1);
                        # Neo4jStore ([neo4j], post-V1)
   cli/                 # paquete de 3 capas (Click → run_<cmd>() núcleo → envelope/errores);
-                       # cli/commands/ = 15 subcomandos (incl. monitor FSM→MONITORED, enrich refs→DOI + co-citación,
-                       # init scaffold de workspace —ADR 0029, curate dump/import CSV —#22+#26). CLI = API
+                       # cli/commands/ = 16 subcomandos (incl. monitor FSM→MONITORED, enrich refs→DOI + co-citación,
+                       # init scaffold de workspace —ADR 0029, curate dump/import CSV —#22+#26,
+                       # networks capa declarativa YAML —Hito 9). CLI = API
                        # para LLM y agentes (Hito 6, ARCHITECTURE.md §6.3). No es un cli.py plano.
   workspace.py         # Workspace (init/open/resolve) + WorkspaceManifest (ADR 0029): la carpeta es la
                        # unidad de persistencia; resolución ambiente; import perezoso de DuckDBStore

--- a/docs/API.md
+++ b/docs/API.md
@@ -85,6 +85,15 @@
 > transversal:** no transiciona el `CycleState`. Cierra el hueco de la
 > [Nota 09](Notas/09-sesion-qa-prueba-ecologia-valoraciones.md) B4/B5/P1 (no había dump CSV ni
 > reimport en lote: la curación a escala no era viable). Ver §convenciones CLI.
+>
+> **Sincronizado con la capa declarativa NetworkSpec — Hito 9 (AS-BUILT, 2026-06-17):** `NetworkSpec`
+> (§10) gana el campo **`resolution: float = 1.0`** (resolución de Louvain, fuera del `corpus_hash` —
+> seed intacto, R2) y **`extra="forbid"`** (campo desconocido en el YAML → error accionable). Nueva
+> función **`load_specs(redes.yaml)`** (carga/valida una lista de specs; clave raíz `networks:`) y el
+> **16° subcomando `b2g networks --spec`** (construye cada red con `Networks.build` y el helper
+> compartido `_write_artifacts`; mismo envelope que `build`; **NO** transiciona el `CycleState` ni
+> sella `.corpus_hash`). `pyyaml` pasó a dependencia del núcleo (import perezoso). Ver §10 +
+> §convenciones CLI.
 
 ## Convenciones
 
@@ -104,12 +113,12 @@ datos · `3` dependencia · `4` red · `5` store/snapshot corrupto o bloqueado).
 invocaciones:** el estado vive en el `library.duckdb` del **workspace** (opciones globales
 **opcionales** `--workspace`/`--store`, ver abajo).
 
-**Set de 15 subcomandos** (decisión del PO, ADR 0021 §A — **amplía** este doc, que antes listaba 9
+**Set de 16 subcomandos** (decisión del PO, ADR 0021 §A — **amplía** este doc, que antes listaba 9
 y dejaba `accept`/`reject` como "solo programático"; el 12° `monitor` se agregó en el cleanup
 pre-v0.3; el 13° `enrich` en el Ciclo 8a, ADR
 [0025](decisiones/0025-enricher-cocitacion-openalex.md); el 14° `init` con el workspace, ADR
 [0029](decisiones/0029-workspace-por-investigacion.md); el 15° `curate` con la curación a escala,
-#22 + #26):
+#22 + #26; el 16° `networks` con la capa declarativa YAML, Hito 9):
 
 - `seed`, `chain`, **`filter`** (filtros PRISMA deterministas: año/tipo/idioma/citas **con conteo
   en cada paso**), `build`, `export`, `snapshot`, **`status`** (expone el ciclo: estado actual,
@@ -180,6 +189,17 @@ pre-v0.3; el 13° `enrich` en el Ciclo 8a, ADR
     que el Forager guarde `scent` en provenance) y **`cluster` siempre vacío** (integración con redes
     diferida). **Curación TRANSVERSAL: `curate` NO transiciona el `CycleState`** (disponible en cualquier
     estado del lazo, igual que `accept`/`reject`; ADR 0016 enmendado R3). `--json` con `schema="1"`.
+- **`networks`** (Hito 9, AS-BUILT 2026-06-17): **capa declarativa** — construye redes desde un YAML
+  versionable. **`b2g networks --spec <redes.yaml>`** carga la lista de specs con `load_specs` (§10;
+  clave raíz `networks:`), construye cada red con `Networks.build` y escribe artefactos con el helper
+  compartido **`_write_artifacts`** (extraído de `build.py`): mismos GraphML + `metrics.json` +
+  `clusters.csv` que `build`, en `<out-dir>/<kind>/`. **`--out-dir`** override (default
+  `<workspace>/networks/`); resolución de store/workspace idéntica a `build` (`resolve_workspace`).
+  `--json` con `schema="1"`, mismo formato que `build` (lista de redes en `data["networks"]`, con
+  `clusters_csv` condicional). **Ejecución ad-hoc transversal al lazo: NO transiciona el `CycleState`
+  ni sella `networks/.corpus_hash`** (mismo criterio que `enrich`/`curate`). Errores accionables:
+  YAML malformado / spec inválida → `DataError` (exit 2); falta `python-louvain` → `DependencyError`
+  (exit 3).
 
 **`--workspace` / `--store` globales (ambos OPCIONALES, mutuamente excluyentes).** Van en el grupo
 `b2g`, **antes** del subcomando. Una investigación = un **workspace** (carpeta marcada por
@@ -204,8 +224,9 @@ archivo se generó—.
 
 **Transiciones automáticas del ciclo** (ADR 0021 §F; AS-BUILT R3): `seed`→`SEEDED`, `chain`→`FORAGED`,
 `filter`→`FILTERED`, `build`→`BUILT`, **`monitor`→`MONITORED`** (cleanup pre-v0.3);
-`accept`/`reject`/**`curate`**/`export`/`snapshot`/`status`/`inspect`/`validate`/**`enrich`** **no
-transicionan** (`curate` es curación transversal; `enrich` es ortogonal al lazo, ADR 0025). El estado
+`accept`/`reject`/**`curate`**/`export`/`snapshot`/`status`/`inspect`/`validate`/**`enrich`**/**`networks`**
+**no transicionan** (`curate` es curación transversal; `enrich` y `networks` son ortogonales al lazo,
+ADR 0025 / Hito 9). El estado
 destino lo dicta `bib2graph.cycle.apply_transition`
 (fuente única de verdad; los comandos no hardcodean el destino). `seed` con **estado previo** se trata
 como **`reseed`** (loop-back a `SEEDED`, ronda++, acumula sobre lo curado).
@@ -1098,10 +1119,12 @@ class CsvExporter: ...       # v1 — nodos.csv + aristas.csv para pandas
 
 ---
 
-## 10. Capa declarativa — `NetworkSpec` (v0.2, hook desde v1)
+## 10. Capa declarativa — `NetworkSpec` (v0.2, capa declarativa AS-BUILT Hito 9)
 
 ```python
 class NetworkSpec(BaseModel):
+    model_config = ConfigDict(extra="forbid")   # Hito 9: campo desconocido en el YAML → error
+                                                 # accionable (no se ignora en silencio)
     kind: NetworkKind        # R5: enum de constants.py (fuente única, ADR 0023);
                              # antes era un Literal[...] duplicado (eliminado)
     min_weight: int = 1
@@ -1109,10 +1132,21 @@ class NetworkSpec(BaseModel):
     max_year: int | None = None
     scope: Literal["full", "seeds_only"] = "full"
     clustering: Literal["louvain", "label_prop", "greedy_modularity"] | None = "louvain"
-    # Louvain ya es reproducible (random_state derivado del corpus_hash, Hito R2). El parámetro
-    # `resolution` (y demás params por algoritmo) se exponen acá en el Hito 9 (diferido de R2).
+    resolution: float = 1.0  # Hito 9: resolución de Louvain (python-louvain best_partition).
+                             # Default 1.0 = comportamiento anterior. Ignorado en label_prop/
+                             # greedy_modularity (sin error). FUERA del corpus_hash (param de spec,
+                             # no de contenido — como min_weight/scope; el seed de Louvain sigue
+                             # siendo función pura del corpus_hash, R2).
     assortativity_attribute: str | None = None     # p. ej. "region"
     layout: Literal["spring", "kamada_kawai", "circular"] | None = None
+
+
+def load_specs(path: str | Path) -> list[NetworkSpec]:
+    """Carga y valida una lista de NetworkSpec desde YAML (Hito 9). Re-exportada desde
+    bib2graph.networks. Clave raíz `networks:` = lista; cada entrada se valida con
+    NetworkSpec(**entry) (no se redefine el schema). Errores accionables (ValueError):
+    YAML malformado, falta de raíz `networks:`, entrada no-dict, y ValidationError citando
+    archivo + `red #<idx>` (0-based) + campo."""
 
 class NetworkArtifact:
     graph: nx.Graph
@@ -1134,8 +1168,9 @@ class Networks:
         Los artefactos vienen **decorados** (label legible + atributos de nodo, §7.1)."""
 ```
 
-**Modo quick** (v1) cubre baja fricción; **modo spec** (v0.2, YAML) cubre el pipeline declarativo
-versionable.
+**Modo quick** (v1) cubre baja fricción; **modo spec** (Hito 9, YAML) cubre el pipeline declarativo
+versionable, vía `load_specs(redes.yaml)` + `Networks.build` por red (y el subcomando `b2g
+networks --spec`, §convenciones CLI).
 
 **Notas de contrato** (Hito 2, ADR [0014](decisiones/0014-proyeccion-redes-pesos-asortatividad.md)):
 
@@ -1145,9 +1180,32 @@ versionable.
   **omite avisándolo por log** (→4) si esa columna está vacía (no se corrió `enrich`). El
   `CoCitationProjector` también queda disponible vía
   `Networks.build(corpus, NetworkSpec(kind="cocitation"))`.
-- **`NetworkSpec` es un hook mínimo en v1** (modelo Pydantic ya consumido por `build`/`quick`); la
-  carga desde YAML y la validación avanzada son del Hito 9. El símbolo público re-exportado desde
-  `bib2graph` es `NetworkArtifact` (no `NetworkSpec`, que se importa desde `bib2graph.networks`).
+- **`NetworkSpec` es un hook mínimo en v1** (modelo Pydantic ya consumido por `build`/`quick`); el
+  símbolo público re-exportado desde `bib2graph` es `NetworkArtifact` (no `NetworkSpec`, que se
+  importa desde `bib2graph.networks`).
+- **AS-BUILT Hito 9 (2026-06-17) — capa declarativa YAML.** `NetworkSpec` gana `model_config =
+  ConfigDict(extra="forbid")` (campo desconocido → error) y el campo **`resolution: float = 1.0`**
+  (resolución de Louvain, propagada por `_build_artifact` a
+  `community_louvain.best_partition(..., resolution=...)`; **ignorada** en `label_prop`/
+  `greedy_modularity`). `resolution` queda **fuera del `corpus_hash`** (es param de spec, no de
+  contenido — como `min_weight`/`scope`), así que el seed de Louvain sigue siendo función pura del
+  `corpus_hash` (R2) y la reproducibilidad/equivalencia de comunidades se mantienen. **`load_specs`**
+  (en `networks/spec.py`, re-exportada desde `bib2graph.networks`) carga la lista de specs desde un
+  YAML con clave raíz `networks:`; cada entrada se valida con `NetworkSpec(**entry)`. Errores
+  accionables (`ValueError`): YAML malformado, falta de raíz `networks:`, entrada no-dict, y
+  `ValidationError` citando archivo + `red #<idx>` (0-based) + campo. Ejemplo `redes.yaml`:
+
+  ```yaml
+  networks:
+    - kind: bibliographic_coupling
+      min_weight: 2
+      resolution: 1.5
+    - kind: author_collab
+      clustering: label_prop
+  ```
+
+  Se ejecuta vía el subcomando **`b2g networks --spec redes.yaml`** (§convenciones CLI). DoD del
+  Hito 9 cubierto, incluida la **equivalencia build≡quick** (nodos + aristas + comunidades).
 - **AS-BUILT #25 — artefactos decorados:** `_build_artifact` (en `facade.py`) aplica `decorate`
   (§7.1) sobre el grafo, así que `build`/`quick` devuelven artefactos con `label` legible + atributos
   de nodo (`year`/`is_seed`/`curation_status`/`degree_centrality`/`community`) listos para el export
@@ -1278,10 +1336,14 @@ b2g status --json     # CycleState + round + curation_available + workspace + co
 Retrocompat: `b2g --store biblioteca.duckdb seed …` (sin `init`, `.duckdb` suelto = workspace
 degenerado) sigue siendo válido.
 
-El **modo declarativo** (`b2g ... --spec redes.yaml`, `NetworkSpec` desde YAML) es del **Hito 9**
-(v0.3+), **no construido todavía**:
+El **modo declarativo** (`b2g networks --spec redes.yaml`, `NetworkSpec` desde YAML) está
+**construido** (Hito 9, AS-BUILT 2026-06-17): un YAML versionable describe qué redes calcular.
 
 ```bash
-# Hito 9 (futuro): pipeline declarativo desde un YAML versionable (dentro del workspace)
-b2g networks --spec redes.yaml --json
+# Hito 9: pipeline declarativo desde un YAML versionable (dentro del workspace)
+b2g networks --spec redes.yaml --json   # carga load_specs(redes.yaml) → Networks.build por red →
+                                        # escribe networks/<kind>/ (GraphML + metrics.json + clusters.csv)
 ```
+
+`b2g networks` es **ad-hoc / transversal al lazo**: **NO** transiciona el `CycleState` ni sella
+`networks/.corpus_hash` (igual criterio que `enrich`/`curate`). Ver §convenciones CLI.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -438,8 +438,9 @@ trabajo posterior, pero la API se **diseña con estos principios desde el hito 1
    faltante"); la capacidad-de-source-faltante se convierte en `DependencyError` mediante un
    **pre-check `hasattr` en el borde** (p. ej. `chain.py` antes del `Forager`). Ver ADR 0021 §D.
 
-Son **14 subcomandos** (`seed`, `chain`, `filter`, `build`, `export`, `snapshot`, `status`,
-`inspect`, `validate`, `accept`, `reject`, **`monitor`**, **`enrich`**, **`init`**); `build`/`export` están
+Son **16 subcomandos** (`seed`, `chain`, `filter`, `build`, `export`, `snapshot`, `status`,
+`inspect`, `validate`, `accept`, `reject`, **`monitor`**, **`enrich`**, **`init`**, **`curate`**,
+**`networks`**); `build`/`export` están
 **separados** y el `CycleState` transiciona automáticamente por comando (ADR 0021). El 12°
 **`monitor`** (cleanup pre-v0.3) re-chequea citantes nuevos del corpus (forward chaining) y
 transiciona a `MONITORED`. El 13° **`enrich`** (Hito 8 = Ciclos 8a + 8b, ADR
@@ -447,7 +448,11 @@ transiciona a `MONITORED`. El 13° **`enrich`** (Hito 8 = Ciclos 8a + 8b, ADR
 co-citación, flag `--max-citing`) y **no transiciona** el ciclo (ortogonal al lazo). El 14°
 **`init`** (AS-BUILT ADR [0029](decisiones/0029-workspace-por-investigacion.md)) hace scaffold de un
 workspace (carpeta + `workspace.json` + `library.duckdb` + `networks/`/`snapshots/`/`exports/`;
-`b2g init .` inicializa el cwd) y **no transiciona** el ciclo. El error de uso (p. ej.
+`b2g init .` inicializa el cwd) y **no transiciona** el ciclo. El 15° **`curate`** (#22 + #26) hace
+curación a escala vía CSV (dump/import en lote, transversal: **no transiciona** el ciclo). El 16°
+**`networks`** (Hito 9, AS-BUILT 2026-06-17) construye redes desde un YAML declarativo
+(`b2g networks --spec <yaml>`, `load_specs` + `Networks.build` por red, helper compartido
+`_write_artifacts`) y **no transiciona** el ciclo ni sella `.corpus_hash` (transversal al lazo). El error de uso (p. ej.
 `--workspace` y `--store` juntos, o ningún store/workspace resoluble) sale **sin envelope** (Click
 aborta el parseo: stderr + exit 1).
 

--- a/docs/ROADMAP/04-lo-que-viene.md
+++ b/docs/ROADMAP/04-lo-que-viene.md
@@ -101,7 +101,18 @@ cross-source.
 
 ---
 
-## Hito 9 — Capa declarativa: `NetworkSpec` (v0.2)
+## Hito 9 — Capa declarativa: `NetworkSpec` (v0.2) — **COMPLETO ✅**
+
+> **Hito 9 COMPLETO ✅ (2026-06-17):** `NetworkSpec` gana **carga declarativa desde YAML** vía
+> **`load_specs(path)`** (`networks/spec.py`, re-exportada desde `bib2graph.networks`; esquema raíz
+> `networks:` = lista, cada entrada validada con `NetworkSpec(**entry)`, errores accionables citando
+> archivo + `red #<idx>` + campo). Suma el campo **`resolution: float = 1.0`** (resolución de Louvain,
+> propagada por `_build_artifact` a `best_partition(..., resolution=...)`; ignorada en `label_prop`/
+> `greedy_modularity`; **fuera del `corpus_hash`** → seed de Louvain intacto, R2) y
+> **`extra="forbid"`** (campo desconocido → error). Nuevo **16° subcomando `b2g networks --spec
+> <yaml>`** (escribe artefactos con el helper compartido `_write_artifacts`; mismo envelope que
+> `build`; **NO** transiciona el `CycleState` ni sella `.corpus_hash`). `pyyaml` promovido al núcleo
+> (import perezoso). Gate verde, **516 tests**. Ver API.md §10 + §convenciones CLI.
 
 **Alcance**
 
@@ -116,14 +127,14 @@ qué se calcula). Abre la puerta a un GUI (editor de `NetworkSpec`).
 
 **Criterios de aceptación (DoD)**
 
-- Un `redes.yaml` válido carga y valida; uno inválido falla con error accionable.
-- `Networks.build(corpus, spec)` desde YAML es **equivalente** a la spec correspondiente de
-  `Networks.quick`.
+- **✅** Un `redes.yaml` válido carga y valida; uno inválido falla con error accionable.
+- **✅** `Networks.build(corpus, spec)` desde YAML es **equivalente** a la spec correspondiente de
+  `Networks.quick` (nodos + aristas + comunidades).
 
 **Tests (TDD — los justos)**
 
-- Carga/validación de un YAML válido y uno inválido (2 casos).
-- Equivalencia `build(spec)` ≡ la spec de `quick` para una red.
+- **✅** Carga/validación de un YAML válido y uno inválido (2 casos).
+- **✅** Equivalencia `build(spec)` ≡ la spec de `quick` para una red.
 
 **Se vuelve posible:** pipelines reproducibles versionados en git. Abre la puerta a un GUI.
 

--- a/docs/decisiones/0006-tabla-canonica-y-networkspec.md
+++ b/docs/decisiones/0006-tabla-canonica-y-networkspec.md
@@ -10,6 +10,14 @@
   **supersedida por [0009](0009-biblioteca-viva-duckdb.md)** (biblioteca viva stateful en DuckDB;
   el snapshot pasa a ser un *export* derivable del estado vivo). El resto de este ADR (tabla
   canónica Arrow + Pydantic, `NetworkSpec`, versionado/tooling) **sigue vigente**.
+- **Enmienda AS-BUILT (2026-06-17, Hito 9 — capa declarativa NetworkSpec):** la `NetworkSpec` de
+  este ADR ganó su **carga declarativa desde YAML**. Construido: el loader **`load_specs(path)`**
+  (`networks/spec.py`, re-exportado desde `bib2graph.networks`) con **esquema raíz `networks:`** (lista
+  de entradas, cada una validada con `NetworkSpec(**entry)`); el campo **`resolution: float = 1.0`**
+  (resolución de Louvain, fuera del `corpus_hash`); **`model_config = ConfigDict(extra="forbid")`**
+  (campo desconocido → error accionable); el **16° subcomando `b2g networks --spec <yaml>`**; y
+  **`pyyaml`** promovido a dependencia del núcleo (import perezoso). El cuerpo histórico abajo
+  (`NetworkSpec` como hook mínimo) **sigue vigente**; esto solo registra el AS-BUILT. Ver API.md §10.
 - **Enmienda (2026-06-15, 2º giro):** el punto "el `Corpus` es un *wrapper* delgado sobre la
   tabla" (sección A) queda **enmendado por [0015](0015-corpus-tabular-backend.md)**: el `Corpus`
   ya no envuelve una `pa.Table` cruda con semántica de valor, sino un **`TabularBackend`

--- a/docs/decisiones/0017-reproducibilidad-historia-snapshot.md
+++ b/docs/decisiones/0017-reproducibilidad-historia-snapshot.md
@@ -97,11 +97,13 @@ en fechas distintas no son comparables.
    `detect_communities(method="louvain")` se siembra con un `random_state` derivado del
    `corpus_hash` (`_louvain_seed_from_hash`, `facade.py`: `int(corpus_hash[:8], 16) % 2**31`),
    de modo que **mismo corpus → mismas comunidades** entre corridas.
-   **`resolution` diferido a Hito 9 (NetworkSpec):** la idea original incluía exponer el parámetro
-   `resolution` de Louvain; se difiere al Hito 9, donde `NetworkSpec` gana la carga declarativa
-   (YAML) y los parámetros por algoritmo. R2 entrega la pata que importa para la reproducibilidad
-   (el `random_state` seeded); `resolution` queda `python-louvain` default hasta entonces. El
-   diferimiento es aditivo (no rompe nada construido).
+   **`resolution` expuesta en Hito 9 ✅ (2026-06-17):** la idea original incluía exponer el parámetro
+   `resolution` de Louvain; se difirió al Hito 9 y ya está construido — `NetworkSpec.resolution: float
+   = 1.0`, propagado a `community_louvain.best_partition(..., resolution=...)`, **fuera del
+   `corpus_hash`** (param de spec, no de contenido), así que el seed de Louvain (`random_state`
+   derivado del `corpus_hash`) queda **intacto** y la reproducibilidad se mantiene. R2 entregó la pata
+   que importa para la reproducibilidad (el `random_state` seeded); la exposición de `resolution` es
+   aditiva (no rompe nada construido).
 
 **Consecuencia:** el snapshot vuelve a ser **reproducible bit a bit** (cumple la promesa original) y
 la pureza de `facade.py` ("mismo corpus + mismo spec → mismo `NetworkArtifact`") deja de estar rota.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,14 +43,24 @@ classifiers = [
     "Topic :: Text Processing :: Markup",
 ]
 dependencies = [
-    "pyarrow>=15",       # tabla canónica (ADR 0006)
-    "pydantic>=2.6",     # validación del wrapper Corpus y Manifest
-    "networkx>=3.2",     # grafos
-    "click>=8.1",        # CLI agente-native (ADR 0010)
-    "tqdm>=4.66",        # progreso
-    "duckdb>=0.10",      # biblioteca viva, persistencia por defecto (ADR 0009)
-    "httpx>=0.27",       # cliente OpenAlex backbone; testeable con MockTransport (ADR 0007)
-    "python-louvain>=0.16",  # comunidades Louvain; DECLARADO, nunca usado sin declarar (lección 7)
+    "pyarrow>=15",
+    # tabla canónica (ADR 0006)
+    "pydantic>=2.6",
+    # validación del wrapper Corpus y Manifest
+    "networkx>=3.2",
+    # grafos
+    "click>=8.1",
+    # CLI agente-native (ADR 0010)
+    "tqdm>=4.66",
+    # progreso
+    "duckdb>=0.10",
+    # biblioteca viva, persistencia por defecto (ADR 0009)
+    "httpx>=0.27",
+    # cliente OpenAlex backbone; testeable con MockTransport (ADR 0007)
+    "python-louvain>=0.16",
+    # comunidades Louvain; DECLARADO, nunca usado sin declarar (lección 7)
+    "pyyaml>=6.0.3",
+    # parser de specs declarativas (NetworkSpec YAML, Hito 9)
 ]
 
 [project.optional-dependencies]
@@ -107,6 +117,7 @@ dev-dependencies = [
     "commitizen>=3.13",
     "types-tqdm",
     "types-networkx>=3.6.1.20260612",
+    "types-pyyaml>=6.0.12.20260518",
 ]
 
 # ----- Tooling ------------------------------------------------------------

--- a/src/bib2graph/cli/__init__.py
+++ b/src/bib2graph/cli/__init__.py
@@ -1,6 +1,6 @@
 """cli — CLI agente-native ``b2g`` (Hito 6 + ADR 0029 workspace).
 
-Arma el grupo Click principal, registra los 14 subcomandos y expone
+Arma el grupo Click principal, registra los 16 subcomandos y expone
 ``main()`` como entry point del paquete.
 
 Entry point en ``pyproject.toml``:
@@ -8,7 +8,7 @@ Entry point en ``pyproject.toml``:
 
 Subcomandos:
     init, seed, chain, filter, build, enrich, monitor, export, snapshot,
-    status, inspect, validate, accept, reject, curate.
+    status, inspect, validate, accept, reject, curate, networks.
 
 Cada subcomando lleva:
   - ``--json``: salida JSON estructurada (envelope versionado, §API.md).
@@ -46,6 +46,7 @@ from bib2graph.cli.commands.filter import filter_cmd
 from bib2graph.cli.commands.init import init_cmd
 from bib2graph.cli.commands.inspect import inspect_cmd
 from bib2graph.cli.commands.monitor import monitor_cmd
+from bib2graph.cli.commands.networks import networks_cmd
 from bib2graph.cli.commands.reject import reject_cmd
 from bib2graph.cli.commands.seed import seed_cmd
 from bib2graph.cli.commands.snapshot import snapshot_cmd
@@ -106,7 +107,7 @@ def b2g(ctx: click.Context, workspace: str | None, store: str | None) -> None:
     error accionable (exit 1) que sugiere 'b2g init' o '--workspace'.
 
     Subcomandos: init, seed, chain, filter, build, enrich, monitor, export,
-    snapshot, status, inspect, validate, accept, reject, curate.
+    snapshot, status, inspect, validate, accept, reject, curate, networks.
 
     Ejemplo con workspace:
         b2g init mi-investigacion
@@ -122,7 +123,7 @@ def b2g(ctx: click.Context, workspace: str | None, store: str | None) -> None:
     ctx.obj["store"] = store
 
 
-# Registrar los 15 subcomandos
+# Registrar los 16 subcomandos
 b2g.add_command(init_cmd)
 b2g.add_command(seed_cmd)
 b2g.add_command(chain_cmd)
@@ -138,6 +139,7 @@ b2g.add_command(validate_cmd)
 b2g.add_command(accept_cmd)
 b2g.add_command(reject_cmd)
 b2g.add_command(curate_cmd)
+b2g.add_command(networks_cmd)
 
 
 def main() -> int:

--- a/src/bib2graph/cli/commands/build.py
+++ b/src/bib2graph/cli/commands/build.py
@@ -20,9 +20,10 @@ Los artefactos se escriben en ``<networks_dir>/<kind>/``:
 
 from __future__ import annotations
 
+import csv as _csv
 import json
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import click
 
@@ -30,69 +31,41 @@ from bib2graph.cli._envelope import build_envelope, emit, emit_human
 from bib2graph.cli._errors import DependencyError, handle_errors
 from bib2graph.cli._store import open_store, resolve_workspace
 
+if TYPE_CHECKING:
+    from bib2graph.corpus import Corpus
+    from bib2graph.networks.spec import NetworkArtifact
+
+
 # ---------------------------------------------------------------------------
-# Función núcleo (testeable, sin Click)
+# Helper compartido: escritura de artefactos por red
 # ---------------------------------------------------------------------------
 
 
-def run_build(
-    store_path: str | Path,
-    *,
-    out_dir: str | Path | None = None,
-) -> dict[str, Any]:
-    """Computa redes bibliométricas y escribe artefactos a disco.
+def _write_artifacts(
+    artifacts: list[NetworkArtifact],
+    corpus: Corpus,
+    artifacts_dir: Path,
+) -> list[dict[str, Any]]:
+    """Escribe GraphML + metrics.json + clusters.csv por cada ``NetworkArtifact``.
 
-    Usa ``Networks.quick`` para las 4 redes principales (coupling, co-autoría,
-    institución, co-word). Escribe GraphML + metrics.json por red.
-    Para redes de paper con comunidades detectadas escribe también clusters.csv
-    (tabla de resumen de comunidades, issue #31).
-    Sella ``networks/.corpus_hash`` con el hash del corpus que las produjo.
-    Transiciona a BUILT tras escribir con éxito.
+    Helper reutilizable por ``run_build`` y ``run_networks``.  Contiene SOLO la
+    lógica de export de artefactos: NO transiciona ``CycleState`` ni sella
+    ``.corpus_hash`` (esas responsabilidades quedan en quien llame a esta función).
 
     Args:
-        store_path: Ruta al archivo ``.duckdb``.
-        out_dir: Directorio base de salida. Default: ``<store_dir>/networks/``.
+        artifacts: Lista de artefactos a exportar.
+        corpus: Corpus origen (se necesita para ``cluster_table``).
+        artifacts_dir: Directorio base donde se crean las subcarpetas ``<kind>/``.
 
     Returns:
-        Dict con ``networks_built``, ``artifacts_dir``, ``corpus_hash``
-        y lista de redes.
-
-    Raises:
-        DependencyError: Si falta ``python-louvain``.
-        StoreError: Si el store está bloqueado.
+        Lista de dicts con ``kind``, ``nodes``, ``edges``, ``graphml``,
+        ``metrics_json`` y (si aplica) ``clusters_csv``.
     """
-    import csv as _csv
-
-    from bib2graph.cycle import apply_transition
     from bib2graph.exporters.graphml import GraphMLExporter
     from bib2graph.networks.clusters import cluster_table
-    from bib2graph.networks.facade import Networks
-
-    store = open_store(store_path)
-    corpus = store.load()
-
-    # R3 — fuente única de verdad: el destino de la transición lo dicta cycle.py,
-    # no un literal en el comando (ADR 0016 enmendado §1).
-    current_state = store.backend.loop_state()
-    current_round = store.backend.loop_round()
-    new_state, new_round = apply_transition(current_state, "build", current_round)
-
-    store_path_obj = Path(store_path)
-    if out_dir is None:
-        artifacts_dir = store_path_obj.parent / "networks"
-    else:
-        artifacts_dir = Path(out_dir)
-
-    try:
-        artifacts = Networks.quick(corpus)
-    except ImportError as exc:
-        raise DependencyError(
-            f"Dependencia faltante para detectar comunidades: {exc}. "
-            "Instalá python-louvain: uv add python-louvain."
-        ) from exc
 
     exporter = GraphMLExporter()
-    networks_info = []
+    networks_info: list[dict[str, Any]] = []
 
     for art in artifacts:
         kind = art.spec.kind
@@ -170,6 +143,68 @@ def run_build(
         if clusters_path is not None:
             net_entry["clusters_csv"] = clusters_path
         networks_info.append(net_entry)
+
+    return networks_info
+
+
+# ---------------------------------------------------------------------------
+# Función núcleo (testeable, sin Click)
+# ---------------------------------------------------------------------------
+
+
+def run_build(
+    store_path: str | Path,
+    *,
+    out_dir: str | Path | None = None,
+) -> dict[str, Any]:
+    """Computa redes bibliométricas y escribe artefactos a disco.
+
+    Usa ``Networks.quick`` para las 4 redes principales (coupling, co-autoría,
+    institución, co-word). Escribe GraphML + metrics.json por red.
+    Para redes de paper con comunidades detectadas escribe también clusters.csv
+    (tabla de resumen de comunidades, issue #31).
+    Sella ``networks/.corpus_hash`` con el hash del corpus que las produjo.
+    Transiciona a BUILT tras escribir con éxito.
+
+    Args:
+        store_path: Ruta al archivo ``.duckdb``.
+        out_dir: Directorio base de salida. Default: ``<store_dir>/networks/``.
+
+    Returns:
+        Dict con ``networks_built``, ``artifacts_dir``, ``corpus_hash``
+        y lista de redes.
+
+    Raises:
+        DependencyError: Si falta ``python-louvain``.
+        StoreError: Si el store está bloqueado.
+    """
+    from bib2graph.cycle import apply_transition
+    from bib2graph.networks.facade import Networks
+
+    store = open_store(store_path)
+    corpus = store.load()
+
+    # R3 — fuente única de verdad: el destino de la transición lo dicta cycle.py,
+    # no un literal en el comando (ADR 0016 enmendado §1).
+    current_state = store.backend.loop_state()
+    current_round = store.backend.loop_round()
+    new_state, new_round = apply_transition(current_state, "build", current_round)
+
+    store_path_obj = Path(store_path)
+    if out_dir is None:
+        artifacts_dir = store_path_obj.parent / "networks"
+    else:
+        artifacts_dir = Path(out_dir)
+
+    try:
+        artifacts = Networks.quick(corpus)
+    except ImportError as exc:
+        raise DependencyError(
+            f"Dependencia faltante para detectar comunidades: {exc}. "
+            "Instalá python-louvain: uv add python-louvain."
+        ) from exc
+
+    networks_info = _write_artifacts(artifacts, corpus, artifacts_dir)
 
     # ADR 0029 — sellar con corpus_hash para detección de staleness.
     # El hash ya lo tiene el corpus vía Manifest/CorpusSnapshot; lo derivamos

--- a/src/bib2graph/cli/commands/networks.py
+++ b/src/bib2graph/cli/commands/networks.py
@@ -1,0 +1,166 @@
+"""cli.commands.networks — Subcomando ``b2g networks``.
+
+Carga una especificación declarativa de redes desde un archivo YAML y
+construye cada red, escribiendo artefactos a disco.
+
+A diferencia de ``b2g build`` (que usa ``Networks.quick`` y transiciona el
+``CycleState`` del lazo bibliométrico), este subcomando es **ad-hoc**:
+  - Acepta cualquier combinación de redes definidas en el YAML.
+  - NO transiciona el ``CycleState`` ni sella ``.corpus_hash``
+    (ejecución declarativa transversal al lazo — mismo criterio que
+    ``b2g enrich`` y ``b2g curate``).
+
+Los artefactos se escriben en ``<out_dir>/<kind>/``:
+  - ``network.graphml``: el grafo en formato GraphML.
+  - ``metrics.json``: métricas de red calculadas.
+  - ``clusters.csv``: tabla de resumen de comunidades (solo redes de paper
+    con comunidades detectadas, issue #31).
+
+Envelope ``--json`` (schema="1"): lista de redes en el mismo formato que
+``b2g build``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import click
+
+from bib2graph.cli._envelope import build_envelope, emit, emit_human
+from bib2graph.cli._errors import DataError, DependencyError, handle_errors
+from bib2graph.cli._store import open_store, resolve_workspace
+from bib2graph.cli.commands.build import _write_artifacts
+
+# ---------------------------------------------------------------------------
+# Función núcleo (testeable, sin Click)
+# ---------------------------------------------------------------------------
+
+
+def run_networks(
+    store_path: str | Path,
+    spec_path: str | Path,
+    *,
+    out_dir: str | Path | None = None,
+) -> dict[str, Any]:
+    """Construye redes bibliométricas desde una especificación YAML.
+
+    Carga ``spec_path`` con ``load_specs``, construye cada red con
+    ``Networks.build`` y escribe artefactos con el helper ``_write_artifacts``
+    (compartido con ``run_build``).
+
+    NO transiciona el ``CycleState`` ni sella ``.corpus_hash``:
+    esta operación es transversal al lazo bibliométrico (igual que ``enrich``
+    y ``curate``).
+
+    Args:
+        store_path: Ruta al archivo ``.duckdb``.
+        spec_path: Ruta al archivo YAML con la definición de redes.
+        out_dir: Directorio base de salida. Default: ``<store_dir>/networks/``.
+
+    Returns:
+        Dict con ``networks_built``, ``artifacts_dir`` y lista de redes
+        (mismo esquema que ``run_build``).
+
+    Raises:
+        DataError: Si el YAML está malformado o alguna spec es inválida.
+        DependencyError: Si falta ``python-louvain``.
+        StoreError: Si el store está bloqueado.
+    """
+    from bib2graph.networks.facade import Networks
+    from bib2graph.networks.spec import load_specs
+
+    store = open_store(store_path)
+    corpus = store.load()
+
+    store_path_obj = Path(store_path)
+    if out_dir is None:
+        artifacts_dir = store_path_obj.parent / "networks"
+    else:
+        artifacts_dir = Path(out_dir)
+
+    try:
+        specs = load_specs(spec_path)
+    except (ValueError, FileNotFoundError) as exc:
+        raise DataError(str(exc)) from exc
+
+    try:
+        artifacts = [Networks.build(corpus, spec) for spec in specs]
+    except ImportError as exc:
+        raise DependencyError(
+            f"Dependencia faltante para detectar comunidades: {exc}. "
+            "Instalá python-louvain: uv add python-louvain."
+        ) from exc
+
+    networks_info = _write_artifacts(artifacts, corpus, artifacts_dir)
+
+    return {
+        "networks_built": len(artifacts),
+        "artifacts_dir": str(artifacts_dir),
+        "networks": networks_info,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Comando Click
+# ---------------------------------------------------------------------------
+
+
+@click.command("networks")
+@click.option(
+    "--spec",
+    "spec_path",
+    required=True,
+    type=click.Path(exists=True, dir_okay=False),
+    help="Ruta al archivo YAML con la especificación de redes.",
+)
+@click.option(
+    "--out-dir",
+    default=None,
+    help=(
+        "Directorio base de artefactos "
+        "(default: <workspace>/networks/ o <store_dir>/networks/)."
+    ),
+)
+@click.option(
+    "--json",
+    "json_output",
+    is_flag=True,
+    default=False,
+    help="Salida JSON estructurada.",
+)
+@click.pass_context
+@handle_errors("networks")
+def networks_cmd(
+    ctx: click.Context,
+    spec_path: str,
+    out_dir: str | None,
+    json_output: bool,
+) -> None:
+    """Construye redes bibliométricas desde una especificación YAML.
+
+    Carga el YAML indicado con --spec, valida cada red contra NetworkSpec y
+    escribe artefactos (GraphML + metrics.json + clusters.csv cuando aplica).
+
+    No transiciona el estado del lazo bibliométrico.
+    """
+    ws = resolve_workspace(ctx.obj)
+    effective_out_dir: str | Path | None = out_dir
+    if effective_out_dir is None:
+        effective_out_dir = ws.networks_dir
+
+    data = run_networks(ws.library_path, spec_path, out_dir=effective_out_dir)
+
+    if json_output:
+        envelope = build_envelope(
+            command="networks",
+            ok=True,
+            data=data,
+            exit_code=0,
+        )
+        emit(envelope)
+    else:
+        emit_human(f"Redes construidas: {data['networks_built']}")
+        emit_human(f"Artefactos en: {data['artifacts_dir']}")
+        for net in data["networks"]:
+            emit_human(f"  {net['kind']}: {net['nodes']} nodos, {net['edges']} aristas")

--- a/src/bib2graph/networks/__init__.py
+++ b/src/bib2graph/networks/__init__.py
@@ -33,7 +33,7 @@ from bib2graph.networks.projectors import (
     KeywordCoOccurrenceProjector,
     collect_item_to_papers,
 )
-from bib2graph.networks.spec import NetworkArtifact, NetworkSpec
+from bib2graph.networks.spec import NetworkArtifact, NetworkSpec, load_specs
 
 __all__ = [
     "MIN_WEIGHT_DEFAULT",
@@ -55,5 +55,6 @@ __all__ = [
     "decorate",
     "decorate_graph",
     "detect_communities",
+    "load_specs",
     "network_metrics",
 ]

--- a/src/bib2graph/networks/analyzer.py
+++ b/src/bib2graph/networks/analyzer.py
@@ -107,6 +107,7 @@ def detect_communities(
     method: str = "louvain",
     *,
     random_state: int | None = None,
+    resolution: float = 1.0,
 ) -> dict[Any, int]:
     """Detecta comunidades en el grafo con el método indicado.
 
@@ -122,6 +123,10 @@ def detect_communities(
         random_state: Semilla entera para reproducibilidad de Louvain
             (solo se usa cuando ``method='louvain'``).  Si es ``None``,
             Louvain corre sin semilla (no reproducible).
+        resolution: Parámetro de resolución para Louvain (``best_partition``).
+            Default 1.0 = comportamiento estándar de python-louvain.
+            Se ignora para ``label_prop`` y ``greedy_modularity`` (no es un error;
+            esos algoritmos no tienen parámetro de resolución equivalente).
 
     Returns:
         Dict nodo → id de comunidad (int).
@@ -141,7 +146,7 @@ def detect_communities(
                 "'python-louvain'. Instalalo con: uv add python-louvain"
             ) from None
         partition: dict[Any, int] = community_louvain.best_partition(
-            g, random_state=random_state
+            g, random_state=random_state, resolution=resolution
         )
         return partition
 

--- a/src/bib2graph/networks/facade.py
+++ b/src/bib2graph/networks/facade.py
@@ -159,7 +159,10 @@ def _build_artifact(corpus: Corpus, spec: NetworkSpec) -> NetworkArtifact:
                 corpus_hash = corpus._backend.corpus_hash()
                 random_state = _louvain_seed_from_hash(corpus_hash)
             communities = detect_communities(
-                g, method=spec.clustering, random_state=random_state
+                g,
+                method=spec.clustering,
+                random_state=random_state,
+                resolution=spec.resolution,
             )
         except ImportError:
             raise  # dep faltante: fallar fuerte (lección 7, AGENTS.md)

--- a/src/bib2graph/networks/spec.py
+++ b/src/bib2graph/networks/spec.py
@@ -1,8 +1,9 @@
-"""spec — NetworkSpec (hook mínimo) y NetworkArtifact.
+"""spec — NetworkSpec (modelo declarativo) y NetworkArtifact.
 
 Contiene los tipos de datos centrales del módulo de redes:
-  - ``NetworkSpec``: configuración declarativa de una red (hook para Hito 9).
+  - ``NetworkSpec``: configuración declarativa de una red (Hito 9).
   - ``NetworkArtifact``: resultado de proyectar + analizar un corpus.
+  - ``load_specs``: carga y valida una lista de ``NetworkSpec`` desde YAML.
 
 R5: ``NetworkSpec.kind`` usa ``NetworkKind`` como tipo (fuente única, ADR 0023).
 El ``Literal[...]`` duplicado fue eliminado; mypy sigue validando porque
@@ -14,10 +15,11 @@ Ver API.md §10.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
 import networkx as nx
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict, ValidationError
 
 from bib2graph.constants import NetworkKind
 
@@ -31,11 +33,14 @@ else:
 class NetworkSpec(BaseModel):
     """Configuración declarativa de una red bibliométrica.
 
-    Hito 2: se usa como hook mínimo en ``Networks.build``/``Networks.quick``.
-    La carga desde YAML y la validación avanzada se implementan en el Hito 9.
+    Hito 9: soporta carga desde YAML vía ``load_specs``.
 
     R5: ``kind`` es de tipo ``NetworkKind`` (fuente única, ADR 0023).  Ya no
     hay un ``Literal[...]`` duplicado en ``spec.py`` y ``facade.py``.
+
+    ``extra="forbid"``: campos desconocidos en el YAML producen un error
+    accionable en ``load_specs`` (citando el campo y el índice de la red),
+    en vez de ignorarse silenciosamente.
 
     Args:
         kind: Tipo de red a proyectar (``NetworkKind`` enum).
@@ -44,9 +49,14 @@ class NetworkSpec(BaseModel):
         max_year: Filtro de año máximo (futuro).
         scope: Alcance de la proyección.
         clustering: Método de detección de comunidades.
+        resolution: Resolución para Louvain (python-louvain ``best_partition``).
+            Default 1.0 reproduce el comportamiento anterior. Ignorado para
+            ``label_prop`` y ``greedy_modularity`` (sin error).
         assortativity_attribute: Atributo categórico para asortatividad.
         layout: Algoritmo de layout para visualización (futuro).
     """
+
+    model_config = ConfigDict(extra="forbid")
 
     kind: NetworkKind
     min_weight: int = 1
@@ -54,8 +64,87 @@ class NetworkSpec(BaseModel):
     max_year: int | None = None
     scope: Literal["full", "seeds_only"] = "full"
     clustering: Literal["louvain", "label_prop", "greedy_modularity"] | None = "louvain"
+    resolution: float = 1.0
     assortativity_attribute: str | None = None
     layout: Literal["spring", "kamada_kawai", "circular"] | None = None
+
+
+def load_specs(path: str | Path) -> list[NetworkSpec]:
+    """Carga y valida una lista de ``NetworkSpec`` desde un archivo YAML.
+
+    El documento YAML debe tener la clave raíz ``networks:`` con una lista de
+    entradas; cada entrada se valida construyendo ``NetworkSpec(**entry)`` para
+    reusar la validación Pydantic (no se redefine el schema).
+
+    Errores accionables:
+    - YAML malformado (sintaxis) → ``ValueError`` con el detalle del
+      ``yaml.YAMLError``.
+    - Spec inválida (``kind`` desconocido, campo extra, tipo incorrecto) →
+      ``ValueError`` citando el archivo, el índice de la red (0-based) y el
+      campo problemático extraído del ``ValidationError`` de Pydantic.
+
+    Args:
+        path: Ruta al archivo YAML con la definición de redes.
+
+    Returns:
+        Lista de ``NetworkSpec`` validadas, en el orden del archivo.
+
+    Raises:
+        ValueError: Si el YAML está malformado, falta la clave ``networks:``,
+            o alguna entrada no cumple el schema de ``NetworkSpec``.
+        FileNotFoundError: Si el archivo no existe.
+
+    Ejemplo de YAML válido::
+
+        networks:
+          - kind: bibliographic_coupling
+            min_weight: 2
+            resolution: 1.5
+          - kind: author_collab
+            clustering: label_prop
+    """
+    import yaml  # importación perezosa — PyYAML es dependencia declarada del proyecto
+
+    resolved = Path(path)
+
+    try:
+        raw = yaml.safe_load(resolved.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        raise ValueError(f"YAML malformado en '{resolved}': {exc}") from exc
+
+    if not isinstance(raw, dict) or "networks" not in raw:
+        raise ValueError(
+            f"El archivo '{resolved}' debe tener una clave raíz 'networks:' "
+            "con una lista de definiciones de red."
+        )
+
+    entries = raw["networks"]
+    if not isinstance(entries, list):
+        raise ValueError(
+            f"La clave 'networks:' en '{resolved}' debe ser una lista, "
+            f"pero se encontró: {type(entries).__name__}."
+        )
+
+    specs: list[NetworkSpec] = []
+    for idx, entry in enumerate(entries):
+        if not isinstance(entry, dict):
+            raise ValueError(
+                f"'{resolved}' — red #{idx}: se esperaba un objeto de campos, "
+                f"pero se encontró: {type(entry).__name__}."
+            )
+        try:
+            specs.append(NetworkSpec(**entry))
+        except ValidationError as exc:
+            # Extraer el primer error para dar un mensaje accionable
+            first_error = exc.errors()[0]
+            field = ".".join(str(loc) for loc in first_error["loc"]) or "<root>"
+            msg = first_error["msg"]
+            raise ValueError(
+                f"'{resolved}' — red #{idx}: campo '{field}': {msg}. "
+                f"({len(exc.errors())} error(es) de validación en total)"
+            ) from exc
+
+    return specs
 
 
 @dataclass

--- a/tests/unit/test_networkspec_yaml.py
+++ b/tests/unit/test_networkspec_yaml.py
@@ -1,0 +1,530 @@
+"""Tests TDD del Hito 9 — capa declarativa NetworkSpec (YAML).
+
+Casos cubiertos (docs/ROADMAP — Hito 9 DoD):
+
+1. load_specs: YAML válido (1-2 redes) → lista de NetworkSpec correctos
+   (incluido campo ``resolution``).
+2. load_specs: YAML malformado (sintaxis) → ValueError accionable.
+3. load_specs: YAML válido pero spec inválida (kind inexistente, campo extra)
+   → ValueError accionable que cita el índice de la red y el campo.
+4. Equivalencia build≡quick: para bibliographic_coupling con defaults, la red
+   producida por Networks.build(corpus, spec_desde_yaml_con_defaults) tiene los
+   mismos nodos/aristas que Networks.quick(corpus)[coupling].
+5. No-regresión resolution=1.0 ≡ comportamiento actual (default).
+6. Subcomando b2g networks --spec end-to-end con CliRunner: corre, escribe
+   artefactos, NO transiciona el CycleState, envelope JSON correcto.
+
+Marcador: ``unit`` (sin red ni I/O externo; DuckDB en tmp_path).
+Fecha de fixtures: 2026-06-17.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pyarrow as pa
+import pytest
+
+from bib2graph.networks.spec import NetworkSpec, load_specs
+from bib2graph.schemas import CORPUS_SCHEMA
+
+# ---------------------------------------------------------------------------
+# Fixtures comunes
+# ---------------------------------------------------------------------------
+
+
+def _make_corpus_rows() -> list[dict[str, Any]]:
+    """3 papers con referencias compartidas (produce aristas de coupling)."""
+    return [
+        {
+            "id": f"P{i}",
+            "openalex_id": None,
+            "doi": None,
+            "title": f"Paper {i}",
+            "year": 2020,
+            "abstract": None,
+            "source": None,
+            "language": None,
+            "publisher": None,
+            "research_areas": None,
+            "is_seed": True,
+            "curation_status": "candidate",
+            "provenance": None,
+            "authors_raw": None,
+            "authors_id": [f"AUTH_{i}", "AUTH_0"],
+            "authors_affiliations": None,
+            "keywords_raw": None,
+            "keywords_id": [f"KW_{i}", "KW_SHARED"],
+            "institutions_raw": None,
+            "institutions_id": [f"INST_{i}"],
+            "references_id": [f"REF_{i}", "REF_SHARED"],
+            "references_doi": None,
+            "cited_by_id": None,
+        }
+        for i in range(3)
+    ]
+
+
+def _make_corpus():  # type: ignore[no-untyped-def]
+    """Corpus Arrow mínimo con estructura de coupling."""
+    from bib2graph.corpus import Corpus
+
+    rows = _make_corpus_rows()
+    table = pa.Table.from_pylist(rows, schema=CORPUS_SCHEMA)
+    return Corpus.from_arrow(table)
+
+
+def _seed_store(store_path: Path) -> None:
+    """Pobla un store con corpus mínimo para tests CLI."""
+    from bib2graph.corpus import Corpus
+    from bib2graph.stores.duckdb import DuckDBStore
+
+    rows = _make_corpus_rows()
+    table = pa.Table.from_pylist(rows, schema=CORPUS_SCHEMA)
+    corpus = Corpus.from_arrow(table)
+    store = DuckDBStore(store_path)
+    store.persist(corpus)
+
+
+# ---------------------------------------------------------------------------
+# 1. load_specs: YAML válido → NetworkSpec correctos
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_load_specs_yaml_valido_una_red(tmp_path: Path) -> None:
+    """YAML válido con 1 red → lista con 1 NetworkSpec con los campos correctos."""
+    yaml_content = """\
+networks:
+  - kind: bibliographic_coupling
+    min_weight: 2
+    resolution: 1.5
+"""
+    spec_file = tmp_path / "redes.yaml"
+    spec_file.write_text(yaml_content, encoding="utf-8")
+
+    specs = load_specs(spec_file)
+
+    assert len(specs) == 1
+    spec = specs[0]
+    assert isinstance(spec, NetworkSpec)
+    assert spec.kind == "bibliographic_coupling"
+    assert spec.min_weight == 2
+    assert spec.resolution == 1.5
+
+
+@pytest.mark.unit
+def test_load_specs_yaml_valido_dos_redes(tmp_path: Path) -> None:
+    """YAML válido con 2 redes → lista con 2 NetworkSpec en el orden correcto."""
+    yaml_content = """\
+networks:
+  - kind: bibliographic_coupling
+  - kind: author_collab
+    clustering: label_prop
+"""
+    spec_file = tmp_path / "redes.yaml"
+    spec_file.write_text(yaml_content, encoding="utf-8")
+
+    specs = load_specs(spec_file)
+
+    assert len(specs) == 2
+    assert specs[0].kind == "bibliographic_coupling"
+    assert specs[1].kind == "author_collab"
+    assert specs[1].clustering == "label_prop"
+
+
+@pytest.mark.unit
+def test_load_specs_defaults_correctos(tmp_path: Path) -> None:
+    """Una red sin campos opcionales usa los defaults de NetworkSpec."""
+    yaml_content = "networks:\n  - kind: keyword_cooccurrence\n"
+    spec_file = tmp_path / "redes.yaml"
+    spec_file.write_text(yaml_content, encoding="utf-8")
+
+    specs = load_specs(spec_file)
+
+    spec = specs[0]
+    assert spec.min_weight == 1
+    assert spec.resolution == 1.0
+    assert spec.clustering == "louvain"
+    assert spec.scope == "full"
+
+
+@pytest.mark.unit
+def test_load_specs_campo_resolution_en_yaml(tmp_path: Path) -> None:
+    """El campo resolution se carga correctamente desde el YAML."""
+    yaml_content = "networks:\n  - kind: bibliographic_coupling\n    resolution: 0.5\n"
+    spec_file = tmp_path / "redes.yaml"
+    spec_file.write_text(yaml_content, encoding="utf-8")
+
+    specs = load_specs(spec_file)
+
+    assert specs[0].resolution == 0.5
+
+
+# ---------------------------------------------------------------------------
+# 2. load_specs: YAML malformado → ValueError accionable
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_load_specs_yaml_malformado_lanza_value_error(tmp_path: Path) -> None:
+    """YAML con sintaxis inválida → ValueError que describe el problema.
+
+    Los tabuladores dentro del bloque YAML son ilegales y PyYAML los
+    rechaza con un YAMLError.
+    """
+    # Tabulador al inicio de línea es síntaxis inválida en YAML
+    yaml_content = "networks:\n\t- kind: bibliographic_coupling\n"
+    spec_file = tmp_path / "redes.yaml"
+    spec_file.write_text(yaml_content, encoding="utf-8")
+
+    with pytest.raises(ValueError, match="YAML malformado"):
+        load_specs(spec_file)
+
+
+@pytest.mark.unit
+def test_load_specs_sin_clave_raiz_networks(tmp_path: Path) -> None:
+    """YAML sin clave 'networks:' → ValueError accionable."""
+    yaml_content = "redes:\n  - kind: bibliographic_coupling\n"
+    spec_file = tmp_path / "redes.yaml"
+    spec_file.write_text(yaml_content, encoding="utf-8")
+
+    with pytest.raises(ValueError, match="networks:"):
+        load_specs(spec_file)
+
+
+@pytest.mark.unit
+def test_load_specs_archivo_no_existe() -> None:
+    """Archivo YAML inexistente → FileNotFoundError."""
+    with pytest.raises(FileNotFoundError):
+        load_specs("/ruta/que/no/existe.yaml")
+
+
+# ---------------------------------------------------------------------------
+# 3. load_specs: spec inválida → ValueError con índice y campo
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_load_specs_kind_invalido_cita_indice(tmp_path: Path) -> None:
+    """Kind inexistente → ValueError que cita el índice (0-based) de la red."""
+    yaml_content = """\
+networks:
+  - kind: bibliographic_coupling
+  - kind: red_que_no_existe
+"""
+    spec_file = tmp_path / "redes.yaml"
+    spec_file.write_text(yaml_content, encoding="utf-8")
+
+    with pytest.raises(ValueError) as exc_info:
+        load_specs(spec_file)
+
+    msg = str(exc_info.value)
+    # Debe citar el índice 1 (segunda red, 0-based) y el campo 'kind'
+    assert "#1" in msg
+    assert "kind" in msg
+
+
+@pytest.mark.unit
+def test_load_specs_campo_extra_lanza_error(tmp_path: Path) -> None:
+    """Campo no permitido en la spec → ValueError accionable con el índice."""
+    yaml_content = """\
+networks:
+  - kind: bibliographic_coupling
+    campo_inventado: true
+"""
+    spec_file = tmp_path / "redes.yaml"
+    spec_file.write_text(yaml_content, encoding="utf-8")
+
+    with pytest.raises(ValueError, match="#0"):
+        load_specs(spec_file)
+
+
+@pytest.mark.unit
+def test_load_specs_tipo_incorrecto_cita_campo(tmp_path: Path) -> None:
+    """min_weight con tipo incorrecto → ValueError que cita el campo."""
+    yaml_content = """\
+networks:
+  - kind: bibliographic_coupling
+    min_weight: "no_es_un_numero"
+"""
+    spec_file = tmp_path / "redes.yaml"
+    spec_file.write_text(yaml_content, encoding="utf-8")
+
+    with pytest.raises(ValueError) as exc_info:
+        load_specs(spec_file)
+
+    msg = str(exc_info.value)
+    assert "min_weight" in msg
+
+
+# ---------------------------------------------------------------------------
+# 4. Equivalencia build ≡ quick para bibliographic_coupling con defaults
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_equivalencia_build_vs_quick_con_defaults(tmp_path: Path) -> None:
+    """Networks.build(corpus, spec_yaml_defaults) ≡ Networks.quick[coupling].
+
+    La spec del YAML usa exactamente los mismos defaults que NetworkSpec(kind=k)
+    puro (sin sobreescribir resolution ni min_weight).  Esto garantiza que
+    la red resultante tenga los mismos nodos, aristas Y comunidades que la que
+    produce quick.
+
+    Las COMUNIDADES también deben coincidir: el seed de Louvain es función pura
+    del corpus_hash de contenido (facade._louvain_seed_from_hash), no del orden
+    de llamada, y ``resolution`` nunca entra al hash.  Por eso dos builds con la
+    misma spec sobre el mismo corpus producen idénticas comunidades — y eso es
+    justo lo que pide el DoD del Hito 9 (build ≡ quick).
+    """
+    from bib2graph.networks.facade import Networks
+
+    corpus = _make_corpus()
+
+    # Spec equivalente a NetworkSpec(kind="bibliographic_coupling") puro
+    yaml_content = "networks:\n  - kind: bibliographic_coupling\n"
+    spec_file = tmp_path / "redes.yaml"
+    spec_file.write_text(yaml_content, encoding="utf-8")
+
+    [spec_yaml] = load_specs(spec_file)
+    art_build = Networks.build(corpus, spec_yaml)
+
+    # Obtener el artefacto de coupling de quick
+    arts_quick = Networks.quick(corpus)
+    art_quick = next(a for a in arts_quick if a.spec.kind == "bibliographic_coupling")
+
+    assert set(art_build.graph.nodes()) == set(art_quick.graph.nodes())
+    assert set(art_build.graph.edges()) == set(art_quick.graph.edges())
+    # DoD Hito 9: la equivalencia incluye las comunidades (seed puro del hash).
+    assert art_build.communities == art_quick.communities
+
+
+# ---------------------------------------------------------------------------
+# 5. No-regresión: resolution=1.0 ≡ comportamiento anterior
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_resolution_default_no_cambia_comportamiento() -> None:
+    """detect_communities con resolution=1.0 produce el mismo resultado que sin pasarlo.
+
+    Verifica que el parámetro ``resolution`` con su valor por defecto (1.0)
+    es inocuo: produce el mismo número de comunidades que la llamada anterior
+    que no lo pasaba (equivalencia funcional con el comportamiento pre-Hito 9).
+    """
+    import networkx as nx
+
+    from bib2graph.networks.analyzer import detect_communities
+
+    g: nx.Graph = nx.Graph()
+    g.add_edges_from([("A", "B"), ("B", "C"), ("C", "A"), ("D", "E"), ("E", "F")])
+
+    # Sin resolution explícito (default 1.0)
+    result_default = detect_communities(g, method="louvain", random_state=42)
+    # Con resolution=1.0 explícito
+    result_explicit = detect_communities(
+        g, method="louvain", random_state=42, resolution=1.0
+    )
+
+    assert result_default == result_explicit
+    assert isinstance(result_default, dict)
+    assert set(result_default.keys()) == set(g.nodes())
+
+
+@pytest.mark.unit
+def test_resolution_ignorado_en_label_prop() -> None:
+    """resolution se ignora silenciosamente para label_prop (sin error)."""
+    import networkx as nx
+
+    from bib2graph.networks.analyzer import detect_communities
+
+    g: nx.Graph = nx.Graph()
+    g.add_edges_from([("A", "B"), ("B", "C"), ("C", "A")])
+
+    # No debe lanzar error aunque resolution se pase para label_prop
+    result = detect_communities(g, method="label_prop", resolution=2.0)
+    assert set(result.keys()) == set(g.nodes())
+
+
+@pytest.mark.unit
+def test_resolution_ignorado_en_greedy_modularity() -> None:
+    """resolution se ignora silenciosamente para greedy_modularity (sin error)."""
+    import networkx as nx
+
+    from bib2graph.networks.analyzer import detect_communities
+
+    g: nx.Graph = nx.Graph()
+    g.add_edges_from([("A", "B"), ("B", "C"), ("C", "A")])
+
+    result = detect_communities(g, method="greedy_modularity", resolution=0.5)
+    assert set(result.keys()) == set(g.nodes())
+
+
+# ---------------------------------------------------------------------------
+# 6. Subcomando b2g networks --spec end-to-end (CliRunner)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_networks_cmd_escribe_artefactos(tmp_path: Path) -> None:
+    """b2g networks --spec corre, escribe artefactos y devuelve exit 0."""
+    from click.testing import CliRunner
+
+    from bib2graph.cli import b2g
+
+    store_path = tmp_path / "test.duckdb"
+    _seed_store(store_path)
+
+    yaml_content = "networks:\n  - kind: bibliographic_coupling\n"
+    spec_file = tmp_path / "redes.yaml"
+    spec_file.write_text(yaml_content, encoding="utf-8")
+
+    out_dir = tmp_path / "output_nets"
+
+    runner = CliRunner()
+    result = runner.invoke(
+        b2g,
+        [
+            "--store",
+            str(store_path),
+            "networks",
+            "--spec",
+            str(spec_file),
+            "--out-dir",
+            str(out_dir),
+        ],
+    )
+
+    assert result.exit_code == 0, f"Salida inesperada: {result.output}"
+    # Verificar que al menos existe la carpeta del kind
+    coupling_dir = out_dir / "bibliographic_coupling"
+    assert coupling_dir.exists() or out_dir.exists()
+
+
+@pytest.mark.unit
+def test_networks_cmd_no_transiciona_cycle_state(tmp_path: Path) -> None:
+    """b2g networks --spec NO transiciona el CycleState del lazo.
+
+    A diferencia de ``b2g build``, el subcomando ``networks`` es transversal
+    al lazo bibliométrico: no modifica el estado del ciclo FSM.
+    """
+    from click.testing import CliRunner
+
+    from bib2graph.cli import b2g
+    from bib2graph.stores.duckdb import DuckDBStore
+
+    store_path = tmp_path / "test.duckdb"
+    _seed_store(store_path)
+
+    # Capturar el estado antes
+    store_before = DuckDBStore(store_path)
+    state_before = store_before.backend.loop_state()
+
+    yaml_content = "networks:\n  - kind: bibliographic_coupling\n"
+    spec_file = tmp_path / "redes.yaml"
+    spec_file.write_text(yaml_content, encoding="utf-8")
+
+    out_dir = tmp_path / "output_nets"
+
+    runner = CliRunner()
+    result = runner.invoke(
+        b2g,
+        [
+            "--store",
+            str(store_path),
+            "networks",
+            "--spec",
+            str(spec_file),
+            "--out-dir",
+            str(out_dir),
+        ],
+    )
+
+    assert result.exit_code == 0, f"Salida inesperada: {result.output}"
+
+    # El CycleState no debe haber cambiado
+    store_after = DuckDBStore(store_path)
+    state_after = store_after.backend.loop_state()
+    assert state_after == state_before
+
+
+@pytest.mark.unit
+def test_networks_cmd_json_envelope_correcto(tmp_path: Path) -> None:
+    """b2g networks --spec --json emite envelope con schema='1' y claves de build."""
+    from click.testing import CliRunner
+
+    from bib2graph.cli import b2g
+
+    store_path = tmp_path / "test.duckdb"
+    _seed_store(store_path)
+
+    yaml_content = "networks:\n  - kind: bibliographic_coupling\n"
+    spec_file = tmp_path / "redes.yaml"
+    spec_file.write_text(yaml_content, encoding="utf-8")
+
+    out_dir = tmp_path / "output_nets"
+
+    runner = CliRunner()
+    result = runner.invoke(
+        b2g,
+        [
+            "--store",
+            str(store_path),
+            "networks",
+            "--spec",
+            str(spec_file),
+            "--out-dir",
+            str(out_dir),
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, f"Salida inesperada: {result.output}"
+    envelope = json.loads(result.output)
+
+    assert envelope["schema"] == "1"
+    assert envelope["ok"] is True
+    assert envelope["command"] == "networks"
+    assert envelope["exit_code"] == 0
+    assert "networks_built" in envelope["data"]
+    assert "artifacts_dir" in envelope["data"]
+    assert "networks" in envelope["data"]
+    assert envelope["data"]["networks_built"] == 1
+
+
+@pytest.mark.unit
+def test_networks_cmd_yaml_invalido_emite_data_error(tmp_path: Path) -> None:
+    """b2g networks --spec con YAML inválido emite DataError (exit 2) en JSON."""
+    from click.testing import CliRunner
+
+    from bib2graph.cli import b2g
+
+    store_path = tmp_path / "test.duckdb"
+    _seed_store(store_path)
+
+    # Kind inexistente → DataError en el loader
+    yaml_content = "networks:\n  - kind: red_inexistente\n"
+    spec_file = tmp_path / "redes_malas.yaml"
+    spec_file.write_text(yaml_content, encoding="utf-8")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        b2g,
+        [
+            "--store",
+            str(store_path),
+            "networks",
+            "--spec",
+            str(spec_file),
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 2  # DataError → exit 2
+    envelope = json.loads(result.output)
+    assert envelope["ok"] is False
+    assert envelope["error"] is not None
+    assert envelope["error"]["code"] == "DATA_ERROR"

--- a/uv.lock
+++ b/uv.lock
@@ -88,6 +88,7 @@ dependencies = [
     { name = "pyarrow" },
     { name = "pydantic" },
     { name = "python-louvain" },
+    { name = "pyyaml" },
     { name = "tqdm" },
 ]
 
@@ -108,6 +109,7 @@ dev = [
     { name = "pytest-cov" },
     { name = "ruff" },
     { name = "types-networkx" },
+    { name = "types-pyyaml" },
     { name = "types-tqdm" },
 ]
 
@@ -121,6 +123,7 @@ requires-dist = [
     { name = "pyarrow", specifier = ">=15" },
     { name = "pydantic", specifier = ">=2.6" },
     { name = "python-louvain", specifier = ">=0.16" },
+    { name = "pyyaml", specifier = ">=6.0.3" },
     { name = "rapidfuzz", marker = "extra == 'dedup'", specifier = ">=3,<4" },
     { name = "tqdm", specifier = ">=4.66" },
 ]
@@ -134,6 +137,7 @@ dev = [
     { name = "pytest-cov", specifier = ">=4" },
     { name = "ruff", specifier = ">=0.3" },
     { name = "types-networkx", specifier = ">=3.6.1.20260612" },
+    { name = "types-pyyaml", specifier = ">=6.0.12.20260518" },
     { name = "types-tqdm" },
 ]
 
@@ -1423,6 +1427,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/6a/d6/86483526df18c9936cb321b33f6df929db20414378f536972c5e9ee20789/types_networkx-3.6.1.20260612.tar.gz", hash = "sha256:9a28345fb3ad985e460667ef2b9c0879920761c8000cd07b424c0bf1b24ca778", size = 73974 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6e/1d/4694309c774f552a0dad8d357bc8c2b152120c9744dad4f21fdc3e819c37/types_networkx-3.6.1.20260612-py3-none-any.whl", hash = "sha256:829cdad128c10e072aacadd0421d7ebd64cee9731110e9d6b3f22b575fe0bbfd", size = 162459 },
+]
+
+[[package]]
+name = "types-pyyaml"
+version = "6.0.12.20260518"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b8/83/4a1afc3fbfcf5b8d46fc390cd95ed6b0dc9010a265f4e9f46314efffa37a/types_pyyaml-6.0.12.20260518.tar.gz", hash = "sha256:d917f83fb38462550338c1297faedd860b3ec83912b96b1e3d73255f7473e466", size = 17850 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/a2/c01db32be2ae7d6a1689972f3c492b149ee4e164b12fdfd9f64b50888215/types_pyyaml-6.0.12.20260518-py3-none-any.whl", hash = "sha256:d2150f75a231c9fe9c7463bd29487d93e60bac90400287351384bc2284eba7cd", size = 20312 },
 ]
 
 [[package]]


### PR DESCRIPTION
**Hito 9** — última pieza del ROADMAP pendiente antes de la GUI.

`load_specs` (loader YAML, raíz `networks:`, errores accionables) + `NetworkSpec.resolution` + `extra="forbid"`; `detect_communities(resolution=...)` con `resolution` **fuera del corpus_hash** (seed de Louvain intacto). Nuevo subcomando **`b2g networks --spec`** (16º) que reusa el helper `_write_artifacts` extraído de `build` y **no** transiciona el lazo.

DoD cumplido incl. **equivalencia build≡quick (nodos+aristas+comunidades)**. verifier **PASA** (cazó que el test de equivalencia omitía comunidades con justificación falsa → corregido: el seed es función pura del hash, las comunidades SÍ coinciden). **516 tests**, 0 enlaces rotos. Docs: API §10/§12.3, enmienda AS-BUILT ADR 0006, cierre de diferimiento en 0017, ROADMAP Hito 9 ✅.