### PR TITLE
feat(workspace): snapshot/export por ambiente + aviso de staleness (#32)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,10 +32,13 @@
   `networks/` (proyectores, analyzer, spec, facade), `exporters/` (GraphML, CSV) y `cli/`.
   El **CLI `b2g` es real** —paquete `cli/` con 16 subcomandos en `cli/commands/`, no un
   placeholder (el 16° `b2g networks` es la capa declarativa YAML del Hito 9, abajo)—.
-  **516 tests verdes** (mypy/ruff limpios; el núcleo importa sin `duckdb`). Entre las
+  **534 tests verdes** (mypy/ruff limpios; el núcleo importa sin `duckdb`). Entre las
   redes, la **composición de comunidades es exportable**: `networks/cluster_table` (función pura)
   resume cada comunidad de una red de paper en una fila y `b2g build` la escribe como `clusters.csv`
-  (#31, AS-BUILT 2026-06-17; ver `docs/API.md` §7.2).
+  (#31, AS-BUILT 2026-06-17; ver `docs/API.md` §7.2). **`b2g snapshot`/`b2g export` resuelven por
+  workspace** (`--out-dir` override opcional → `<workspace>/snapshots|exports/`) y **`b2g status` avisa
+  de staleness** de la cache de redes (`networks_cache_stale`; avisa, no regenera) — remanentes del
+  modelo workspace cerrados (#32, AS-BUILT 2026-06-17; ver el bullet de workspace abajo).
 - **Hito 9 COMPLETO — capa declarativa `NetworkSpec` YAML** (AS-BUILT 2026-06-17): `NetworkSpec`
   (`networks/spec.py`) suma el campo **`resolution: float = 1.0`** (resolución de Louvain, **fuera del
   `corpus_hash`** → seed intacto) y **`extra="forbid"`**. Nueva función **`load_specs(path)`**
@@ -90,7 +93,12 @@
   walk-up del cwd buscando `workspace.json`). El `.duckdb` suelto sigue válido (workspace degenerado).
   `b2g status` suma `workspace: {root, source}`; `b2g build` sella `networks/.corpus_hash`. **422
   tests verdes**, 14 subcomandos. Flujo: `b2g init <name>` → trabajar **dentro** de la carpeta sin
-  `--store`.
+  `--store`. **Remanentes cerrados (#32, AS-BUILT 2026-06-17):** `b2g snapshot`/`b2g export` ya
+  resuelven por workspace (`--out-dir` pasó a override opcional → `<workspace>/snapshots|exports/`;
+  modo degenerado = dir hermano) y `b2g status` suma `networks_cache_stale: bool` + `warnings`
+  accionable cuando el `networks/.corpus_hash` no coincide con el corpus vivo (**avisa, NO regenera**:
+  invalidación por hash, no build-system). `Workspace` ganó `read_networks_corpus_hash()` /
+  `is_networks_cache_stale()`. Con esto el modelo workspace queda **completo** (no quedan remanentes).
 - **Curación a escala vía CSV** (#22 + #26, 2026-06-16): nuevo **15° subcomando `b2g curate`**
   (`cli/commands/curate.py`) con dos modos mutuamente excluyentes — **`--dump`** escribe
   `curacion.csv` (default `<workspace>/exports/`; `--out` override; `--all` para todo el corpus, default
@@ -292,8 +300,10 @@ src/bib2graph/
                        # init scaffold de workspace —ADR 0029, curate dump/import CSV —#22+#26,
                        # networks capa declarativa YAML —Hito 9). CLI = API
                        # para LLM y agentes (Hito 6, ARCHITECTURE.md §6.3). No es un cli.py plano.
-  workspace.py         # Workspace (init/open/resolve) + WorkspaceManifest (ADR 0029): la carpeta es la
-                       # unidad de persistencia; resolución ambiente; import perezoso de DuckDBStore
+  workspace.py         # Workspace (init/open/resolve; snapshots_dir/exports_dir/networks_dir;
+                       # read_networks_corpus_hash/is_networks_cache_stale —staleness #32) +
+                       # WorkspaceManifest (ADR 0029): la carpeta es la unidad de persistencia;
+                       # resolución ambiente; import perezoso de DuckDBStore
 tests/
   unit/                # tests puros, sin red ni I/O (default)
   integration/         # red / APIs externas / Neo4j; @pytest.mark.integration

--- a/docs/API.md
+++ b/docs/API.md
@@ -94,6 +94,18 @@
 > compartido `_write_artifacts`; mismo envelope que `build`; **NO** transiciona el `CycleState` ni
 > sella `.corpus_hash`). `pyyaml` pasó a dependencia del núcleo (import perezoso). Ver §10 +
 > §convenciones CLI.
+>
+> **Sincronizado con los remanentes del modelo workspace — #32 (AS-BUILT, 2026-06-17):** cierra lo
+> que el ADR [0029](decisiones/0029-workspace-por-investigacion.md) dejó "fuera de corte".
+> **`b2g snapshot` y `b2g export`** se resuelven por ambiente: `--out-dir` pasó de obligatorio a
+> **override OPCIONAL**; sin él, `snapshot` escribe en **`<workspace>/snapshots/`** y `export` en
+> **`<workspace>/exports/`** (resolución vía `resolve_workspace`, igual que `build`; modo degenerado =
+> dir hermano del `.duckdb`, sin regresión). **`b2g status`** suma el campo aditivo
+> **`data["networks_cache_stale"]: bool`** + un `warnings` accionable cuando el `networks/.corpus_hash`
+> sellado **no coincide** con el `corpus_hash` del corpus vivo (aviso "ejecutá `b2g build`"; **NO**
+> regenera — invalidación por hash, no build-system, ADR 0029). `schema="1"` intacto. `Workspace` ganó
+> `read_networks_corpus_hash()` e `is_networks_cache_stale(live_hash)` (los accessors
+> `snapshots_dir`/`exports_dir`/`networks_dir` ya existían). Ver §convenciones CLI.
 
 ## Convenciones
 
@@ -128,7 +140,9 @@ pre-v0.3; el 13° `enrich` en el Ciclo 8a, ADR
   (`curation_available`, curación transversal) + la **ronda** (`round`), campos aditivos que mantienen
   `schema="1"`. **AS-BUILT workspace (ADR 0029):** `status` suma el campo aditivo
   `workspace: {root, source}` (la raíz resuelta y de dónde salió — flag/env/cwd); `schema="1"`
-  intacto. `inspect`, `validate`.
+  intacto. **AS-BUILT #32 (2026-06-17):** suma también el campo aditivo `networks_cache_stale: bool`
+  (+ `warnings` accionable cuando la cache de `networks/` quedó obsoleta respecto al corpus vivo;
+  avisa, NO regenera — ver §`build`/`export`/`snapshot` abajo). `inspect`, `validate`.
 - **`seed`** (flags ergonómicos, #14 + #30): **`--max-results INT`** propaga a
   `OpenAlexSource(max_results=...)` —sin flag, el default del source = 200— para exploración con
   muestras chicas (Nota 09 B1). **`--exclude TEXT`** (repetible) son **negaciones quirúrgicas**:
@@ -214,13 +228,29 @@ vive en su `library.duckdb`; el CLI es stateful **vía archivo**, no vía proces
   del cwd buscando `workspace.json`. Sin ninguno → **error accionable** que sugiere `b2g init`.
 
 **`build` y `export` separados** (decisión del PO, ADR 0021 §B): `build` computa `Networks.quick`
-(4 redes) y escribe artefactos a `<store_dir>/networks/<kind>/` (+ transiciona a `BUILT`);
-`export --format graphml|csv --out-dir ...` **relee** esos artefactos y los serializa (sin
-transición). **AS-BUILT #31 (2026-06-17):** `build` también escribe **`clusters.csv`** (tabla de
+(4 redes) y escribe artefactos a `<workspace>/networks/<kind>/` (+ transiciona a `BUILT`);
+`export --format graphml|csv` **relee** esos artefactos (fuente resuelta vía `ws.networks_dir`) y
+los serializa (sin transición). **AS-BUILT #32 (2026-06-17):** `export --out-dir` pasó a **override
+OPCIONAL** — sin él, escribe en **`<workspace>/exports/`** (resolución ambiente como `build`; modo
+degenerado = dir hermano del `.duckdb`). **AS-BUILT #31 (2026-06-17):** `build` también escribe **`clusters.csv`** (tabla de
 resumen de comunidades, §7.2) en `<networks_dir>/<kind>/` **solo** para redes de **paper** con
 comunidades detectadas (listas con separador `|`); en el envelope `--json`, cada entrada de
 `data["networks"]` suma `clusters_csv` (ruta del archivo) **condicionalmente** —solo cuando ese
 archivo se generó—.
+
+**`snapshot` (AS-BUILT #32, 2026-06-17):** `b2g snapshot` sella una foto reproducible del estado vivo
+(parquet + `manifest.json`, ADR 0017). **`--out-dir` pasó a override OPCIONAL** — sin él, escribe en
+**`<workspace>/snapshots/`** (resolución ambiente vía `resolve_workspace`, igual que `build`); en modo
+degenerado (`--store` suelto) cae en el dir hermano del `.duckdb` (sin regresión). No transiciona el
+`CycleState`.
+
+**Staleness de la cache de redes (AS-BUILT #32, 2026-06-17):** `b2g status` suma el campo aditivo
+`data["networks_cache_stale"]: bool` (`schema="1"` intacto) y, cuando es `true`, un `warnings`
+accionable ("ejecutá `b2g build`"). Lo dispara que el `networks/.corpus_hash` **sellado** por el
+último `build` **no coincida** con el `corpus_hash` del corpus vivo (calculado con el **mismo**
+`compute_corpus_hash(corpus.to_arrow())` que `build` usa para sellar → sin falsos positivos). Si la
+cache **no existe** (nunca se corrió `build`), **no** es stale. `status` **avisa, NO regenera**:
+invalidación por hash, **no** un build-system (ADR [0029](decisiones/0029-workspace-por-investigacion.md)).
 
 **Transiciones automáticas del ciclo** (ADR 0021 §F; AS-BUILT R3): `seed`→`SEEDED`, `chain`→`FORAGED`,
 `filter`→`FILTERED`, `build`→`BUILT`, **`monitor`→`MONITORED`** (cleanup pre-v0.3);

--- a/docs/ROADMAP/04-lo-que-viene.md
+++ b/docs/ROADMAP/04-lo-que-viene.md
@@ -226,8 +226,13 @@ No se prometen ni se cablean clientes que no se usan.
   subcomando `b2g init`**, `--store` opcional + `--workspace` con resolución ambiente; el `.duckdb`
   suelto sigue válido (workspace degenerado). Prerequisito de la epic GUI local
   ([#34](https://github.com/complexluise/bib2graph/issues/34),
-  [Nota 07](../Notas/07-frontend-tool-for-thought.md)). **Fuera de este corte:** `snapshot`/`export`
-  aún con `--out-dir` explícito; staleness solo sella el hash (sin aviso/regeneración automática).
+  [Nota 07](../Notas/07-frontend-tool-for-thought.md)). **Remanentes cerrados · ✅ HECHO (2026-06-17,
+  #32):** `b2g snapshot`/`b2g export` ya resuelven por workspace (`--out-dir` pasó a override opcional
+  → `<workspace>/snapshots|exports/`; modo degenerado = dir hermano) y `b2g status` suma
+  `networks_cache_stale: bool` + `warnings` cuando el `networks/.corpus_hash` no coincide con el
+  corpus vivo (**avisa, NO regenera**: invalidación por hash, no build-system). `Workspace` ganó
+  `read_networks_corpus_hash()`/`is_networks_cache_stale()`. **El modelo workspace queda COMPLETO**
+  (sin remanentes). Gate verde, **534 tests**.
 - **Curación a escala vía CSV (#22 dump + #26 import) · ✅ HECHO (2026-06-16):** marcar papers de a
   uno con `accept`/`reject --ids` no escala (síntomas B4/B5/P1 de la
   [Nota 09](../Notas/09-sesion-qa-prueba-ecologia-valoraciones.md)). Se agregó el **15° subcomando

--- a/docs/decisiones/0029-workspace-por-investigacion.md
+++ b/docs/decisiones/0029-workspace-por-investigacion.md
@@ -144,3 +144,30 @@ Implementado y verificado (gate verde, 416 tests). Lo construido en este corte:
   aviso de cache obsoleta ni regeneración automática cuando el `corpus_hash` deja de coincidir; se
   implementará cuando aparezca la necesidad (la invalidación por hash sigue siendo el modelo, no un
   build system — ver Consecuencias).
+
+## ADDENDUM AS-BUILT (2026-06-17) — remanentes del corte cerrados ([#32](https://github.com/complexluise/bib2graph/issues/32))
+
+Implementado y verificado (gate verde, 534 tests). Los **dos puntos** que el corte del 2026-06-16
+dejó explícitamente "fuera" (sección arriba) pasan a **CONSTRUIDOS**:
+
+- **`snapshot`/`export` redirigidos por ambiente.** `--out-dir` pasó de obligatorio a **override
+  OPCIONAL** en ambos comandos. Sin él, `b2g snapshot` escribe en **`<workspace>/snapshots/`** y
+  `b2g export` en **`<workspace>/exports/`** (resolución vía `resolve_workspace`, **el mismo path que
+  `build`**). `export` además resuelve la **fuente** de redes con `ws.networks_dir` (mismo path que
+  antes, en ambos modos). En **modo degenerado** (`--store` suelto) los artefactos caen en el dir
+  hermano del `.duckdb`, **sin regresión**.
+- **Aviso de staleness en `b2g status` por `corpus_hash`.** `status` suma el campo aditivo
+  `data["networks_cache_stale"]: bool` (`schema="1"` intacto) y un `warnings` accionable ("ejecutá
+  `b2g build`") cuando el `networks/.corpus_hash` **sellado** por el último `build` **no coincide** con
+  el `corpus_hash` del corpus vivo. El hash vivo se computa con el **mismo**
+  `compute_corpus_hash(corpus.to_arrow())` que `build` usa para sellar → **sin falsos positivos**. Si
+  la cache no existe (nunca se corrió `build`), no es stale. **Es un AVISO, NO regenera:** se respeta
+  la **invalidación por hash** decidida arriba — **no** un build-system, **no** un grafo de
+  dependencias. El snapshot sigue siendo lo reproducible; `networks/` es cache regenerable.
+
+**Capa `Workspace` (lo construido para esto):** se agregaron `read_networks_corpus_hash() -> str |
+None` (lee `networks/.corpus_hash`; `None` si no existe) e `is_networks_cache_stale(live_hash) -> bool`
+(`True` **solo** si el archivo existe Y difiere del hash vivo). Los accessors
+`snapshots_dir`/`exports_dir`/`networks_dir` (`_library_path.parent / "..."`, también en modo
+degenerado) **ya existían** desde el corte anterior. Con esto, la **fundación workspace queda
+completa**: no quedan remanentes del modelo en el backlog.

--- a/src/bib2graph/cli/commands/export.py
+++ b/src/bib2graph/cli/commands/export.py
@@ -2,6 +2,13 @@
 
 Serializa los artefactos de build al formato pedido.
 NO transiciona el CycleState.
+
+ADR 0029 — workspace:
+  El directorio de salida es ``<workspace>/exports/`` por defecto.
+  Si se pasa ``--out-dir`` explícito, se usa ese (override opcional).
+  La fuente de artefactos de build es ``<workspace>/networks/`` por defecto.
+  Modo degenerado (``--store archivo.duckdb`` suelto): usa dirs hermanos
+  ``networks/`` y ``exports/`` relativos al ``.duckdb``.
 """
 
 from __future__ import annotations
@@ -14,7 +21,7 @@ import click
 
 from bib2graph.cli._envelope import build_envelope, emit, emit_human
 from bib2graph.cli._errors import DataError, handle_errors
-from bib2graph.cli._store import resolve_library_path
+from bib2graph.cli._store import resolve_workspace
 
 # ---------------------------------------------------------------------------
 # Función núcleo (testeable, sin Click)
@@ -133,8 +140,11 @@ def run_export(
 )
 @click.option(
     "--out-dir",
-    required=True,
-    help="Directorio de salida para los archivos exportados.",
+    default=None,
+    help=(
+        "Directorio de salida para los archivos exportados "
+        "(default: <workspace>/exports/ o <store_dir>/exports/)."
+    ),
 )
 @click.option(
     "--json",
@@ -148,18 +158,25 @@ def run_export(
 def export_cmd(
     ctx: click.Context,
     fmt: str,
-    out_dir: str,
+    out_dir: str | None,
     json_output: bool,
 ) -> None:
     """Serializa artefactos de build al formato pedido (GraphML o CSV).
 
     No transiciona el CycleState.
+
+    El directorio de salida por defecto es ``<workspace>/exports/``.
+    Con ``--out-dir`` se puede especificar un directorio alternativo.
     """
-    store_path = resolve_library_path(ctx.obj)
+    # ADR 0029: resolver workspace para obtener dirs canónicos
+    ws = resolve_workspace(ctx.obj)
+    effective_out_dir: Path = Path(out_dir) if out_dir is not None else ws.exports_dir
+
     data = run_export(
-        store_path,
+        ws.library_path,
         format=fmt,  # type: ignore[arg-type]
-        out_dir=out_dir,
+        out_dir=effective_out_dir,
+        networks_dir=ws.networks_dir,
     )
 
     if json_output:

--- a/src/bib2graph/cli/commands/snapshot.py
+++ b/src/bib2graph/cli/commands/snapshot.py
@@ -2,6 +2,12 @@
 
 Exporta una foto sellada del corpus actual (parquet + manifest.json).
 NO transiciona el CycleState.
+
+ADR 0029 — workspace:
+  El directorio de salida es ``<workspace>/snapshots/`` por defecto.
+  Si se pasa ``--out-dir`` explícito, se usa ese (override opcional).
+  Modo degenerado (``--store archivo.duckdb`` suelto): usa el dir hermano
+  ``snapshots/`` relativo al ``.duckdb``.
 """
 
 from __future__ import annotations
@@ -13,7 +19,7 @@ import click
 
 from bib2graph.cli._envelope import build_envelope, emit, emit_human
 from bib2graph.cli._errors import handle_errors
-from bib2graph.cli._store import open_store, resolve_library_path
+from bib2graph.cli._store import open_store, resolve_workspace
 
 # ---------------------------------------------------------------------------
 # Función núcleo (testeable, sin Click)
@@ -61,8 +67,11 @@ def run_snapshot(
 @click.command("snapshot")
 @click.option(
     "--out-dir",
-    required=True,
-    help="Directorio destino del snapshot (se crea si no existe).",
+    default=None,
+    help=(
+        "Directorio destino del snapshot "
+        "(default: <workspace>/snapshots/ o <store_dir>/snapshots/)."
+    ),
 )
 @click.option(
     "--json",
@@ -75,15 +84,21 @@ def run_snapshot(
 @handle_errors("snapshot")
 def snapshot_cmd(
     ctx: click.Context,
-    out_dir: str,
+    out_dir: str | None,
     json_output: bool,
 ) -> None:
     """Exporta una foto sellada del corpus actual (parquet + manifest.json).
 
     No transiciona el CycleState.
+
+    El directorio de salida por defecto es ``<workspace>/snapshots/``.
+    Con ``--out-dir`` se puede especificar un directorio alternativo.
     """
-    store_path = resolve_library_path(ctx.obj)
-    data = run_snapshot(store_path, out_dir=out_dir)
+    # ADR 0029: usar snapshots_dir del workspace si no se especifica --out-dir
+    ws = resolve_workspace(ctx.obj)
+    effective_out_dir: Path = Path(out_dir) if out_dir is not None else ws.snapshots_dir
+
+    data = run_snapshot(ws.library_path, out_dir=effective_out_dir)
 
     if json_output:
         envelope = build_envelope(

--- a/src/bib2graph/cli/commands/status.py
+++ b/src/bib2graph/cli/commands/status.py
@@ -18,6 +18,7 @@ Mantiene ``schema="1"`` (campos nuevos son aditivos, no rompen agentes).
 
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -137,12 +138,34 @@ def status_cmd(
         "source": ws.source,
     }
 
+    # ADR 0029 — aviso de staleness de la cache de redes.
+    # Si networks/.corpus_hash existe y no coincide con el corpus vivo,
+    # se emite un aviso accionable (no se regenera automáticamente).
+    # R5: open_store_readonly para consistencia (no auto-crea ante typo;
+    # mapea StoreLockedError → exit 5 vía el decorador @handle_errors).
+    warnings: list[str] = []
+    from bib2graph.backends.memory import compute_corpus_hash
+
+    _store = open_store_readonly(store_path)
+    _corpus = _store.load()
+    live_hash = compute_corpus_hash(_corpus.to_arrow())
+    stale = ws.is_networks_cache_stale(live_hash)
+
+    if stale:
+        warnings.append(
+            "La cache de redes (networks/) está desactualizada: el corpus cambió "
+            "desde el último build. Ejecutá 'b2g build' para regenerarla."
+        )
+
+    data["networks_cache_stale"] = stale
+
     if json_output:
         envelope = build_envelope(
             command="status",
             ok=True,
             data=data,
             exit_code=0,
+            warnings=warnings,
         )
         emit(envelope)
     else:
@@ -162,3 +185,5 @@ def status_cmd(
         )
         ws_root = data["workspace"]["root"] or "(modo degenerado)"
         emit_human(f"Workspace: {ws_root} (resuelto vía {data['workspace']['source']})")
+        for w in warnings:
+            print(f"AVISO: {w}", file=sys.stderr)

--- a/src/bib2graph/workspace.py
+++ b/src/bib2graph/workspace.py
@@ -356,6 +356,40 @@ class Workspace:
             f"library={self._library_path!r}, source={self._source!r})"
         )
 
+    def read_networks_corpus_hash(self) -> str | None:
+        """Lee el ``corpus_hash`` sellado en ``networks/.corpus_hash``.
+
+        Devuelve ``None`` si el archivo no existe (cache no generada aún).
+
+        Returns:
+            El hash sellado como string, o ``None``.
+        """
+        hash_file = self.networks_dir / ".corpus_hash"
+        if not hash_file.exists():
+            return None
+        return hash_file.read_text(encoding="utf-8").strip()
+
+    def is_networks_cache_stale(self, live_corpus_hash: str) -> bool:
+        """Verifica si la cache de redes está desactualizada respecto al corpus vivo.
+
+        Compara el ``corpus_hash`` sellado en ``networks/.corpus_hash`` con el
+        ``live_corpus_hash`` del corpus actual.  Devuelve ``True`` si la cache
+        existe pero su hash no coincide (stale); ``False`` si coincide o si la
+        cache todavía no existe (no hay cache que invalidar).
+
+        Args:
+            live_corpus_hash: Hash del corpus vivo (calculado con
+                ``compute_corpus_hash``).
+
+        Returns:
+            ``True`` si la cache existe y su hash difiere del corpus vivo.
+            ``False`` en cualquier otro caso.
+        """
+        sealed = self.read_networks_corpus_hash()
+        if sealed is None:
+            return False
+        return sealed != live_corpus_hash
+
     def to_dict(self) -> dict[str, Any]:
         """Serializa el workspace a dict para el envelope JSON del CLI."""
         return {

--- a/tests/unit/test_workspace_remanentes.py
+++ b/tests/unit/test_workspace_remanentes.py
@@ -1,0 +1,517 @@
+"""Tests TDD — remanentes del modelo workspace (ADR 0029).
+
+Cierra los ítems "fuera de este corte" del AS-BUILT 2026-06-16:
+
+  Parte A — Redirigir snapshot/export al workspace:
+    - snapshot sin --out-dir escribe en <workspace>/snapshots/
+    - export sin --out-dir escribe en <workspace>/exports/
+    - --out-dir explícito sigue funcionando (override gana)
+    - Modo degenerado (--store suelto) sigue resolviendo dirs hermanos
+
+  Parte B — Staleness de la cache de redes:
+    - is_networks_cache_stale con hash distinto → True
+    - is_networks_cache_stale con hash coincidente → False
+    - is_networks_cache_stale sin .corpus_hash → False
+    - read_networks_corpus_hash sin archivo → None
+    - read_networks_corpus_hash con archivo → string del hash
+    - status con cache stale → aviso en envelope["warnings"]
+    - status con cache fresca → sin aviso
+    - data["networks_cache_stale"] reflejado correctamente
+
+Filosofía (AGENTS.md): se testean funciones núcleo y el comportamiento del
+comando via CliRunner donde corresponde. Marcador: ``unit``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pyarrow as pa
+import pytest
+
+from bib2graph.schemas import CORPUS_SCHEMA
+
+# ---------------------------------------------------------------------------
+# Helpers compartidos
+# ---------------------------------------------------------------------------
+
+
+def _make_corpus_row(
+    *, id: str, title: str = "Test", curation_status: str = "candidate"
+) -> dict[str, Any]:
+    """Fila mínima con schema completo."""
+    return {
+        "id": id,
+        "openalex_id": None,
+        "doi": None,
+        "title": title,
+        "year": 2020,
+        "abstract": None,
+        "source": None,
+        "language": "en",
+        "publisher": None,
+        "research_areas": None,
+        "is_seed": True,
+        "curation_status": curation_status,
+        "provenance": None,
+        "authors_raw": None,
+        "authors_id": None,
+        "authors_affiliations": None,
+        "keywords_raw": None,
+        "keywords_id": None,
+        "institutions_raw": None,
+        "institutions_id": None,
+        "references_id": None,
+        "references_doi": None,
+        "cited_by_id": None,
+    }
+
+
+def _seed_store(store_path: Path, rows: list[dict[str, Any]] | None = None) -> None:
+    """Puebla un store con filas mínimas."""
+    from bib2graph.corpus import Corpus
+    from bib2graph.stores.duckdb import DuckDBStore
+
+    if rows is None:
+        rows = [_make_corpus_row(id="P1"), _make_corpus_row(id="P2")]
+    table = pa.Table.from_pylist(rows, schema=CORPUS_SCHEMA)
+    corpus = Corpus.from_arrow(table)
+    store = DuckDBStore(store_path)
+    store.persist(corpus)
+
+
+# ---------------------------------------------------------------------------
+# Parte A — snapshot sin --out-dir usa <workspace>/snapshots/
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_snapshot_sin_outdir_usa_workspace_snapshots_dir(tmp_path: Path) -> None:
+    """run_snapshot con out_dir = ws.snapshots_dir escribe en <workspace>/snapshots/."""
+    from bib2graph.cli.commands.snapshot import run_snapshot
+    from bib2graph.workspace import Workspace
+
+    ws_dir = tmp_path / "proyecto"
+    ws = Workspace.init(ws_dir, "proyecto")
+    _seed_store(ws.library_path)
+
+    data = run_snapshot(ws.library_path, out_dir=ws.snapshots_dir)
+
+    assert Path(data["snapshot_dir"]).is_relative_to(ws.snapshots_dir)
+    assert (ws.snapshots_dir / "corpus.parquet").exists() or any(
+        ws.snapshots_dir.iterdir()
+    )
+    assert "corpus_hash" in data
+    assert "total_papers" in data
+
+
+@pytest.mark.unit
+def test_snapshot_cmd_sin_outdir_resuelve_snapshots_dir(tmp_path: Path) -> None:
+    """snapshot_cmd sin --out-dir usa ws.snapshots_dir (integración Click)."""
+    from click.testing import CliRunner
+
+    from bib2graph.cli.commands.snapshot import snapshot_cmd
+    from bib2graph.workspace import Workspace
+
+    ws_dir = tmp_path / "proyecto"
+    ws = Workspace.init(ws_dir, "proyecto")
+    _seed_store(ws.library_path)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        snapshot_cmd,
+        ["--json"],
+        obj={"workspace": str(ws_dir), "store": None},
+    )
+
+    assert result.exit_code == 0, result.output
+    import json
+
+    envelope = json.loads(result.output)
+    assert envelope["ok"] is True
+    snap_dir = Path(envelope["data"]["snapshot_dir"])
+    # El snapshot debe quedar dentro de <workspace>/snapshots/
+    assert snap_dir.is_relative_to(ws.snapshots_dir)
+
+
+@pytest.mark.unit
+def test_snapshot_cmd_con_outdir_explicito_usa_ese(tmp_path: Path) -> None:
+    """snapshot_cmd con --out-dir explícito usa ese directorio (override gana)."""
+    from click.testing import CliRunner
+
+    from bib2graph.cli.commands.snapshot import snapshot_cmd
+    from bib2graph.workspace import Workspace
+
+    ws_dir = tmp_path / "proyecto"
+    ws = Workspace.init(ws_dir, "proyecto")
+    _seed_store(ws.library_path)
+
+    custom_out = tmp_path / "mi_snapshot"
+    runner = CliRunner()
+    result = runner.invoke(
+        snapshot_cmd,
+        ["--out-dir", str(custom_out), "--json"],
+        obj={"workspace": str(ws_dir), "store": None},
+    )
+
+    assert result.exit_code == 0, result.output
+    import json
+
+    envelope = json.loads(result.output)
+    assert envelope["ok"] is True
+    snap_dir = Path(envelope["data"]["snapshot_dir"])
+    # El snapshot debe estar dentro del directorio explícito, NO en snapshots/
+    assert snap_dir.is_relative_to(custom_out)
+    assert not snap_dir.is_relative_to(ws.snapshots_dir)
+
+
+@pytest.mark.unit
+def test_snapshot_modo_degenerado_usa_dir_hermano(tmp_path: Path) -> None:
+    """snapshot en modo degenerado (--store suelto) usa el dir hermano snapshots/."""
+    from bib2graph.workspace import Workspace
+
+    store_file = tmp_path / "mi.duckdb"
+    _seed_store(store_file)
+
+    ws = Workspace.resolve(store=str(store_file))
+    # El snapshots_dir degenerado es el dir hermano del duckdb
+    assert ws.snapshots_dir == store_file.parent / "snapshots"
+
+
+# ---------------------------------------------------------------------------
+# Parte A — export sin --out-dir usa <workspace>/exports/
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_export_cmd_sin_outdir_resuelve_exports_dir(tmp_path: Path) -> None:
+    """export_cmd sin --out-dir usa ws.exports_dir (integración Click)."""
+    from click.testing import CliRunner
+
+    from bib2graph.cli.commands.build import run_build
+    from bib2graph.cli.commands.export import export_cmd
+    from bib2graph.workspace import Workspace
+
+    ws_dir = tmp_path / "proyecto"
+    ws = Workspace.init(ws_dir, "proyecto")
+    _seed_store(ws.library_path)
+
+    # Primero construir las redes (export las necesita)
+    run_build(ws.library_path, out_dir=ws.networks_dir)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        export_cmd,
+        ["--json"],
+        obj={"workspace": str(ws_dir), "store": None},
+    )
+
+    assert result.exit_code == 0, result.output
+    import json
+
+    envelope = json.loads(result.output)
+    assert envelope["ok"] is True
+    out_dir = Path(envelope["data"]["out_dir"])
+    # El export debe quedar dentro de <workspace>/exports/
+    assert out_dir == ws.exports_dir
+
+
+@pytest.mark.unit
+def test_export_cmd_con_outdir_explicito_usa_ese(tmp_path: Path) -> None:
+    """export_cmd con --out-dir explícito usa ese directorio (override gana)."""
+    from click.testing import CliRunner
+
+    from bib2graph.cli.commands.build import run_build
+    from bib2graph.cli.commands.export import export_cmd
+    from bib2graph.workspace import Workspace
+
+    ws_dir = tmp_path / "proyecto"
+    ws = Workspace.init(ws_dir, "proyecto")
+    _seed_store(ws.library_path)
+
+    run_build(ws.library_path, out_dir=ws.networks_dir)
+
+    custom_out = tmp_path / "mi_export"
+    runner = CliRunner()
+    result = runner.invoke(
+        export_cmd,
+        ["--out-dir", str(custom_out), "--json"],
+        obj={"workspace": str(ws_dir), "store": None},
+    )
+
+    assert result.exit_code == 0, result.output
+    import json
+
+    envelope = json.loads(result.output)
+    assert envelope["ok"] is True
+    out_dir = Path(envelope["data"]["out_dir"])
+    assert out_dir == custom_out
+    assert out_dir != ws.exports_dir
+
+
+@pytest.mark.unit
+def test_export_modo_degenerado_usa_dir_hermano(tmp_path: Path) -> None:
+    """export en modo degenerado (--store suelto) usa el dir hermano exports/."""
+    from bib2graph.workspace import Workspace
+
+    store_file = tmp_path / "mi.duckdb"
+    store_file.touch()
+
+    ws = Workspace.resolve(store=str(store_file))
+    # El exports_dir degenerado es el dir hermano del duckdb
+    assert ws.exports_dir == store_file.parent / "exports"
+
+
+# ---------------------------------------------------------------------------
+# Parte B — helpers de staleness en Workspace
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_read_networks_corpus_hash_sin_archivo_devuelve_none(tmp_path: Path) -> None:
+    """read_networks_corpus_hash devuelve None si no hay .corpus_hash."""
+    from bib2graph.workspace import Workspace
+
+    ws_dir = tmp_path / "ws"
+    ws = Workspace.init(ws_dir, "test")
+
+    assert ws.read_networks_corpus_hash() is None
+
+
+@pytest.mark.unit
+def test_read_networks_corpus_hash_con_archivo_devuelve_hash(tmp_path: Path) -> None:
+    """read_networks_corpus_hash devuelve el hash sellado."""
+    from bib2graph.workspace import Workspace
+
+    ws_dir = tmp_path / "ws"
+    ws = Workspace.init(ws_dir, "test")
+
+    hash_file = ws.networks_dir / ".corpus_hash"
+    hash_file.write_text("abc123", encoding="utf-8")
+
+    assert ws.read_networks_corpus_hash() == "abc123"
+
+
+@pytest.mark.unit
+def test_is_networks_cache_stale_sin_corpus_hash_es_false(tmp_path: Path) -> None:
+    """is_networks_cache_stale es False si no hay .corpus_hash (no hay cache)."""
+    from bib2graph.workspace import Workspace
+
+    ws_dir = tmp_path / "ws"
+    ws = Workspace.init(ws_dir, "test")
+
+    assert ws.is_networks_cache_stale("cualquier_hash") is False
+
+
+@pytest.mark.unit
+def test_is_networks_cache_stale_hash_coincidente_es_false(tmp_path: Path) -> None:
+    """is_networks_cache_stale es False cuando el hash sellado coincide."""
+    from bib2graph.workspace import Workspace
+
+    ws_dir = tmp_path / "ws"
+    ws = Workspace.init(ws_dir, "test")
+
+    hash_file = ws.networks_dir / ".corpus_hash"
+    hash_file.write_text("hash_estable_42", encoding="utf-8")
+
+    assert ws.is_networks_cache_stale("hash_estable_42") is False
+
+
+@pytest.mark.unit
+def test_is_networks_cache_stale_hash_distinto_es_true(tmp_path: Path) -> None:
+    """is_networks_cache_stale es True cuando el hash sellado difiere del vivo."""
+    from bib2graph.workspace import Workspace
+
+    ws_dir = tmp_path / "ws"
+    ws = Workspace.init(ws_dir, "test")
+
+    hash_file = ws.networks_dir / ".corpus_hash"
+    hash_file.write_text("hash_viejo", encoding="utf-8")
+
+    assert ws.is_networks_cache_stale("hash_nuevo") is True
+
+
+@pytest.mark.unit
+def test_staleness_tras_build_y_sin_cambios_es_false(tmp_path: Path) -> None:
+    """Tras un build con el corpus actual, is_networks_cache_stale es False."""
+    from bib2graph.backends.memory import compute_corpus_hash
+    from bib2graph.cli.commands.build import run_build
+    from bib2graph.stores.duckdb import DuckDBStore
+    from bib2graph.workspace import Workspace
+
+    ws_dir = tmp_path / "ws"
+    ws = Workspace.init(ws_dir, "test")
+    _seed_store(ws.library_path)
+
+    run_build(ws.library_path, out_dir=ws.networks_dir)
+
+    store = DuckDBStore(ws.library_path)
+    corpus = store.load()
+    live_hash = compute_corpus_hash(corpus.to_arrow())
+
+    assert ws.is_networks_cache_stale(live_hash) is False
+
+
+@pytest.mark.unit
+def test_staleness_tras_build_y_nuevo_paper_es_true(tmp_path: Path) -> None:
+    """Tras un build y agregar un paper, is_networks_cache_stale es True."""
+    from bib2graph.backends.memory import compute_corpus_hash
+    from bib2graph.cli.commands.build import run_build
+    from bib2graph.corpus import Corpus
+    from bib2graph.stores.duckdb import DuckDBStore
+    from bib2graph.workspace import Workspace
+
+    ws_dir = tmp_path / "ws"
+    ws = Workspace.init(ws_dir, "test")
+    _seed_store(ws.library_path)
+
+    run_build(ws.library_path, out_dir=ws.networks_dir)
+
+    # Agregar un paper nuevo al corpus (cambia el hash vivo)
+    new_row = _make_corpus_row(id="P_NUEVO", title="Nuevo paper")
+    new_table = pa.Table.from_pylist([new_row], schema=CORPUS_SCHEMA)
+    new_corpus = Corpus.from_arrow(new_table)
+    store = DuckDBStore(ws.library_path)
+    existing_corpus = store.load()
+    merged = existing_corpus.merge(new_corpus)
+    store.persist(merged)
+
+    store2 = DuckDBStore(ws.library_path)
+    updated_corpus = store2.load()
+    live_hash = compute_corpus_hash(updated_corpus.to_arrow())
+
+    assert ws.is_networks_cache_stale(live_hash) is True
+
+
+# ---------------------------------------------------------------------------
+# Parte B — status reporta staleness en el envelope
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_status_sin_cache_no_avisa_staleness(tmp_path: Path) -> None:
+    """status sin cache de redes: data['networks_cache_stale'] es False."""
+    from click.testing import CliRunner
+
+    from bib2graph.cli.commands.status import status_cmd
+    from bib2graph.workspace import Workspace
+
+    ws_dir = tmp_path / "proyecto"
+    ws = Workspace.init(ws_dir, "proyecto")
+    _seed_store(ws.library_path)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        status_cmd,
+        ["--json"],
+        obj={"workspace": str(ws_dir), "store": None},
+    )
+
+    assert result.exit_code == 0, result.output
+    import json
+
+    envelope = json.loads(result.output)
+    assert envelope["ok"] is True
+    assert envelope["data"]["networks_cache_stale"] is False
+    assert envelope["warnings"] == []
+
+
+@pytest.mark.unit
+def test_status_cache_fresca_no_avisa(tmp_path: Path) -> None:
+    """status con cache fresca (hash coincide): sin aviso y stale=False."""
+    from click.testing import CliRunner
+
+    from bib2graph.cli.commands.build import run_build
+    from bib2graph.cli.commands.status import status_cmd
+    from bib2graph.workspace import Workspace
+
+    ws_dir = tmp_path / "proyecto"
+    ws = Workspace.init(ws_dir, "proyecto")
+    _seed_store(ws.library_path)
+
+    # Build → sella el hash
+    run_build(ws.library_path, out_dir=ws.networks_dir)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        status_cmd,
+        ["--json"],
+        obj={"workspace": str(ws_dir), "store": None},
+    )
+
+    assert result.exit_code == 0, result.output
+    import json
+
+    envelope = json.loads(result.output)
+    assert envelope["ok"] is True
+    assert envelope["data"]["networks_cache_stale"] is False
+    assert envelope["warnings"] == []
+
+
+@pytest.mark.unit
+def test_status_cache_stale_emite_aviso(tmp_path: Path) -> None:
+    """status con cache obsoleta: warnings tiene un mensaje con 'b2g build'."""
+    from bib2graph.cli.commands.build import run_build
+    from bib2graph.cli.commands.status import status_cmd
+    from bib2graph.workspace import Workspace
+
+    # Sellar un hash "viejo" artificialmente
+    ws_dir = tmp_path / "proyecto"
+    ws = Workspace.init(ws_dir, "proyecto")
+    _seed_store(ws.library_path)
+    run_build(ws.library_path, out_dir=ws.networks_dir)
+
+    # Sobrescribir .corpus_hash con un hash falso para simular staleness
+    hash_file = ws.networks_dir / ".corpus_hash"
+    hash_file.write_text("hash_falso_del_pasado", encoding="utf-8")
+
+    import json
+
+    from click.testing import CliRunner
+
+    runner = CliRunner()
+    result = runner.invoke(
+        status_cmd,
+        ["--json"],
+        obj={"workspace": str(ws_dir), "store": None},
+    )
+
+    assert result.exit_code == 0, result.output
+    envelope = json.loads(result.output)
+    assert envelope["ok"] is True
+    assert envelope["data"]["networks_cache_stale"] is True
+    assert len(envelope["warnings"]) == 1
+    assert "b2g build" in envelope["warnings"][0]
+
+
+@pytest.mark.unit
+def test_status_cache_stale_modo_degenerado_no_avisa(tmp_path: Path) -> None:
+    """status en modo degenerado (sin workspace): networks_cache_stale es False.
+
+    En modo degenerado no hay networks/.corpus_hash conocido (networks_dir
+    apunta al dir hermano del duckdb suelto, que puede no existir).
+    is_networks_cache_stale devuelve False si no existe el archivo.
+    """
+    import json
+
+    from click.testing import CliRunner
+
+    from bib2graph.cli.commands.status import status_cmd
+
+    store_file = tmp_path / "mi.duckdb"
+    _seed_store(store_file)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        status_cmd,
+        ["--json"],
+        obj={"workspace": None, "store": str(store_file)},
+    )
+
+    assert result.exit_code == 0, result.output
+    envelope = json.loads(result.output)
+    assert envelope["ok"] is True
+    # Sin .corpus_hash → no stale
+    assert envelope["data"]["networks_cache_stale"] is False
+    assert envelope["warnings"] == []


### PR DESCRIPTION
Cierra **#32** — los remanentes que ADR 0029 dejó 'fuera de corte', últimos de código del terreno pre-GUI.

- `snapshot`/`export`: `--out-dir` → override **opcional**; default `<workspace>/snapshots|exports/`. Modo degenerado sin regresión.
- `status`: **aviso de staleness** (`networks_cache_stale` + warning) cuando el `.corpus_hash` sellado por `build` ≠ corpus vivo. **No regenera** (ADR 0029: invalidación por hash, no build-system). Mismo `compute_corpus_hash` → sin falsos positivos.

Verificación PASA (paridad de hash confirmada + test e2e; modo degenerado sin regresión; doble-open corregido a `open_store_readonly`). **534 tests**, 0 enlaces rotos. Docs: API + ADDENDUM AS-BUILT ADR 0029 + ROADMAP (modelo workspace COMPLETO).