### PR TITLE
fix(sources): filtro --exclude mal-formado en OpenAlex (#30)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,9 +147,11 @@
   `docs/API.md` §convenciones CLI.
 - **Ergonomía de `b2g seed` (#14 + #30, 2026-06-16):** **`--max-results INT`** propaga a
   `OpenAlexSource(max_results=...)` (sin flag = default 200) para explorar con muestras chicas;
-  **`--exclude TEXT`** (repetible) son negaciones quirúrgicas que agregan
-  `AND NOT title_and_abstract.search:"<término>"` por término al filtro y se **reportan en el
-  `translation_report`** del `SeedResult` (query visible, ignorado con `--native`). Cierra el síntoma
+  **`--exclude TEXT`** (repetible) son negaciones quirúrgicas que inyectan cada `AND NOT "<término>"`
+  **dentro** de la única expresión `title_and_abstract.search:((query) AND NOT "<término>")` (el campo
+  **no se repite**; la forma vieja con campo repetido devolvía 0 en OpenAlex, corregido AS-BUILT
+  2026-06-17, fix de #30 validado contra la API real vía test `@pytest.mark.network`) y se **reportan
+  en el `translation_report`** del `SeedResult` (query visible, ignorado con `--native`). Cierra el síntoma
   B1 de la [Nota 09](docs/Notas/09-sesion-qa-prueba-ecologia-valoraciones.md). **476 tests verdes**.
   Ver `docs/API.md` §2 + §convenciones CLI.
 - Toda la información del producto, la arquitectura, los contratos y la secuencia de
@@ -223,7 +225,9 @@ El proyecto se gestiona con **uv** (entorno + lockfile + versión de Python). **
 - **Un solo test:** `uv run pytest tests/unit/test_corpus.py::test_merge_idempotente -xvs`
 - **Por marcador:** `uv run pytest -m unit` / `uv run pytest -m integration` (los tests que
   toquen red o Neo4j se marcan `integration` y usan Testcontainers o mocks; el núcleo va en
-  `unit`).
+  `unit`). El marcador **`network`** es aparte: tests que pegan a la **API real de OpenAlex**
+  (no mock) — **fuera del gate por defecto** (`addopts -m "not network"`); se corren explícitos con
+  `uv run pytest -m network`. Los `integration` de DuckDB/store **sí** quedan en el gate.
 - **Lint:** `uv run ruff check .` y `uv run ruff format --check .` (así lo corre el CI; `exploracion/` excluido)
 - **Tipos:** `uv run mypy src`
 - **Todo en uno (gate de CI):** `uv run ruff check . && uv run ruff format --check . && uv run mypy src && uv run pytest`

--- a/docs/API.md
+++ b/docs/API.md
@@ -205,11 +205,14 @@ rehidratación de corpus curado sin red, Ciclo 9a, ADR
   Flags ergonómicos de OpenAlex (#14 + #30, **solo con `--equation`/`--spec`**): **`--max-results INT`**
   propaga a `OpenAlexSource(max_results=...)` —sin flag, el default del source = 200— para exploración
   con muestras chicas (Nota 09 B1); **`--exclude TEXT`** (repetible) son **negaciones quirúrgicas**:
-  cada término agrega `AND NOT title_and_abstract.search:"<término>"` al filtro y queda en el
+  cada término se inyecta **dentro** de la única expresión de búsqueda como
+  `title_and_abstract.search:((query) AND NOT "<término>")` (el campo **no se repite**; el `AND NOT`
+  va adentro del paréntesis) y queda en el
   `translation_report` del `SeedResult` (ejercicio consciente, query visible); ignorado con `--native`
   (query cruda); **`--min-year INT`/`--max-year INT`** (Ciclo 10) **filtran de verdad** contra OpenAlex
-  agregando `from_publication_date:<min_year>-01-01` y/o `to_publication_date:<max_year>-12-31` al
-  filtro (sintaxis idiomática de rango, combinada con coma; reportado en el `translation_report`).
+  agregando `from_publication_date:<min_year>-01-01` y/o `to_publication_date:<max_year>-12-31` como
+  predicado de filtro **separado por coma, fuera** de la expresión `search` (sintaxis idiomática de
+  rango; reportado en el `translation_report`).
   Con `--spec`, todos estos parámetros vienen del YAML (paridad 1:1 flag ⇄ campo). **Combinar
   cualquier flag de OpenAlex (`--exclude`/`--max-results`/`--native`/`--email`/`--min-year`/`--max-year`)
   con `--from-bib` → error de uso, exit 1** (falla fuerte, no ignora en silencio). En modo `--native`,
@@ -672,8 +675,9 @@ class Source(Protocol):
     def seed(self, query: str, *, exclude: list[str] | None = None) -> "SeedResult":
         """Siembra desde una ecuación de búsqueda. Devuelve el Corpus + la query ejecutada
         y el reporte de traducción (qué mapeó, qué se aproximó, qué se descartó).
-        `exclude` (negaciones quirúrgicas, opcional): cada término agrega
-        `AND NOT title_and_abstract.search:"<término>"` al filtro y se REPORTA en el
+        `exclude` (negaciones quirúrgicas, opcional): cada término se inyecta DENTRO de la
+        única expresión `title_and_abstract.search:((query) AND NOT "<término>")` (el campo
+        NO se repite) y se REPORTA en el
         translation_report (query visible, ejercicio consciente). Las comillas internas del
         término se sanean. Ignorado con `native=True` (query cruda). Una Source que no siembra
         por ecuación (p. ej. BibtexSource) lanza NotImplementedError."""
@@ -698,7 +702,7 @@ class EquationSpec(BaseModel):
     """Configuración declarativa de una ecuación de búsqueda (ADR 0030).
     model_config = ConfigDict(extra="forbid"): campo desconocido en el YAML → error accionable."""
     query: str                          # requerido (no vacío) — la ecuación de búsqueda
-    exclude: list[str] = []             # #30 — AND NOT title_and_abstract.search:"…" por término
+    exclude: list[str] = []             # #30 — AND NOT "…" DENTRO de la search:((query) AND NOT "…")
     max_results: int | None = None      # #14 — tope (None → default del source, 200)
     native: bool = False                # passthrough crudo a OpenAlex (sin traducción)
     min_year: int | None = None         # DECLARADO, AÚN NO FILTRA (ver nota)
@@ -722,7 +726,7 @@ def load_equation_spec(path: str | Path) -> EquationSpec:
 
 | Implementación | Estado | Notas |
 |----------------|--------|-------|
-| `OpenAlexSource` | **v1 (construido, Hito 4)** | **Referencia/backbone**, sobre `httpx`. Entrega mínimo + enriquecimiento: refs inline + afiliaciones per-autor + instituciones; `cited_by_id` queda **diferido** al chaining/`Enricher` (no se trae en el seed). Traducción **passthrough** —envuelve la ecuación en `title_and_abstract.search:(...)` y **reporta** los límites WoS (NEAR/comodín/tags) sin traducirlos; el traductor WoS→OpenAlex es v0.2. Flag `native=True` (query cruda). **Negaciones (`exclude`, #30):** `seed(..., exclude=[...])` y `_translate(exclude=...)` agregan `AND NOT title_and_abstract.search:"<término>"` por término al filtro y lo **reportan en el `translation_report`** (query visible); comillas internas saneadas; **ignorado con `native=True`**. *(La sintaxis NOT no se validó contra la API real —mock—; es plausible/coherente con el passthrough.)* Credenciales inyectadas (arg → `OPENALEX_API_KEY` → `~/.openalex/credentials` → polite pool; ADR 0012). Cursor paging con tope `max_results` (param de `__init__`, default 200; **`b2g seed --max-results INT`** lo propaga para exploración con muestras chicas, Nota 09 B1). Puebla `Manifest.openalex_version` (header o fecha del fetch; ADR 0017). `transport` inyectable (tests con `MockTransport`, sin red en CI). |
+| `OpenAlexSource` | **v1 (construido, Hito 4)** | **Referencia/backbone**, sobre `httpx`. Entrega mínimo + enriquecimiento: refs inline + afiliaciones per-autor + instituciones; `cited_by_id` queda **diferido** al chaining/`Enricher` (no se trae en el seed). Traducción **passthrough** —envuelve la ecuación en `title_and_abstract.search:(...)` y **reporta** los límites WoS (NEAR/comodín/tags) sin traducirlos; el traductor WoS→OpenAlex es v0.2. Flag `native=True` (query cruda). **Negaciones (`exclude`, #30):** `seed(..., exclude=[...])` y `_translate(exclude=...)` inyectan cada `AND NOT "<término>"` **DENTRO** de la única expresión `title_and_abstract.search:((query) AND NOT "<término>")` (el campo **no se repite**; el filtro de año queda como predicado separado por coma **fuera** de la expresión `search`) y lo **reportan en el `translation_report`** (query visible); comillas internas saneadas; **ignorado con `native=True`**. *(Sintaxis **validada contra OpenAlex real** vía test `@pytest.mark.network`, 2026-06-17: la forma vieja con el campo repetido devolvía 0 resultados.)* Credenciales inyectadas (arg → `OPENALEX_API_KEY` → `~/.openalex/credentials` → polite pool; ADR 0012). Cursor paging con tope `max_results` (param de `__init__`, default 200; **`b2g seed --max-results INT`** lo propaga para exploración con muestras chicas, Nota 09 B1). Puebla `Manifest.openalex_version` (header o fecha del fetch; ADR 0017). `transport` inyectable (tests con `MockTransport`, sin red en CI). |
 | `BibtexSource` | **v1, secundaria (construido, Hito 4)** | Sembrar desde *pearls* vía `load()`. Extra **`[bibtex]`** (import perezoso de `bibtexparser`, ADR 0005); acceso defensivo (fix del bug T1: campos faltantes sin `KeyError`). Mínimo universal. `seed()` lanza `NotImplementedError` (BibTeX no siembra por ecuación). **R5:** un `.bib` con error de parseo grave → `ValueError` accionable (antes lo tragaba en silencio); un `.bib` sin entradas válidas / con entradas omitidas por falta de título → `UserWarning` (no no-op silencioso). Carga bulk con `from_arrow`. |
 | `ScieloSource` / `RedalycSource` / `LaReferenciaSource` | futuro | Fuentes regionales, mínimo universal. Declaradas, no implementadas (ADR 0018). |
 | `RisSource` / `CsvSource` | futuro | No implementados. |

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -174,7 +174,8 @@ No es una herramienta para usuario final no técnico: no hay GUI ni servicio web
   **declara** como contrato en V1 y se concreta en **v0.2+**.
 - **Traducción** de la ecuación a query OpenAlex con **query ejecutada visible + reporte de
   traducción**, ambas **registradas** con la corrida. Incluye **negaciones quirúrgicas**
-  (`b2g seed --exclude`, repetible: `AND NOT title_and_abstract.search:"…"` por término) que se
+  (`b2g seed --exclude`, repetible: cada `AND NOT "…"` va **dentro** de la única expresión
+  `title_and_abstract.search:((query) AND NOT "…")`, campo no repetido) que se
   **reportan en el reporte de traducción** (ejercicio consciente, no silencioso), y
   **`--max-results`** para acotar el fetch en exploración con muestras chicas.
 - **Chaining asistido** backward/forward sobre OpenAlex; **profundidad 1 por defecto**, opt-in a

--- a/docs/ROADMAP/04-lo-que-viene.md
+++ b/docs/ROADMAP/04-lo-que-viene.md
@@ -287,11 +287,17 @@ No se prometen ni se cablean clientes que no se usan.
   `OpenAlexSource(max_results=...)` (sin flag = default del source, 200) para explorar con muestras
   chicas (síntoma B1 de la [Nota 09](../Notas/09-sesion-qa-prueba-ecologia-valoraciones.md)).
   **`--exclude TEXT` repetible (#30)** son **negaciones quirúrgicas**: `seed(..., exclude=[...])` y
-  `_translate(exclude=...)` agregan `AND NOT title_and_abstract.search:"<término>"` por término al
-  filtro y las **reportan en el `translation_report`** del `SeedResult` (ejercicio consciente, query
-  visible); comillas internas saneadas; **ignorado con `native=True`**. *(La sintaxis NOT no se validó
-  contra la API real —mock—; plausible/coherente con el passthrough.)* Gate verde, **476 tests**. Ver
+  `_translate(exclude=...)` inyectan cada `AND NOT "<término>"` **dentro** de la única expresión
+  `title_and_abstract.search:((query) AND NOT "<término>")` (el campo **no se repite**) y las
+  **reportan en el `translation_report`** del `SeedResult` (ejercicio consciente, query
+  visible); comillas internas saneadas; **ignorado con `native=True`**. Gate verde, **476 tests**. Ver
   `API.md` §2 + §convenciones CLI.
+  *(**Corrección AS-BUILT 2026-06-17, `fix/openalex-exclude-filter`:** el corte original de #30 serializaba*
+  *cada negación **repitiendo el campo** (`…search:(query) AND NOT …search:"x"`), forma que OpenAlex no parsea*
+  *→ **0 resultados**. Los tests de #30 eran solo unit con `MockTransport` y assertaban la **forma buggeada** del*
+  *string → falso positivo. El fix mueve el `AND NOT "x"` **dentro** del único `search:((…))` y agrega (a) un*
+  *assert-guardia `executed.count("title_and_abstract.search:") == 1` en unit y (b) un test `@pytest.mark.network`*
+  *contra la **API real** —0 → ~3958 resultados—, fuera del gate por defecto.)*
 
 > **RETIRADO del producto (ADR [0022](../decisiones/0022-producto-sin-ia-generativa.md), 2026-06-15):**
 > el **fallback fuzzy/semántico del thesaurus por LLM** y la **"máquina de tensiones"** (la antigua

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -179,10 +179,13 @@ addopts = [
     "--strict-config",
     "--cov=bib2graph",
     "--cov-report=term-missing",
+    "-m",
+    "not network",
 ]
 markers = [
     "unit: tests puros, sin red ni I/O (default)",
-    "integration: tests con red, servicios externos, o Testcontainers",
+    "integration: tests con I/O local (duckdb/store); corren en el gate",
+    "network: tests que requieren red real (p.ej. OpenAlex); excluidos del gate por defecto (correr con -m network)",
 ]
 
 [tool.coverage.run]

--- a/src/bib2graph/sources/openalex.py
+++ b/src/bib2graph/sources/openalex.py
@@ -96,9 +96,9 @@ def _translate(
     - Comodín ``*``: comportamiento distinto al de WoS.
     - Tags de campo WoS (``TS=``, ``AB=``, ``AU=``…): no mapean 1:1.
 
-    Las exclusiones (``exclude``) añaden cláusulas
-    ``AND NOT title_and_abstract.search:"<término>"`` al final del filtro y
-    se reportan en el translation_report para transparencia (PRD §4).
+    Las exclusiones (``exclude``) añaden cláusulas ``AND NOT "<término>"``
+    dentro de la expresión ``title_and_abstract.search:(...)`` y se reportan
+    en el translation_report para transparencia (PRD §4).
 
     El filtro de año (``min_year``/``max_year``) agrega cláusulas
     ``from_publication_date:<min_year>-01-01`` y/o
@@ -109,8 +109,9 @@ def _translate(
         query: Ecuación de búsqueda.
         native: Si es ``True``, no traducir; usar query cruda.
         exclude: Lista de términos a excluir de título/abstract.  Cada uno
-            genera una cláusula ``AND NOT title_and_abstract.search:"…"``.
-            ``None`` o lista vacía = sin exclusiones.
+            genera una cláusula ``AND NOT "…"`` dentro del paréntesis de
+            ``title_and_abstract.search``.  ``None`` o lista vacía = sin
+            exclusiones.
         min_year: Año mínimo de publicación (inclusive).  Genera
             ``from_publication_date:<min_year>-01-01``.  ``None`` = sin límite.
         max_year: Año máximo de publicación (inclusive).  Genera
@@ -141,23 +142,27 @@ def _translate(
             "mapean 1:1 en OpenAlex; se descartaron del filtro de campo."
         )
 
-    # Envolver en el filtro de OpenAlex (PASSTHROUGH)
-    executed = f"title_and_abstract.search:({query})"
-
-    # Negaciones: cada término excluido agrega una cláusula AND NOT (#30).
+    # Negaciones: cada término excluido agrega una cláusula AND NOT dentro del
+    # paréntesis de title_and_abstract.search (#30, fix bug).
+    # OpenAlex interpreta el filtro como predicados separados por coma; repetir
+    # el nombre del campo fuera del paréntesis produce 0 resultados.
     # Las comillas internas se eliminan para no romper la frase entrecomillada
     # en el filtro de OpenAlex (un `"` embebido cierra la frase antes de tiempo).
     terms = [t.strip().replace('"', "") for t in (exclude or []) if t and t.strip()]
+
+    # Construir el cuerpo interno: (query) [AND NOT "t1" AND NOT "t2" ...]
+    body = f"({query})"
     if terms:
-        not_clauses = " ".join(
-            f'AND NOT title_and_abstract.search:"{t}"' for t in terms
-        )
-        executed = f"{executed} {not_clauses}"
+        not_clauses = " ".join(f'AND NOT "{t}"' for t in terms)
+        body = f"{body} {not_clauses}"
         report.append(
             f"Exclusiones aplicadas ({len(terms)}): "
             + ", ".join(f'"{t}"' for t in terms)
             + ". Cláusulas AND NOT añadidas al filtro de OpenAlex."
         )
+
+    # Envolver UNA sola vez en el campo de OpenAlex (PASSTHROUGH)
+    executed = f"title_and_abstract.search:{body}"
 
     # Filtro de año: sintaxis idiomática de rango de OpenAlex.
     # Las cláusulas se combinan con AND junto al resto del filtro.
@@ -516,7 +521,8 @@ class OpenAlexSource:
             query: Ecuación de búsqueda (WoS-style o nativa OpenAlex).
             native: Si es ``True``, pasa la query cruda sin traducción.
             exclude: Lista de términos a excluir de título/abstract (#30).
-                Cada término genera ``AND NOT title_and_abstract.search:"…"``.
+                Cada término genera ``AND NOT "…"`` dentro del paréntesis de
+                ``title_and_abstract.search``.
             min_year: Año mínimo de publicación (filtro de rango OpenAlex).
                 Genera ``from_publication_date:<min_year>-01-01``.
                 ``None`` = sin límite inferior.

--- a/tests/integration/test_openalex_exclude_integration.py
+++ b/tests/integration/test_openalex_exclude_integration.py
@@ -1,0 +1,67 @@
+"""Tests de integración para el filtro --exclude de OpenAlexSource.
+
+Estos tests tocan la API real de OpenAlex (sin MockTransport) y verifican
+que la forma del filtro producida por _translate genera resultados reales.
+
+La clase de bug que cubren (campo repetido fuera del paréntesis) da 0
+resultados contra la API real pero no es detectable por mocks, ya que el
+mock no valida la semántica del filtro de OpenAlex.
+
+Marcados como ``network`` → excluidos del gate/CI por defecto
+(``addopts = ["-m", "not network"]``), porque requieren red real a OpenAlex.
+Los tests ``integration`` que NO tocan red (p.ej. duckdb/store) siguen
+corriendo en el gate.  Para correr estos con red real:
+    uv run pytest -m network
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from bib2graph.sources.openalex import OpenAlexSource
+
+
+@pytest.mark.network
+def test_exclude_filter_retorna_resultados_no_cero() -> None:
+    """La query con --exclude devuelve count > 0 contra OpenAlex real.
+
+    Si el filtro tuviera la forma buggeada (campo repetido fuera del
+    paréntesis), OpenAlex devuelve 0 resultados.  Con la forma correcta
+    (NOT dentro del paréntesis) devuelve results > 0.
+
+    Query elegida: "complexity" (amplia) con exclude=["machine learning",
+    "deep learning"] — confirmada 3958 resultados en la sesión de QA del bug.
+    """
+    source = OpenAlexSource(email="trama.complejidad@gmail.com", max_results=10)
+    result = source.seed(
+        "complexity",
+        exclude=["machine learning", "deep learning"],
+        max_year=2023,
+    )
+
+    count = len(result.corpus)
+    assert count > 0, (
+        f"Se esperaban resultados > 0 pero se obtuvieron {count}. "
+        "Posible regresión a la forma buggeada del filtro --exclude "
+        "(campo repetido fuera del paréntesis → 0 resultados en OpenAlex)."
+    )
+
+
+@pytest.mark.network
+def test_exclude_filter_campo_no_repetido_en_query_ejecutada() -> None:
+    """La query ejecutada contra OpenAlex real contiene exactamente un campo de búsqueda.
+
+    Verifica que ``_translate`` no repite ``title_and_abstract.search:``
+    y que la forma enviada a la API es la correcta.
+    """
+    source = OpenAlexSource(email="trama.complejidad@gmail.com", max_results=5)
+    result = source.seed(
+        "systems thinking",
+        exclude=["artificial intelligence"],
+    )
+
+    assert result.executed_query.count("title_and_abstract.search:") == 1, (
+        f"Se repite el campo en la query ejecutada: {result.executed_query!r}"
+    )
+    assert "AND NOT title_and_abstract.search:" not in result.executed_query
+    assert 'AND NOT "artificial intelligence"' in result.executed_query

--- a/tests/unit/test_sources.py
+++ b/tests/unit/test_sources.py
@@ -702,24 +702,31 @@ def test_translate_sin_exclusiones_comportamiento_actual() -> None:
 
 @pytest.mark.unit
 def test_translate_con_una_exclusion() -> None:
-    """Un término excluido → cláusula ``AND NOT title_and_abstract.search:"…"``."""
+    """Un término excluido → cláusula ``AND NOT "…"`` dentro de title_and_abstract.search."""
     query = "sistémico AND complejidad"
     executed, _report = _translate(query, exclude=["machine learning"])
 
-    assert 'AND NOT title_and_abstract.search:"machine learning"' in executed
-    # El prefijo sigue siendo el wrapping correcto
+    # El campo NO se repite: exactamente un "title_and_abstract.search:" en el filtro
+    assert executed.count("title_and_abstract.search:") == 1
+    # La cláusula NOT va dentro del paréntesis, sin prefijo de campo
+    assert 'AND NOT "machine learning"' in executed
+    assert "AND NOT title_and_abstract.search:" not in executed
+    # La query base sigue envuelta correctamente
     assert executed.startswith(f"title_and_abstract.search:({query})")
 
 
 @pytest.mark.unit
 def test_translate_con_multiples_exclusiones() -> None:
-    """Múltiples exclusiones → una cláusula AND NOT por cada término."""
+    """Múltiples exclusiones → una cláusula AND NOT por cada término, todas dentro del paréntesis."""
     query = "sujeto AND sistema"
     terms = ["machine learning", "algorithm", "lupus"]
     executed, _report = _translate(query, exclude=terms)
 
+    # El campo NO se repite: exactamente un "title_and_abstract.search:" en el filtro
+    assert executed.count("title_and_abstract.search:") == 1
+    assert "AND NOT title_and_abstract.search:" not in executed
     for term in terms:
-        assert f'AND NOT title_and_abstract.search:"{term}"' in executed
+        assert f'AND NOT "{term}"' in executed
 
 
 @pytest.mark.unit
@@ -759,21 +766,22 @@ def test_translate_exclusion_none_sin_efecto() -> None:
 
 @pytest.mark.unit
 def test_seed_exclude_en_query_ejecutada() -> None:
-    """``seed(..., exclude=[...])`` refleja las cláusulas NOT en ``executed_query``."""
+    """``seed(..., exclude=[...])`` refleja cláusulas NOT dentro del paréntesis de búsqueda."""
     works = _load_fixture_works()
     transport = _make_handler(works)
     source = OpenAlexSource(transport=transport)
 
     result = source.seed("sistémico", exclude=["machine learning"])
 
-    assert (
-        'AND NOT title_and_abstract.search:"machine learning"' in result.executed_query
-    )
+    # El campo NO se repite: exactamente un "title_and_abstract.search:" en la query
+    assert result.executed_query.count("title_and_abstract.search:") == 1
+    assert 'AND NOT "machine learning"' in result.executed_query
+    assert "AND NOT title_and_abstract.search:" not in result.executed_query
 
 
 @pytest.mark.unit
 def test_seed_exclude_multiples_en_query_ejecutada() -> None:
-    """Múltiples términos excluidos aparecen todos en la query ejecutada."""
+    """Múltiples términos excluidos aparecen todos dentro del paréntesis en la query ejecutada."""
     works = _load_fixture_works()
     transport = _make_handler(works)
     source = OpenAlexSource(transport=transport)
@@ -781,8 +789,11 @@ def test_seed_exclude_multiples_en_query_ejecutada() -> None:
     terms = ["machine learning", "algorithm"]
     result = source.seed("sujeto", exclude=terms)
 
+    # El campo NO se repite: exactamente un "title_and_abstract.search:"
+    assert result.executed_query.count("title_and_abstract.search:") == 1
+    assert "AND NOT title_and_abstract.search:" not in result.executed_query
     for term in terms:
-        assert f'AND NOT title_and_abstract.search:"{term}"' in result.executed_query
+        assert f'AND NOT "{term}"' in result.executed_query
 
 
 @pytest.mark.unit
@@ -843,8 +854,52 @@ def test_translate_exclude_strip_comillas_internas() -> None:
     """Comillas embebidas en un término se eliminan para no romper la frase OpenAlex."""
     executed, _report = _translate("ecologia", exclude=['"machine learning"'])
 
+    # El campo NO se repite: exactamente un "title_and_abstract.search:"
+    assert executed.count("title_and_abstract.search:") == 1
+    assert "AND NOT title_and_abstract.search:" not in executed
     # Las comillas del término se eliminaron; la frase externa queda bien formada
-    assert 'AND NOT title_and_abstract.search:"machine learning"' in executed
+    assert 'AND NOT "machine learning"' in executed
     # No debe haber comilla suelta que cierre la frase antes de tiempo
-    after_not = executed.split("AND NOT title_and_abstract.search:")[1]
-    assert after_not.count('"') == 2  # exactamente apertura y cierre
+    after_not = executed.split('AND NOT "')[1]
+    assert after_not.startswith("machine learning")
+    # La cláusula cierra con exactamente una comilla de cierre
+    assert after_not.count('"') == 1  # solo la comilla de cierre
+
+
+@pytest.mark.unit
+def test_translate_exclude_con_anio_forma_completa() -> None:
+    """Con exclude + year, los NOT van dentro de search y el año va fuera con coma.
+
+    Forma esperada:
+        title_and_abstract.search:(query) AND NOT "t1" AND NOT "t2",
+        from_publication_date:2020-01-01,to_publication_date:2024-12-31
+
+    Los NOT están dentro de la expresión de search (un solo campo);
+    los predicados de año se añaden fuera con coma (sintaxis idiomática OpenAlex).
+    """
+    query = "complejidad AND sistemas"
+    executed, _report = _translate(
+        query,
+        exclude=["machine learning", "deep learning"],
+        min_year=2020,
+        max_year=2024,
+    )
+
+    # Exactamente un campo de búsqueda (no se repite)
+    assert executed.count("title_and_abstract.search:") == 1
+    assert "AND NOT title_and_abstract.search:" not in executed
+
+    # Los NOT van dentro de la expresión (sin prefijo de campo)
+    assert 'AND NOT "machine learning"' in executed
+    assert 'AND NOT "deep learning"' in executed
+
+    # El año va fuera de la expresión de search, separado por coma
+    assert ",from_publication_date:2020-01-01" in executed
+    assert ",to_publication_date:2024-12-31" in executed
+
+    # La expresión de search precede a los predicados de año
+    search_idx = executed.index("title_and_abstract.search:")
+    from_idx = executed.index(",from_publication_date:")
+    to_idx = executed.index(",to_publication_date:")
+    assert search_idx < from_idx
+    assert search_idx < to_idx


### PR DESCRIPTION
**Bugfix** descubierto al construir el ejemplo real (`examples/valoraciones/`): las negaciones `--exclude` (#30) producían un filtro que OpenAlex no entiende → **0 resultados**.

- Causa: `_translate` **repetía el campo** (`AND NOT title_and_abstract.search:"x"`). Fix: los `AND NOT "x"` van **dentro** de la única expresión `title_and_abstract.search:((query) AND NOT "x")`; año fuera con coma. **Validado contra OpenAlex real** (0 → ~3958).
- Los tests de #30 eran **solo-mock** y assertaban la forma rota (falso positivo). Ahora: assert-guardia `count("title_and_abstract.search:") == 1` en unit + 2 tests `@pytest.mark.network` reales. Marker `network` excluido del gate (`-m "not network"`); los `integration` de store **siguen** en el gate.

verifier **PASA** (forma confirmada, sin regresión de cobertura: 598 + 2 network deselected). Desbloquea el Ciclo B (regen del ejemplo desde la ecuación).