### PR TITLE
docs(roadmap): reevaluación pre-GUI — Hitos 1–9 hechos, 10 a la GUI, 11 descartado

### DIFF
--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -217,8 +217,10 @@ No es una herramienta para usuario final no técnico: no hay GUI ni servicio web
   las redes** (comunidades/centralidad/acoplamiento). Era el candidato a *moat*
   ([`Notas/04`](Notas/04-direccion-ia-in-the-loop.md) §5); el diferenciador pasa a ser la **biblioteca
   viva curada + estructura bibliométrica de primera clase + flujo abierto**, no una capa de IA.
-- **Costura Zotero** (biblioteca viva externa) → **V1.1**, extra opt-in `[zotero]`. El **corazón
-  de la persistencia en V1.0 es DuckDB nativo**, no Zotero.
+- **Costura Zotero** (biblioteca viva externa) → **DESCARTADA (decisión del PO, 2026-06-17): no se
+  hace.** El **corazón de la persistencia en V1.0 es DuckDB nativo**, no Zotero; la GUI se construye
+  sobre el workspace local. No es backlog planificado: reabrible solo si aparece demanda real (p.ej.
+  round-trip con un Zotero existente), como hito nuevo con su propio encuadre.
 - **Monitoreo / alertas de literatura nueva** (paso 8 del ciclo, estilo Litmaps) → futuro;
   encaja sobre la biblioteca viva, pero no en V1.
 - **Matriz concepto×paper** (Webster & Watson, paso 5) → futuro; en V1 la organización es vía
@@ -235,7 +237,9 @@ No es una herramienta para usuario final no técnico: no hay GUI ni servicio web
 - **GUI / web / servicio gestionado** → fuera.
 - **WoS / Scopus / RIS / CSV / BibTeX como backbone** → OpenAlex primero; el resto, `Source`
   futura. BibTeX queda como `Source` **secundaria** para sembrar desde *pearls*.
-- **Neo4j** → adaptador `Store` opt-in post-V1; **ya no es sustrato**.
+- **Neo4j** → **DESCARTADO (decisión del PO, 2026-06-17): no se hace.** **Ya no es sustrato** y
+  tampoco se planifica como adaptador `Store` post-V1. Reabrible solo si aparece demanda real, como
+  hito nuevo.
 - **Enricher Semantic Scholar como camino para co-citación** → innecesario: las referencias y
   citantes vienen de OpenAlex ([ADR 0007](decisiones/0007-openalex-backbone.md)).
 - **Concurrencia multi-escritor** → **limitación conocida, no defecto** (ADR
@@ -310,8 +314,9 @@ No es una herramienta para usuario final no técnico: no hay GUI ni servicio web
   (estilo flujo PRISMA).
 - **C4** · Como investigador, quiero **aceptar/rechazar** candidatos y que lo aceptado quede en
   mi **biblioteca viva persistida en DuckDB**, que **crece entre corridas** con su log de
-  procedencia, para cultivar la colección (berry growing). *(La sincronización con Zotero llega
-  como costura opt-in en V1.1.)*
+  procedencia, para cultivar la colección (berry growing). *(La biblioteca viva es DuckDB nativo; la
+  sincronización con Zotero está descartada —decisión del PO, 2026-06-17— y solo se reabriría si hay
+  demanda real.)*
 
 ### Épica D — Proyectar a redes (el final sigue siendo las redes)
 - **D1** · Como investigador, quiero proyectar el corpus a **co-citación, acoplamiento
@@ -352,7 +357,8 @@ precisada por el ADR [0015](decisiones/0015-corpus-tabular-backend.md):
 - El **snapshot deja de ser el modelo de datos** y es un **export sellado derivable del estado
   vivo** (foto reproducible para reportar). **Reproducir = re-leer ese snapshot, no re-correr la
   ecuación** (ADR [0017](decisiones/0017-reproducibilidad-historia-snapshot.md)).
-- **Zotero** queda como **costura externa opt-in en V1.1**, no como la persistencia de 1.0.
+- **Zotero** queda **DESCARTADO (decisión del PO, 2026-06-17): no se hace**; nunca fue la
+  persistencia de 1.0 (DuckDB nativo lo es). Reabrible solo si aparece demanda real, como hito nuevo.
 
 Esta reconciliación ya está reflejada en `ARCHITECTURE.md` (§3.1, §4.3, §6.2), `API.md` (§1, §4) y
 `ROADMAP.md` (Hitos 1.5/3). El estado de construcción (Hitos 0–6 + 1.5 terminados; v0.2 cubre el
@@ -410,7 +416,12 @@ Esta reconciliación ya está reflejada en `ARCHITECTURE.md` (§3.1, §4.3, §6.
    v0.2 alcanza las capacidades del **flujo** `seed → … → export`. **El red-team de la
    [Nota 06](Notas/06-critica-as-built-v0.2.md) corrige el claim "capacidades completas":** falta la
    **tanda de remediación R1–R5** (modelo sin IA, identidad-vs-procedencia reproducible, FSM cíclico,
-   scent bibliométrico, robustez) **antes** de los Hitos 7–11. Tras R1–R5 se construyó el **Hito 8 ✅**
-   (`Enricher` OpenAlex: refs→DOI + co-citación end-to-end, `enrich --max-citing`); siguen pendientes
-   los Hitos 7 (dedup fuzzy), 9 (`NetworkSpec` YAML), 10 (viz) y 11 (Zotero/Neo4j). Estado vivo en el
-   [`ROADMAP.md`](ROADMAP/README.md).
+   scent bibliométrico, robustez) **antes** de los Hitos 7–11. Tras R1–R5 se construyeron el **Hito 7 ✅**
+   (dedup fuzzy `rapidfuzz`), el **Hito 8 ✅** (`Enricher` OpenAlex: refs→DOI + co-citación end-to-end,
+   `enrich --max-citing`) y el **Hito 9 ✅** (`NetworkSpec` YAML + `b2g networks --spec` + `resolution`
+   Louvain, 2026-06-17): **Hitos 1–9 construidos**. Los **Hitos 10 (viz) y 11 (Zotero/Neo4j) fueron
+   reevaluados (2026-06-17, encuadre pre-GUI):** 10 se **difiere/absorbe en la epic GUI #34** (la GUI es
+   la capa de lectura visual; el export visual pre-GUI ya lo cubren `decorate`/`clusters.csv`) y 11 queda
+   **DESCARTADO (decisión del PO, 2026-06-17): Zotero/Neo4j no se hacen** —no son backlog planificado—,
+   reabrible como hito nuevo solo si aparece demanda real; no bloquea la GUI. Estado vivo
+   en el [`ROADMAP.md`](ROADMAP/README.md).

--- a/docs/ROADMAP/04-lo-que-viene.md
+++ b/docs/ROADMAP/04-lo-que-viene.md
@@ -140,13 +140,26 @@ qué se calcula). Abre la puerta a un GUI (editor de `NetworkSpec`).
 
 ---
 
