### PR TITLE
docs: sanear coherencia de artefactos de entrada (README + conteos + residuos)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,17 @@ Kuhlthau): se siembra desde la ecuación, se forrajea (chaining rankeado por est
 cura, **la idea muta** y se vuelve a sembrar — acumulando sobre lo curado. La colección
 **vive y persiste** entre corridas en DuckDB.
 
-> **Estado: v0.3 construido (Hitos 0–6 + 1.5 + tanda de remediación R1–R5).** El flujo **de una
-> ecuación a las redes** ya corre sobre la biblioteca viva, **desde código Python y desde el CLI
-> `b2g`** (que **ya no es un placeholder**). Construido: el `Corpus` canónico sobre `TabularBackend`,
-> los proyectores/analizadores/exportadores, el backend DuckDB (biblioteca viva), las fuentes
-> `OpenAlexSource`/`BibtexSource`, el **forrajeo** (`Forager`, chaining rankeado por *information
-> scent*) + `Preprocessor`/thesaurus + filtros PRISMA, y la **CLI agente-native `b2g`** (12
-> subcomandos, `--json` versionado, exit codes; ADR
-> [0021](docs/decisiones/0021-cli-agente-native-contrato.md)). **327 tests** verdes.
+> **Estado: Hitos 1–9 construidos + remediación R1–R5 + workspace + ejemplos CLI-puros.** El flujo
+> **de una ecuación a las redes** corre sobre la biblioteca viva, **desde código Python y desde el CLI
+> `b2g`**. Construido: el `Corpus` canónico sobre `TabularBackend`, los proyectores/analizadores/
+> exportadores, el backend DuckDB (biblioteca viva), las fuentes `OpenAlexSource`/`BibtexSource`, el
+> **forrajeo** (`Forager`, chaining rankeado por *information scent*) + `Preprocessor`/thesaurus +
+> filtros PRISMA, el **dedup fuzzy** determinista (Hito 7, `rapidfuzz`), el **`Enricher` de co-citación
+> end-to-end** (Hito 8, refs→DOI + citantes vía `b2g enrich`), **`NetworkSpec` YAML** (Hito 9,
+> `b2g networks --spec`), el **workspace por investigación** (ADR
+> [0029](docs/decisiones/0029-workspace-por-investigacion.md): una investigación = una carpeta,
+> `b2g init`) y la **CLI agente-native `b2g`** (`--json` versionado, exit codes; ADR
+> [0021](docs/decisiones/0021-cli-agente-native-contrato.md)).
 >
 > **Remediación completa (Hitos R1–R5):** tras un red-team del código construido
 > ([Nota 06](docs/Notas/06-critica-as-built-v0.2.md)) el PO bloqueó un modelo nuevo (ADR
@@ -30,12 +33,12 @@ cura, **la idea muta** y se vuelve a sembrar — acumulando sobre lo curado. La 
 > snapshot se arregló con **content-hash determinista** identidad-vs-procedencia (R2); el ciclo es un
 > **FSM cíclico** de dominio (`cycle.py`) con `reseed`/ronda y curación visible (R3); se **eliminó**
 > `explain_candidate` + el extra `[llm]` (R4); y se endureció la robustez (bulk-load, UTF-8 en la
-> frontera, `except` acotados — R5). Ver el [roadmap](docs/ROADMAP/README.md) (tanda R1–R5, ✅ completa).
+> frontera, `except` acotados — R5). Ver el [roadmap](docs/ROADMAP/README.md).
 >
-> **Todavía no** (v0.4+ → v1.0, ya con la remediación cerrada): dedup fuzzy (Hito 7), `Enricher` de co-citación
-> end-to-end (Hito 8), `NetworkSpec` YAML (Hito 9), visualización (Hito 10) y costuras Zotero/Neo4j
-> (Hito 11). La **co-citación end-to-end** requiere un 2º nivel de fetch (Hito 8) — hoy da pocas/cero
-> aristas hasta enriquecer.
+> **Pendiente hacia v1.0:** la **GUI local** (epic [#34](https://github.com/complexluise/bib2graph/issues/34),
+> gateada: núcleo → caso real → GUI), que absorbe la visualización (ex-Hito 10). Las costuras
+> Zotero/Neo4j (ex-Hito 11) quedaron **descartadas** (decisión del PO; reabribles solo si aparece
+> demanda real). Ver el [roadmap](docs/ROADMAP/04-lo-que-viene.md).
 
 ## ⚠️ Experimental · construido con IA (AI-in-the-loop)
 
@@ -78,8 +81,8 @@ bib2graph es **un núcleo puro rodeado de costuras**. El núcleo opera sobre un 
 **no depende de DuckDB**, solo del contrato. Alrededor hay costuras enchufables: **`Source`**
 (sembrar — *OpenAlex por defecto* desde una ecuación; BibTeX secundaria), el **forrajeo/
 chaining** (expandir rankeando candidatos por *information scent*), **`Store`** (persistir —
-`DuckDBStore` fachada de la biblioteca viva; Zotero/Neo4j opt-in) y **`Enricher`** (señal
-extra opt-in, ya no estructural).
+`DuckDBStore` fachada de la biblioteca viva) y **`Enricher`** (señal extra opt-in, ya no
+estructural; co-citación end-to-end vía `b2g enrich`).
 
 El **estudio de intercambio ecológico desigual (IED)** es el **caso validador** (corrió el
 pipeline end-to-end sobre datos reales de OpenAlex); el de **semiconductores** queda como caso
@@ -99,32 +102,54 @@ uv run pre-commit install     # hooks de pre-commit
 ```
 
 Capacidades opcionales como extras (lección de v0: núcleo liviano): `uv sync --extra bibtex`
-(sembrar desde un `.bib`, **ya construido**, Hito 4). Los extras `--extra dedup` (Hito 7) /
-`--extra s2` (Hito 8) / `--extra viz` (Hito 10) / `--extra zotero`·`--extra neo4j` (Hito 11) están
-**declarados pero aún vacíos**: se poblarán a medida que se construya cada hito. *(El extra `[llm]`
-**se eliminó** en la remediación (R4): el producto no usa IA generativa — ADR
+(sembrar desde un `.bib`, Hito 4) y `uv sync --extra dedup` (dedup fuzzy `rapidfuzz`, Hito 7).
+*(El extra `[llm]` **se eliminó** en la remediación (R4): el producto no usa IA generativa — ADR
 [0022](docs/decisiones/0022-producto-sin-ia-generativa.md).)*
 
 ## Uso
 
-### Desde el CLI `b2g` (Hito 6 — construido)
+### Desde el CLI `b2g`
 
-De una ecuación a un GraphML, sobre la biblioteca viva, **sin escribir código**. `--store` es
-global (una investigación = un archivo `.duckdb`); cada comando acepta `--json` (envelope
+De una ecuación a un GraphML, sobre la biblioteca viva, **sin escribir código**. Una investigación
+= un **workspace** (carpeta autocontenida): se arranca con `b2g init <nombre>` (o `b2g init .`) y,
+trabajando **dentro** de ella, los comandos resuelven el store por ambiente (sin `--store`). El
+`.duckdb` suelto vía `--store` sigue válido (modo degenerado, retrocompat); ver ADR
+[0029](docs/decisiones/0029-workspace-por-investigacion.md). Cada comando acepta `--json` (envelope
 versionado) para orquestar desde un agente:
 
 ```bash
-b2g --store biblioteca.duckdb seed --equation '"unequal ecological exchange" OR "intercambio ecológico desigual"' --email vos@tucorreo.com
-b2g --store biblioteca.duckdb chain --direction both --max-candidates 300   # candidatos rankeados por scent
-b2g --store biblioteca.duckdb filter --year-gte 2010 --language en --language es   # PRISMA: marca rejected, no borra
-b2g --store biblioteca.duckdb build                                          # Networks.quick → artefactos
-b2g --store biblioteca.duckdb export --format graphml --out-dir redes/       # serializa GraphML/CSV
-b2g --store biblioteca.duckdb status --json                                  # estado del ciclo + ronda + curación + conteos
+b2g init mi-investigacion && cd mi-investigacion
+b2g seed --equation '"unequal ecological exchange" OR "intercambio ecológico desigual"' --email vos@tucorreo.com
+b2g chain --direction both --max-candidates 300   # candidatos rankeados por scent
+b2g filter --year-gte 2010 --language en --language es   # PRISMA: marca rejected, no borra
+b2g build                                          # Networks.quick → artefactos
+b2g export --format graphml --out-dir redes/       # serializa GraphML/CSV
+b2g status --json                                  # estado del ciclo + ronda + curación + conteos
 ```
 
-Subcomandos (12): `seed`, `chain`, `filter`, `build`, `export`, `snapshot`, `status`, `inspect`,
-`validate`, `accept`, `reject`, `monitor`. Exit codes `0` éxito · `1` uso · `2` datos · `3` dependencia ·
-`4` red · `5` store bloqueado/corrupto.
+Los subcomandos disponibles (**fuente de verdad: `b2g --help`**):
+
+```
+accept    Marca papers como accepted en el corpus.
+build     Computa las 4 redes con Networks.quick y escribe artefactos.
+chain     Expande el corpus con candidatos rankeados por information scent.
+curate    Curación en lote: exporta papers a CSV y reimporta decisiones.
+enrich    Enriquece el corpus: references→DOI (8a) y cited_by_id (8b).
+export    Serializa artefactos de build al formato pedido (GraphML o CSV).
+filter    Aplica filtros PRISMA al corpus (marca rejected, no borra).
+init      Inicializa una carpeta como workspace de investigación.
+inspect   Inspecciona el manifest o un paper específico (read-only).
+monitor   Re-chequea OpenAlex por nuevos citantes del corpus.
+networks  Construye redes bibliométricas desde una especificación YAML.
+reject    Marca papers como rejected en el corpus.
+restore   Rehidrata el corpus desde un parquet curado sin tocar la red.
+seed      Siembra el corpus.
+snapshot  Exporta una foto sellada del corpus actual (parquet + manifest).
+status    Muestra el estado del lazo (CycleState) y conteos de curación.
+validate  Valida el schema y consistencia del store.
+```
+
+Exit codes `0` éxito · `1` uso · `2` datos · `3` dependencia · `4` red · `5` store bloqueado/corrupto.
 
 ### Desde código Python
 
@@ -151,7 +176,7 @@ for art in Networks.quick(store.load()):
 
 `Networks.quick` arma acoplamiento bibliográfico (corpus completo), co-autoría, instituciones
 y co-ocurrencia de keywords. La **co-citación** completa requiere un segundo nivel de fetch
-(la red más cara) y llega con el `Enricher` opt-in (Hito 8).
+(la red más cara): la cubre el `Enricher` opt-in vía `b2g enrich` (Hito 8, construido).
 
 ## Comandos de desarrollo
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -438,9 +438,9 @@ trabajo posterior, pero la API se **diseña con estos principios desde el hito 1
    faltante"); la capacidad-de-source-faltante se convierte en `DependencyError` mediante un
    **pre-check `hasattr` en el borde** (p. ej. `chain.py` antes del `Forager`). Ver ADR 0021 §D.
 
-Son **16 subcomandos** (`seed`, `chain`, `filter`, `build`, `export`, `snapshot`, `status`,
+Son **17 subcomandos** (`seed`, `chain`, `filter`, `build`, `export`, `snapshot`, `status`,
 `inspect`, `validate`, `accept`, `reject`, **`monitor`**, **`enrich`**, **`init`**, **`curate`**,
-**`networks`**); `build`/`export` están
+**`networks`**, **`restore`**); `build`/`export` están
 **separados** y el `CycleState` transiciona automáticamente por comando (ADR 0021). El 12°
 **`monitor`** (cleanup pre-v0.3) re-chequea citantes nuevos del corpus (forward chaining) y
 transiciona a `MONITORED`. El 13° **`enrich`** (Hito 8 = Ciclos 8a + 8b, ADR
@@ -452,7 +452,10 @@ workspace (carpeta + `workspace.json` + `library.duckdb` + `networks/`/`snapshot
 curación a escala vía CSV (dump/import en lote, transversal: **no transiciona** el ciclo). El 16°
 **`networks`** (Hito 9, AS-BUILT 2026-06-17) construye redes desde un YAML declarativo
 (`b2g networks --spec <yaml>`, `load_specs` + `Networks.build` por red, helper compartido
-`_write_artifacts`) y **no transiciona** el ciclo ni sella `.corpus_hash` (transversal al lazo). El error de uso (p. ej.
+`_write_artifacts`) y **no transiciona** el ciclo ni sella `.corpus_hash` (transversal al lazo). El 17°
+**`restore`** (Ciclo 9a, ADR [0030](decisiones/0030-ecuacion-declarativa-corpus-ejemplo.md)) rehidrata el
+corpus desde un parquet curado **sin red** (inverso de `snapshot`; preserva `decision`/`curation_status`/
+`is_seed`) y transiciona a `FILTERED` (reusa la transición permisiva `filter`, ADR 0016). El error de uso (p. ej.
 `--workspace` y `--store` juntos, o ningún store/workspace resoluble) sale **sin envelope** (Click
 aborta el parseo: stderr + exit 1).
 

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -411,7 +411,7 @@ Esta reconciliación ya está reflejada en `ARCHITECTURE.md` (§3.1, §4.3, §6.
 3. ✅ Implementación por hitos en curso (coder): **Hitos 0–6 + 1.5 terminados** (núcleo del corpus
    stateful sobre `TabularBackend`, proyectores/analizadores/export, biblioteca viva en DuckDB,
    fuentes OpenAlex/BibTeX, forrajeo + `Preprocessor` + filtros PRISMA, y el **CLI agente-native
-   `b2g`** — 14 subcomandos, ADR [0021](decisiones/0021-cli-agente-native-contrato.md) +
+   `b2g`** — 17 subcomandos, ADR [0021](decisiones/0021-cli-agente-native-contrato.md) +
    [0025](decisiones/0025-enricher-cocitacion-openalex.md) (`enrich`, Ciclo 8a) +
    [0029](decisiones/0029-workspace-por-investigacion.md) (`init` + workspace)). Con ello
    v0.2 alcanza las capacidades del **flujo** `seed → … → export`. **El red-team de la

--- a/docs/ROADMAP/04-lo-que-viene.md
+++ b/docs/ROADMAP/04-lo-que-viene.md
@@ -1,6 +1,11 @@
 > ← Volver al [índice del ROADMAP](README.md)
 
-# LO QUE VIENE (Hitos 7–11, actualizados a la nueva realidad)
+# LO QUE VIENE (Hitos 7–9 HECHOS; 10 y 11 reevaluados)
+
+> **Estado (2026-06-17):** los **Hitos 7, 8 y 9 están COMPLETOS ✅** (dedup fuzzy, `Enricher`
+> de co-citación end-to-end, `NetworkSpec` YAML). Los Hitos 10 y 11 **dejaron de ser trabajo por
+> venir:** el **10 (viz)** se **absorbe en la epic GUI #34** (la GUI es la capa de lectura visual) y el
+> **11 (Zotero/Neo4j)** quedó **DESCARTADO** (decisión del PO, reabrible solo si aparece demanda real).
 
 > **Tras la remediación R1–R5.** Estos hitos son los opcionales/de cierre hacia v1.0, ya
 > reconciliados con el modelo nuevo (sin IA generativa, scent bibliométrico, FSM cíclico).
@@ -252,7 +257,8 @@ No se prometen ni se cablean clientes que no se usan.
   - **9b ✅ HECHO (2026-06-17):** **workspace de ejemplo `examples/valoraciones/`** (corpus curado
     congelado en `corpus.parquet`, **137 filas: 7 `accepted` / 130 `candidate` / 107 seeds**, reducción
     determinista del corpus real del PO CC0/OpenAlex + `equation.yaml` de procedencia + `README.md` +
-    `build_corpus.py` de regeneración) como **excepción al `.gitignore`** de datos de usuario
+    `build_corpus.py` de regeneración — *nota: el Ciclo B (más abajo) **superseded** este `build_corpus.py`;
+    la procedencia del ejemplo pasó a ser **receta CLI**, así que no leer esto como exigencia viva*) como **excepción al `.gitignore`** de datos de usuario
     (`!examples/` + regla defensiva `examples/**/*.duckdb`). El **gate de reproducibilidad R2**
     (`tests/unit/test_example_r2_gate.py`, 7 tests) corre `restore --from-corpus` → `build` →
     `networks`/`clusters` **sin red** sobre el corpus real y verifica **`corpus_hash` estable** +

--- a/docs/ROADMAP/README.md
+++ b/docs/ROADMAP/README.md
@@ -234,5 +234,5 @@ limpio y actual; el cuerpo de cada hito vive en su archivo:
 | D3 asortatividad + composición + proxy | 2 | |
 | D4 export GraphML/CSV | 2 | |
 | E1 snapshot reproducible | 1 + 6 ✅ | `Corpus.snapshot` + `b2g snapshot` |
-| E2 CLI `--json` + exit codes | 0 (principios) + 6 ✅ (CLI) + cleanup pre-v0.3 ✅ (`monitor`) + 8 ✅ (`enrich`) + workspace ✅ (`init`) | `b2g` **14 subcomandos** (Hito 6 entregó 11; `monitor` se sumó en el cleanup pre-v0.3 → `MONITORED`; `enrich` en el Hito 8 —refs→DOI + co-citación, `--max-citing`—, ADR 0025, sin transición; `init` con el workspace, ADR 0029), envelope `--json` versionado, exit 0–5 (ADR 0021) |
+| E2 CLI `--json` + exit codes | 0 (principios) + 6 ✅ (CLI) + cleanup pre-v0.3 ✅ (`monitor`) + 8 ✅ (`enrich`) + workspace ✅ (`init`) | `b2g` **17 subcomandos** (Hito 6 entregó 11; `monitor` se sumó en el cleanup pre-v0.3 → `MONITORED`; `enrich` en el Hito 8 —refs→DOI + co-citación, `--max-citing`—, ADR 0025, sin transición; `init` con el workspace, ADR 0029), envelope `--json` versionado, exit 0–5 (ADR 0021) |
 

--- a/docs/decisiones/0030-ecuacion-declarativa-corpus-ejemplo.md
+++ b/docs/decisiones/0030-ecuacion-declarativa-corpus-ejemplo.md
@@ -1,6 +1,6 @@
 # 0030 — Ecuación declarativa (`equation.yaml`) + `restore` de corpus curado + corpus de ejemplo commiteado
 
-- **Estado:** **Aceptada — AS-BUILT ✅** (9a + 9b + Ciclo 10 completos, 2026-06-17). 9a: `restore` +
+- **Estado:** **Aceptada — AS-BUILT ✅** (9a + 9b + Ciclo 10 + Ciclo B completos, 2026-06-17). 9a: `restore` +
   `equation.yaml` cargable; **9b: workspace de ejemplo `examples/valoraciones/` (corpus 137 filas)
   + gate de reproducibilidad R2** (7 tests; cierra el Ciclo #33). **Ciclo 10: `seed --from-bib`
   (3er modo, sin red) + filtro de año real (`min_year`/`max_year`) + `examples/bibtex/`** (cierra

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,9 +64,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-zotero = []
+# zotero/neo4j: ex-Hito 11, DESCARTADO (PO 2026-06-17). Se reabrirían como hito
+# nuevo si hay demanda real; no se declaran como extras vacíos engañosos.
 s2 = []
-neo4j = []
 dedup = [
     "rapidfuzz>=3,<4",
 ]


### PR DESCRIPTION
Resultado de la **auditoría de coherencia interna** (autoevaluación post-sesión). El corazón documental (AGENTS/API.md/ADRs) estaba al día; los docs de **entrada/posicionamiento** quedaron stale tras tantos ciclos. Esto los alinea a la verdad vigente para **abrir la puerta a los issues #56–#65** sobre base coherente.

- **README** refrescado: estado real (Hitos 1–9 + workspace + ejemplos CLI-puros), **sección CLI pegada de `b2g --help`** (17 comandos, fuente de verdad anti-drift, sin conteo a mano), modelo workspace, sin promesa de `zotero`/`neo4j` (ex-Hito 11 descartado) ni cifras de tests a mano (anti doc-bloat).
- **Conteo de subcomandos → 17** en ARCHITECTURE (+`restore`), PRD, ROADMAP/README (estaban en 16/14).
- Residuos: título de ROADMAP/04, supersede de `build_corpus.py`, línea Estado de ADR 0030, extras vacíos del `pyproject`.

Sin cambios de código. **598 tests**, 0 enlaces rotos. No reescribe historia AS-BUILT inmutable (bien señalizada).