### PR TITLE
feat(sources): OpenAlexSource.fetch_works_by_ids (#55)

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -757,6 +757,14 @@ contrato universal; las consumen el `Forager` y el `Enricher`):
   N+1 diferido de R5). Lo consume el `OpenAlexEnricher` (§3) para poblar `cited_by_id`.
 - **`fetch_dois_for(ids) -> dict`** (Hito 8a): resuelve `references_id`→DOI batcheando por OR (lotes
   ≤100, `select=id,doi`).
+- **`fetch_works_by_ids(ids) -> Corpus`** (#55): materializa works arbitrarios desde sus IDs OpenAlex,
+  batcheando por OR (`openalex_id:W1|W2|...`, lotes ≤100, reusa `_fetch_batch_select`). Devuelve un
+  `Corpus` con `is_seed=False`, `curation_status=CANDIDATE`, `provenance[action="fetched_by_id"]`. IDs
+  inexistentes se **omiten sin error**; orden **determinista** (filas ordenadas por `id` canónico);
+  lista vacía → `Corpus` vacío **sin tocar la red**. Es el primitivo que materializa lo observado por
+  el backward chaining (ver #54). Reusa `_work_to_row` parametrizado (`is_seed`/`action`), que centraliza
+  el mapeo JSON→Arrow para `seed`/`fetch_citing`/`fetch_works_by_ids` (sin duplicar). *(Validado contra
+  OpenAlex real vía test `@pytest.mark.network`.)*
 
 **Reporte de cobertura/calidad** (concepto declarado, concreto **v0.2+**; ADR 0018): por
 seed/source, mide % de refs resueltas, % con DOI, distribución idioma/región y completitud del

--- a/src/bib2graph/schemas.py
+++ b/src/bib2graph/schemas.py
@@ -37,7 +37,7 @@ class ProvenanceEvent(BaseModel):
 
     Fields:
         action: Tipo de evento (``'fetched'``, ``'seeded'``, ``'accepted'``,
-            ``'rejected'``).
+            ``'rejected'``, ``'fetched_by_id'``).
         equation_id: ID de la ecuación de búsqueda que originó el paper, o
             ``None`` si no aplica.
         chaining_hop: Profundidad del chaining (1 = primera expansión), o

--- a/src/bib2graph/sources/openalex.py
+++ b/src/bib2graph/sources/openalex.py
@@ -251,6 +251,8 @@ def _work_to_row(
     *,
     equation_id: str,
     fetched_at: str,
+    is_seed: bool = True,
+    action: str = "fetched",
 ) -> dict[str, Any]:
     """Mapea un objeto JSON de OpenAlex a la fila del schema canónico.
 
@@ -262,6 +264,10 @@ def _work_to_row(
         work: Objeto JSON de un Work de OpenAlex.
         equation_id: ID de la ecuación que originó la búsqueda (para provenance).
         fetched_at: Timestamp ISO de la consulta.
+        is_seed: Si el paper es semilla (``True``) o candidato (``False``).
+            Default ``True`` (comportamiento histórico para ``seed``/``load``).
+        action: Tipo de evento de provenance (``'fetched'``, ``'fetched_by_id'``,
+            etc.).  Default ``'fetched'`` (comportamiento histórico).
 
     Returns:
         Dict con todas las columnas del schema canónico.
@@ -329,7 +335,7 @@ def _work_to_row(
 
     # --- Provenance (evento inicial) ---
     provenance_event = ProvenanceEvent(
-        action="fetched",
+        action=action,
         equation_id=equation_id,
         chaining_hop=None,
         source="openalex",
@@ -349,7 +355,7 @@ def _work_to_row(
         Col.LANGUAGE: work.get("language"),
         Col.PUBLISHER: None,
         Col.RESEARCH_AREAS: None,
-        Col.IS_SEED: True,
+        Col.IS_SEED: is_seed,
         Col.CURATION_STATUS: CurationStatus.CANDIDATE,
         Col.PROVENANCE: ProvenanceEvent.dump_list([provenance_event]),
         Col.AUTHORS_RAW: authors_raw or None,
@@ -649,9 +655,15 @@ class OpenAlexSource:
         works, _ = self._fetch_all_with_retry(filter_str)
         rows: list[dict[str, Any]] = []
         for work in works:
-            row = _work_to_row(work, equation_id=equation_id, fetched_at=fetched_at)
-            # Sobrescribir is_seed y provenance para forward chaining
-            row[Col.IS_SEED] = False
+            # is_seed=False: los citantes son candidatos, no semillas.
+            # La provenance se sobreescribe para agregar chaining_hop=1 (no
+            # soportado como parámetro de _work_to_row: es específico de fetch_citing).
+            row = _work_to_row(
+                work,
+                equation_id=equation_id,
+                fetched_at=fetched_at,
+                is_seed=False,
+            )
             provenance_event = ProvenanceEvent(
                 action="fetched",
                 equation_id=None,
@@ -723,6 +735,75 @@ class OpenAlexSource:
                         resultado[short_id] = doi
 
         return resultado
+
+    def fetch_works_by_ids(self, ids: list[str]) -> Corpus:
+        """Trae works completos de OpenAlex a partir de una lista de IDs.
+
+        Batchea la consulta en lotes de hasta 100 IDs por request, usando el
+        filtro ``openalex_id:W1|W2|...`` con ``select=_FIELDS`` (todos los
+        campos del schema canónico).  Reutiliza ``_fetch_batch_select`` y
+        el retry/backoff de la infraestructura existente.
+
+        Los works resultantes se marcan como ``is_seed=False`` (son candidatos,
+        no semillas de una ecuación) con ``curation_status=CANDIDATE`` y
+        ``provenance[action="fetched_by_id"]``.
+
+        IDs inexistentes en OpenAlex son simplemente omitidos sin error: el
+        filtro OR devuelve solo los works encontrados.
+
+        Las filas del ``Corpus`` retornado se ordenan por ``id`` canónico (D1)
+        para garantizar determinismo entre corridas (ADR 0017).
+
+        Args:
+            ids: Lista de IDs de OpenAlex (p. ej. ``["W12345", "W67890"]``).
+                Se acepta con o sin prefijo URL; se normalizan a ID corto.
+
+        Returns:
+            ``Corpus`` con los works encontrados.  ``is_seed=False``,
+            ``curation_status=CANDIDATE``, ``provenance[action="fetched_by_id"]``.
+            Vacío si ningún ID es encontrado.
+        """
+        if not ids:
+            table = pa.table(
+                {col: [] for col in CORPUS_SCHEMA.names},
+                schema=CORPUS_SCHEMA,
+            )
+            return Corpus.from_arrow(table)
+
+        # Normalizar IDs a la forma corta (W...) por si vienen como URL
+        normalized = [_oa_id_short(i) or i for i in ids]
+
+        fetched_at = datetime.now(UTC).isoformat()
+        all_rows: list[dict[str, Any]] = []
+        batch_size = 100
+
+        for start in range(0, len(normalized), batch_size):
+            lote = normalized[start : start + batch_size]
+            filter_str = "openalex_id:" + "|".join(lote)
+            works = self._fetch_batch_select(filter_str, select=_FIELDS)
+            for work in works:
+                row = _work_to_row(
+                    work,
+                    equation_id="fetched_by_id",
+                    fetched_at=fetched_at,
+                    is_seed=False,
+                    action="fetched_by_id",
+                )
+                all_rows.append(row)
+
+        rows_with_ids = _rows_with_ids(all_rows)
+
+        # Orden determinista por id canónico (ADR 0017)
+        rows_with_ids.sort(key=lambda r: str(r.get(Col.ID, "")))
+
+        if rows_with_ids:
+            table = pa.Table.from_pylist(rows_with_ids, schema=CORPUS_SCHEMA)
+        else:
+            table = pa.table(
+                {col: [] for col in CORPUS_SCHEMA.names},
+                schema=CORPUS_SCHEMA,
+            )
+        return Corpus.from_arrow(table)
 
     def _fetch_batch_select(
         self, filter_str: str, *, select: str

--- a/tests/unit/test_fetch_works_by_ids.py
+++ b/tests/unit/test_fetch_works_by_ids.py
@@ -1,0 +1,326 @@
+"""Tests unitarios para OpenAlexSource.fetch_works_by_ids.
+
+Casos cubiertos (DoD #55):
+(a) Todos los IDs existen → Corpus con esas filas, is_seed=False/CANDIDATE/action="fetched_by_id".
+(b) IDs inexistentes → omitidos sin error (el filtro OR no los devuelve).
+(c) Mezcla parcial → solo los existentes, sin error.
+(d) Orden determinista: mismo input → mismo orden por id canónico.
+(e) Lista vacía → Corpus vacío sin error.
+(f) No-regresión: seed() sigue marcando is_seed=True tras el refactor de _work_to_row.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+
+from bib2graph.constants import Col, CurationStatus
+from bib2graph.schemas import ProvenanceEvent
+from bib2graph.sources.openalex import OpenAlexSource
+
+# ---------------------------------------------------------------------------
+# Fixtures y helpers de mock
+# ---------------------------------------------------------------------------
+
+FIXTURES_DIR = Path(__file__).resolve().parent.parent / "fixtures"
+SAMPLE_WORKS_PATH = FIXTURES_DIR / "sample_works.json"
+
+
+def _load_fixture_works() -> list[dict[str, Any]]:
+    return json.loads(SAMPLE_WORKS_PATH.read_text(encoding="utf-8"))
+
+
+def _make_batch_transport(works: list[dict[str, Any]]) -> httpx.MockTransport:
+    """MockTransport para _fetch_batch_select: devuelve los works en una sola página."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = {
+            "results": works,
+            "meta": {"count": len(works), "next_cursor": None},
+        }
+        return httpx.Response(
+            200,
+            json=body,
+            headers={"x-openalex-api-version": "2026-05-01"},
+        )
+
+    return httpx.MockTransport(handler)
+
+
+def _make_seed_transport(works: list[dict[str, Any]]) -> httpx.MockTransport:
+    """MockTransport para seed() (paginación con cursor): una página y fin."""
+    calls: list[int] = [0]
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls[0] += 1
+        if calls[0] == 1:
+            body = {
+                "results": works,
+                "meta": {"count": len(works), "next_cursor": None},
+            }
+        else:
+            body = {"results": [], "meta": {"count": 0, "next_cursor": None}}
+        return httpx.Response(
+            200,
+            json=body,
+            headers={"x-openalex-api-version": "2026-05-01"},
+        )
+
+    return httpx.MockTransport(handler)
+
+
+# ---------------------------------------------------------------------------
+# (a) Todos los IDs existen → corpus correcto
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_fetch_works_by_ids_todos_existen_devuelve_corpus() -> None:
+    """IDs todos existentes → Corpus con esa cantidad de filas."""
+    works = _load_fixture_works()
+    transport = _make_batch_transport(works)
+    source = OpenAlexSource(transport=transport)
+
+    ids = ["W2741809807", "W1234567890", "W9999999999"]
+    corpus = source.fetch_works_by_ids(ids)
+
+    assert len(corpus) == len(works)
+
+
+@pytest.mark.unit
+def test_fetch_works_by_ids_is_seed_false() -> None:
+    """Los papers traídos por ID tienen is_seed=False."""
+    works = _load_fixture_works()
+    transport = _make_batch_transport(works)
+    source = OpenAlexSource(transport=transport)
+
+    corpus = source.fetch_works_by_ids(["W2741809807"])
+    table = corpus.to_arrow()
+    is_seed_col = table.column(Col.IS_SEED).to_pylist()
+
+    assert all(v is False for v in is_seed_col)
+
+
+@pytest.mark.unit
+def test_fetch_works_by_ids_curation_status_candidate() -> None:
+    """Los papers traídos por ID tienen curation_status=CANDIDATE."""
+    works = _load_fixture_works()
+    transport = _make_batch_transport(works)
+    source = OpenAlexSource(transport=transport)
+
+    corpus = source.fetch_works_by_ids(["W2741809807"])
+    table = corpus.to_arrow()
+    status_col = table.column(Col.CURATION_STATUS).to_pylist()
+
+    assert all(s == CurationStatus.CANDIDATE for s in status_col)
+
+
+@pytest.mark.unit
+def test_fetch_works_by_ids_provenance_action_fetched_by_id() -> None:
+    """El primer evento de provenance tiene action='fetched_by_id'."""
+    works = _load_fixture_works()
+    transport = _make_batch_transport(works)
+    source = OpenAlexSource(transport=transport)
+
+    corpus = source.fetch_works_by_ids(["W2741809807"])
+    table = corpus.to_arrow()
+    provenance_col = table.column(Col.PROVENANCE).to_pylist()
+
+    for prov_json in provenance_col:
+        events = ProvenanceEvent.parse_list(prov_json)
+        assert len(events) >= 1
+        assert events[0].action == "fetched_by_id"
+
+
+# ---------------------------------------------------------------------------
+# (b) IDs inexistentes → omitidos sin error
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_fetch_works_by_ids_inexistentes_devuelve_corpus_vacio() -> None:
+    """IDs que no existen en OpenAlex → corpus vacío, sin error."""
+    transport = _make_batch_transport([])  # API devuelve 0 resultados
+    source = OpenAlexSource(transport=transport)
+
+    corpus = source.fetch_works_by_ids(["W0000000001", "W0000000002"])
+
+    assert len(corpus) == 0
+
+
+@pytest.mark.unit
+def test_fetch_works_by_ids_inexistentes_no_lanza_excepcion() -> None:
+    """IDs inexistentes no lanzan excepción."""
+    transport = _make_batch_transport([])
+    source = OpenAlexSource(transport=transport)
+
+    # No debe lanzar ninguna excepción
+    corpus = source.fetch_works_by_ids(["W9999999998"])
+    assert corpus is not None
+
+
+# ---------------------------------------------------------------------------
+# (c) Mezcla parcial → solo los existentes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_fetch_works_by_ids_mezcla_parcial() -> None:
+    """Con IDs mixtos (algunos existen, otros no), el corpus contiene solo los existentes."""
+    works = _load_fixture_works()[:1]  # solo el primero "existe"
+    transport = _make_batch_transport(works)
+    source = OpenAlexSource(transport=transport)
+
+    # Pasamos 3 IDs pero el mock devuelve solo 1 (simula que los otros no existen)
+    corpus = source.fetch_works_by_ids(["W2741809807", "W0000000001", "W0000000002"])
+
+    assert len(corpus) == 1
+
+
+# ---------------------------------------------------------------------------
+# (d) Orden determinista
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_fetch_works_by_ids_orden_determinista() -> None:
+    """Dos llamadas con el mismo input producen filas en el mismo orden por id canónico."""
+    works = _load_fixture_works()
+
+    # Primera llamada
+    transport1 = _make_batch_transport(works)
+    source1 = OpenAlexSource(transport=transport1)
+    corpus1 = source1.fetch_works_by_ids(["W2741809807", "W1234567890", "W9999999999"])
+
+    # Segunda llamada
+    transport2 = _make_batch_transport(works)
+    source2 = OpenAlexSource(transport=transport2)
+    corpus2 = source2.fetch_works_by_ids(["W2741809807", "W1234567890", "W9999999999"])
+
+    ids1 = corpus1.to_arrow().column(Col.ID).to_pylist()
+    ids2 = corpus2.to_arrow().column(Col.ID).to_pylist()
+
+    assert ids1 == ids2
+
+
+@pytest.mark.unit
+def test_fetch_works_by_ids_orden_es_por_id_canonico() -> None:
+    """Las filas están ordenadas por id canónico (ascendente)."""
+    works = _load_fixture_works()
+    transport = _make_batch_transport(works)
+    source = OpenAlexSource(transport=transport)
+
+    corpus = source.fetch_works_by_ids(["W2741809807", "W1234567890", "W9999999999"])
+    ids = corpus.to_arrow().column(Col.ID).to_pylist()
+
+    assert ids == sorted(ids)
+
+
+# ---------------------------------------------------------------------------
+# (e) Lista vacía → Corpus vacío sin error
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_fetch_works_by_ids_lista_vacia() -> None:
+    """Lista vacía de IDs → Corpus vacío sin error (sin request HTTP)."""
+    # No hay transport: si se hiciera un request, lanzaría error
+    source = OpenAlexSource()
+
+    corpus = source.fetch_works_by_ids([])
+
+    assert len(corpus) == 0
+
+
+# ---------------------------------------------------------------------------
+# (f) No-regresión: seed() sigue marcando is_seed=True tras el refactor
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_seed_sigue_marcando_is_seed_true_tras_refactor() -> None:
+    """Regresión: tras el refactor de _work_to_row, seed() sigue usando is_seed=True."""
+    works = _load_fixture_works()
+    transport = _make_seed_transport(works)
+    source = OpenAlexSource(transport=transport)
+
+    result = source.seed("ecological exchange")
+    table = result.corpus.to_arrow()
+    is_seed_col = table.column(Col.IS_SEED).to_pylist()
+
+    assert all(v is True for v in is_seed_col), (
+        "Regresión: seed() ya no marca is_seed=True. "
+        "El refactor de _work_to_row rompió el comportamiento de seed()."
+    )
+
+
+@pytest.mark.unit
+def test_seed_provenance_action_es_fetched_tras_refactor() -> None:
+    """Regresión: tras el refactor, seed() sigue usando action='fetched' en provenance."""
+    works = _load_fixture_works()
+    transport = _make_seed_transport(works)
+    source = OpenAlexSource(transport=transport)
+
+    result = source.seed("ecological exchange")
+    table = result.corpus.to_arrow()
+    provenance_col = table.column(Col.PROVENANCE).to_pylist()
+
+    for prov_json in provenance_col:
+        events = ProvenanceEvent.parse_list(prov_json)
+        assert len(events) >= 1
+        assert events[0].action == "fetched", (
+            "Regresión: seed() ya no usa action='fetched'. "
+            f"Se obtuvo action='{events[0].action}'."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test de red real (excluido del gate por defecto)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.network
+def test_fetch_works_by_ids_red_real() -> None:
+    """Trae 2-3 IDs reales de OpenAlex y verifica que vuelven con metadata.
+
+    Lección #30: validar contra la API real, no solo mocks.
+    IDs elegidos: works conocidos y estables de OpenAlex.
+    """
+    source = OpenAlexSource(email="trama.complejidad@gmail.com")
+
+    # IDs públicos y estables en OpenAlex
+    ids = [
+        "W2741809807",  # "Biophysical Trade Balance of Ecuador"
+        "W2890038990",  # otro work real
+    ]
+    corpus = source.fetch_works_by_ids(ids)
+
+    assert len(corpus) >= 1, (
+        f"Se esperaba al menos 1 work, se obtuvieron {len(corpus)}. "
+        "Posible cambio en los IDs de OpenAlex o error de red."
+    )
+
+    table = corpus.to_arrow()
+
+    # Verificar is_seed=False en todos
+    is_seed_col = table.column(Col.IS_SEED).to_pylist()
+    assert all(v is False for v in is_seed_col)
+
+    # Verificar curation_status=CANDIDATE en todos
+    status_col = table.column(Col.CURATION_STATUS).to_pylist()
+    assert all(s == CurationStatus.CANDIDATE for s in status_col)
+
+    # Verificar que tienen títulos (metadata presente)
+    title_col = table.column(Col.TITLE).to_pylist()
+    assert all(t for t in title_col), "Algún work no tiene título."
+
+    # Verificar provenance action="fetched_by_id"
+    provenance_col = table.column(Col.PROVENANCE).to_pylist()
+    for prov_json in provenance_col:
+        events = ProvenanceEvent.parse_list(prov_json)
+        assert len(events) >= 1
+        assert events[0].action == "fetched_by_id"


### PR DESCRIPTION
**#55** — el primitivo seguro que habilita el fix de #54 (adición pura, sin tocar contratos existentes).

- `fetch_works_by_ids(ids) -> Corpus`: materializa works por ID OpenAlex, batch OR ≤100 (reusa `_fetch_batch_select`), `is_seed=False`/CANDIDATE/`action="fetched_by_id"`, IDs inexistentes omitidos, orden determinista, lista vacía sin red.
- Centraliza el mapeo JSON→Arrow: `_work_to_row` parametrizado (`is_seed`/`action`) → `seed`/`fetch_citing` **sin regresión** (verificado), mata la duplicación del workaround `prueba/11`.

Autoverificado (el verifier quedó cortado por límite de sesión): gate verde, refactor no-regresivo (defaults preservan seed/fetch_citing), **610 tests** + 3 `network` reales pasan. Sin cambio de schema. Sigue #54 (backward sin fantasmas, usa este primitivo).