-## Hito 10 — Visualización (extra `[viz]`)
+## Hito 10 — Visualización (extra `[viz]`) — **REEVALUADO: DIFERIDO (absorbido por la epic GUI #34)**
 
-**Alcance**
+> **Reevaluación 2026-06-17 (architect, encuadre pre-GUI):** este hito —figuras estáticas
+> `matplotlib`/`seaborn` por red— **se difiere y se absorbe en la epic GUI
+> [#34](https://github.com/complexluise/bib2graph/issues/34)**. Razón: la GUI es **exactamente**
+> la capa de lectura visual de la estructura intelectual (historia D), y su MVP es **read-only
+> visualizar** (Nota 10/T-MVP). Construir ahora figuras estáticas separadas sería trabajo
+> tirado o duplicado cuando llegue la SPA. **No es "terreno pre-GUI".** La **capa de export
+> visual** que sí es separable (layout determinista, atributos de nodo para herramientas
+> externas) **ya existe**: `networks/decorate.py` (#25 ✅, `label`/`year`/`is_seed`/`community`/
+> `degree_centrality`) + `clusters.csv` (#31 ✅) hacen que el GraphML abra legible en
+> Gephi/VOSviewer/Cytoscape **sin código**. Es decir, el "core/export" de viz pre-GUI **ya está
+> cubierto**; lo que queda (render propio) es la GUI. **Verdadero alcance restante = render
+> dentro de #34**, no un extra `[viz]` aparte.
+
+**Alcance (original — diferido)**
 
 - Figuras de redes/comunidades con `matplotlib`/`seaborn`, fuera del núcleo liviano.
 
-**Historias:** apoyo visual a **D** (lectura de la estructura intelectual).
+**Historias:** apoyo visual a **D** (lectura de la estructura intelectual) — **cubierto por #34**.
 
 **Criterios de aceptación (DoD)**
 
@@ -158,27 +171,13 @@ qué se calcula). Abre la puerta a un GUI (editor de `NetworkSpec`).
 
 ---
 
-## Hito 11 — Costuras externas de biblioteca/persistencia (post-V1)
+## Hito 11 — Costuras externas de biblioteca/persistencia (Zotero/Neo4j) — **DESCARTADO (decisión del PO, 2026-06-17)**
 
-**Alcance**
-
-- **`ZoteroStore`** (extra `[zotero]`, **V1.1**): sincronizar la biblioteca viva con una
-  colección Zotero (leer semillas / devolver lo aceptado). Costura opt-in, no el corazón (ADR
-  0009).
-- **`Neo4jStore`** (extra `[neo4j]`, post-V1.2): adaptador tabla→grafo para consultas Cypher.
-  **Ya no es sustrato** (ADR 0002).
-
-**Historias:** extiende **C4** (biblioteca viva sincronizable con Zotero) como costura opt-in.
-
-**Criterios de aceptación (DoD)**
-
-- Round-trip Zotero (leer semillas / escribir aceptados) contra cliente mockeado; `integration`
-  contra Neo4j efímera (Testcontainers) para el adaptador.
-
-**Tests (TDD — los justos)**
-
-- Round-trip Zotero sobre cliente mock.
-- `Neo4jStore` marcado `integration` (Testcontainers o driver mockeado), fuera del gate `unit`.
+> **Decisión del PO (2026-06-17):** **no se hace.** Ni `ZoteroStore` ni `Neo4jStore` son
+> necesarios. La biblioteca viva propia (DuckDB) es el corazón de V1.0 (ADR 0009/0002) y la GUI
+> se construye **sobre el workspace local**, no sobre integraciones externas. Se retira del
+> ROADMAP; si en el futuro aparece demanda real (p.ej. round-trip con un Zotero existente), se
+> reabrirá como un hito nuevo con su propio encuadre. No bloquea nada.
 
 ---
 

--- a/docs/ROADMAP/README.md
+++ b/docs/ROADMAP/README.md
@@ -40,9 +40,15 @@
 > bibliométrico** (R4: proyectores como olfato, retiro de `explain`/`[llm]`/tensiones, ADR
 > 0020/0022/0008) → **robustez/escala** (R5: bulk-load, UTF-8 en la frontera, `except` anchos de la
 > Nota 06). El `ARCHITECTURE.md` apunta a estos hitos por número (R1–R5).
-> **Lo que falta** (tras la remediación R1–R5, el **Hito 8 ✅** —`Enricher` co-citación end-to-end— y
-> el **Hito 7 ✅** —dedup fuzzy `rapidfuzz`—, hacia v1.0): Hitos 9 (`NetworkSpec` YAML), 10 (viz) y 11
-> (Zotero/Neo4j). Tras el **2º giro**
+> **Lo que falta** (tras la remediación R1–R5, el **Hito 8 ✅** —`Enricher` co-citación end-to-end—,
+> el **Hito 7 ✅** —dedup fuzzy `rapidfuzz`— y el **Hito 9 ✅** —`NetworkSpec` YAML + `b2g networks
+> --spec` + `resolution` Louvain, 2026-06-17—, hacia v1.0): **Hitos 1–9 CONSTRUIDOS**. Quedan
+> **reevaluados (2026-06-17, encuadre pre-GUI)** el **Hito 10 (viz) — DIFERIDO/absorbido en la epic
+> GUI [#34](https://github.com/complexluise/bib2graph/issues/34)** (la GUI *es* la capa de lectura
+> visual; el export visual pre-GUI ya lo cubren `decorate` #25 ✅ + `clusters.csv` #31 ✅)— y el
+> **Hito 11 (Zotero/Neo4j) — DESCARTADO (decisión del PO, 2026-06-17)**: no se hace, no es backlog
+> planificado, reabrible si hay demanda real (hito nuevo); no bloquea la GUI. Ver
+> [04 · Lo que viene](04-lo-que-viene.md). Tras el **2º giro**
 > (acta del PO; ADR [0015](../decisiones/0015-corpus-tabular-backend.md)–[0019](../decisiones/0019-concurrencia-diferida.md))
 > se insertó un **Hito 1.5 — Rework de `Corpus` a `TabularBackend`** como el **paso inmediato
 > siguiente, secuenciado por delante del Hito 3** (instrucción explícita del PO: el rework va
@@ -115,8 +121,13 @@ OIDC), no el push de tags. Cortes acordados:
   `exports/`). Suma el **14° subcomando `b2g init`**; `--store` pasó a opcional + nuevo `--workspace`
   (resolución ambiente). El `.duckdb` suelto sigue válido (workspace degenerado). No fue un hito
   numerado (prerequisito de la epic GUI #34). Ver [04 · Lo que viene](04-lo-que-viene.md) §Backlog.
-- **v0.4+ — opcionales (Hitos 7–9):** dedup fuzzy, `Enricher` de co-citación (**Hito 8 ✅**:
-  refs→DOI + co-citación end-to-end), `NetworkSpec`.
+- **v0.4+ — opcionales (Hitos 7–9) · ✅ COMPLETOS:** dedup fuzzy (**Hito 7 ✅**), `Enricher` de
+  co-citación (**Hito 8 ✅**: refs→DOI + co-citación end-to-end), `NetworkSpec` YAML (**Hito 9 ✅**,
+  2026-06-17). Con esto **Hitos 1–9 están construidos**.
+- **Reevaluación 2026-06-17 (pre-GUI):** **Hito 10 (viz) → DIFERIDO/absorbido en la epic GUI #34**
+  (la GUI es la capa de lectura visual; el export visual pre-GUI ya lo cubren `decorate` #25 / `clusters.csv`
+  #31). **Hito 11 (Zotero/Neo4j) → DESCARTADO (decisión del PO, 2026-06-17):** no se hace, no es
+  backlog planificado; reabrible si hay demanda real (hito nuevo), no bloquea la GUI.
 - **1.0.0:** API congelada + caso real (IED) reproducido por un usuario distinto del autor (Nota 06,
   PRODUCTO).
 
@@ -187,7 +198,8 @@ limpio y actual; el cuerpo de cada hito vive en su archivo:
   del red-team (Nota 06): capa `constants`/`schemas`, identidad-vs-procedencia reproducible, FSM
   cíclico (`cycle.py`), scent bibliométrico (sin IA) y robustez. **v0.3 ✅ remediación completa.**
 - **[04 · Lo que viene (Hitos 7–11 + costuras futuras)](04-lo-que-viene.md)** — dedup fuzzy,
-  `Enricher` de co-citación, `NetworkSpec` YAML, viz, Zotero/Neo4j. **Lo que viene (hacia v1.0).**
+  `Enricher` de co-citación, `NetworkSpec` YAML; viz (Hito 10 diferido a la GUI #34) y Zotero/Neo4j
+  (Hito 11 descartado, PO 2026-06-17). **Lo que viene (hacia v1.0).**
 
 
 ## Trazabilidad historias ↔ hitos (resumen)
@@ -206,7 +218,7 @@ limpio y actual; el cuerpo de cada hito vive en su archivo:
 | C1 dedup/normalización autores/inst. | 5 ✅ (det.) + 7 ✅ (fuzzy) | `normalize` conservador + dedup fuzzy `rapidfuzz` (autores; keywords en C2; instituciones diferidas), ADR 0026 |
 | C2 thesaurus multilingüe | 5 ✅ + 7 ✅ (fuzzy) | `apply_thesaurus` (sobrescribe `keywords_id` desde `keywords_raw`); dedup fuzzy de keywords fuera del thesaurus en Hito 7 (`deduplicate_keywords`, ADR 0026) |
 | C3 filtros incl/excl con conteo | 5 ✅ (lógica) + 6 ✅ (CLI `filter`) | flujo PRISMA; marcan `rejected`, no borran; `b2g filter` con conteos por paso |
-| C4 aceptar/rechazar + biblioteca viva | 1 (modelo) + 1.5 (backend) + 3 (persist DuckDB) + 6 ✅ (CLI `accept`/`reject`) + 11 (Zotero) | `accept`/`reject` ahora subcomandos CLI (`b2g accept/reject --ids`); `curate`+GUI = futuro |
+| C4 aceptar/rechazar + biblioteca viva | 1 (modelo) + 1.5 (backend) + 3 (persist DuckDB) + 6 ✅ (CLI `accept`/`reject`) | `accept`/`reject` ahora subcomandos CLI (`b2g accept/reject --ids`); biblioteca viva = DuckDB nativo; `curate`+GUI = futuro. *(Sincronización con Zotero descartada —PO 2026-06-17, ex-Hito 11—, no planificada.)* |
 | D1 cinco proyecciones | 2 + 8 ✅ (co-citación) | co-citación end-to-end vía `b2g enrich` (8b); `Networks.quick` → 4/5 redes según `cited_by_id` |
 | D2 métricas y comunidades | 2 | |
 | D3 asortatividad + composición + proxy | 2 | |


### PR DESCRIPTION
Sincroniza ROADMAP+PRD con la decisión del PO (2026-06-17): **Hito 10 (viz) → absorbido por la epic GUI #34**; **Hito 11 (Zotero/Neo4j) → DESCARTADO** (no se hace, reabrible solo con demanda real). Hitos 1–9 marcados construidos. Rationale 'DuckDB es el corazón de V1.0' intacto. Solo docs, 0 enlaces rotos.