### PR TITLE
fix(foraging): backward chaining sin placeholders fantasma (#54)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ snapshots/*.parquet
 *.duckdb
 *.duckdb.*.bak
 prueba/
+prueba_e2e/
 redes/
 valoraciones_*
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@
   El **CLI `b2g` es real** —paquete `cli/` con 17 subcomandos en `cli/commands/`, no un
   placeholder (el 16° `b2g networks` es la capa declarativa YAML del Hito 9; el 17° `b2g restore`
   rehidrata un corpus curado sin red, Ciclo 9a, abajo)—.
-  **571 tests verdes** (mypy/ruff limpios; el núcleo importa sin `duckdb`). Entre las
+  **636 tests verdes** (mypy/ruff limpios; el núcleo importa sin `duckdb`). Entre las
   redes, la **composición de comunidades es exportable**: `networks/cluster_table` (función pura)
   resume cada comunidad de una red de paper en una fila y `b2g build` la escribe como `clusters.csv`
   (#31, AS-BUILT 2026-06-17; ver `docs/API.md` §7.2). **`b2g snapshot`/`b2g export` resuelven por
@@ -97,6 +97,18 @@
   trayendo los citantes de las semillas aceptadas vía `OpenAlexSource.fetch_citing_batch` (batcheo OR
   ≤50 con presupuesto por semilla) y los une (idempotente, sin crecer el corpus). `b2g enrich` con
   `--max-citing` (tope por semilla); `Networks.quick` → 4 o 5 redes según haya `cited_by_id`.
+- **Backward chaining sin placeholders** (#54, 2026-06-17): el backward del `Forager`
+  (`b2g chain`) **ya no persiste filas-fantasma `[candidate:W...]` en el corpus** (revierte el
+  comportamiento de Hito 5 — la promesa de "no contaminan" era **falsa**: los stubs llegaron a ser
+  ~la mitad del corpus y entraban al `corpus_hash`; Notas 09/12). Los IDs observados salen por
+  `RankedCandidates.observed_refs` y `b2g chain` los persiste en la tabla append-only hermana
+  **`referenced_but_not_fetched`** (`backends/base.py` Protocol + `DuckDBBackend`/`InMemoryBackend`:
+  `add_referenced_refs`/`referenced_refs_count`/`referenced_refs`), **fuera del `corpus_hash`** (arregla
+  la contaminación previa). `b2g status` suma `referenced_not_fetched`; `b2g chain` suma
+  `observed_refs_count`. **El forward arrastra el MISMO footgun** (placeholder de título), abierto como
+  **#78** — NO está limpio. Materializador on-demand diferido a #71. **636 tests verdes.** Ver
+  `docs/API.md` §5/§4 y ADR [0020](docs/decisiones/0020-metodo-forrajeo-scent-filtros-reject.md)
+  §AS-BUILT #54.
 - **Forward chaining del `Forager` batcheado** (#21, 2026-06-16): el forward del `Forager`
   (`b2g chain`/`b2g monitor`) **ya no es N+1** — reusa `OpenAlexSource.fetch_citing_batch` (batcheo OR
   + cap por semilla `max_citing_per_paper`/`--max-citing`, default 50) con preview sin red. **Opera
@@ -332,7 +344,10 @@ src/bib2graph/
                        # equation.py (EquationSpec + load_equation_spec, capa declarativa de la
                        # ecuación —seed --spec, 9a); RIS, CSV (futuro, no publicar)
   backends/            # TabularBackend (Protocol) + InMemoryBackend (núcleo puro) +
-                       # DuckDBBackend (biblioteca viva, carga perezosa de duckdb; persiste cycle)
+                       # DuckDBBackend (biblioteca viva, carga perezosa de duckdb; persiste cycle).
+                       # #54: tabla hermana referenced_but_not_fetched (IDs observados por el backward
+                       # sin materializar) → add_referenced_refs/referenced_refs_count/referenced_refs,
+                       # fuera del corpus_hash
   foraging/            # Forager (chaining + ranking por scent BIBLIOMÉTRICO vía proyectores, Hito R4).
                        # SIN explain.py / explain_candidate / [llm] (eliminados, ADR 0022)
   preprocessors/       # normalize + thesaurus multilingüe DETERMINISTA, sin fallback LLM (núcleo);

--- a/docs/API.md
+++ b/docs/API.md
@@ -196,7 +196,10 @@ rehidratación de corpus curado sin red, Ciclo 9a, ADR
   `workspace: {root, source}` (la raíz resuelta y de dónde salió — flag/env/cwd); `schema="1"`
   intacto. **AS-BUILT #32 (2026-06-17):** suma también el campo aditivo `networks_cache_stale: bool`
   (+ `warnings` accionable cuando la cache de `networks/` quedó obsoleta respecto al corpus vivo;
-  avisa, NO regenera — ver §`build`/`export`/`snapshot` abajo). `inspect`, `validate`.
+  avisa, NO regenera — ver §`build`/`export`/`snapshot` abajo). **AS-BUILT #54 (2026-06-17):** `status`
+  suma el campo aditivo `referenced_not_fetched` (nº de IDs que el backward chaining observó sin
+  materializar — tabla `referenced_but_not_fetched`, §4/§5; `schema="1"` intacto), y `b2g chain` suma
+  `observed_refs_count` a su envelope JSON. `inspect`, `validate`.
 - **`seed`** (ADR [0030](decisiones/0030-ecuacion-declarativa-corpus-ejemplo.md), Ciclo 9a + Ciclo
   10 AS-BUILT 2026-06-17): tiene **exactamente TRES modos mutuamente excluyentes** (exactamente uno
   requerido; pasar más de uno o ninguno → error de uso, exit 1):
@@ -647,7 +650,23 @@ class TabularBackend(Protocol):
     def corpus_hash(self) -> str: ...        # D2, order-independent, sobre el contenido
     def __len__(self) -> int: ...
     def __eq__(self, other: object) -> bool: ...   # igualdad canónica por corpus_hash (D2)
+
+    # AS-BUILT #54 (2026-06-17): tabla hermana `referenced_but_not_fetched` (append-only, par de
+    # loop_state_log) — los IDs que el backward chaining OBSERVA sin materializar en el corpus (§5).
+    # FUERA de la tabla `corpus` y del corpus_hash (son estado, no contenido; ADR 0017).
+    def add_referenced_refs(self, ref_ids: list[str], *, cycle_round: int) -> "TabularBackend": ...
+        # Registra IDs observados (idempotente por existencia de `ref_id`; observed_at = now() del backend).
+    def referenced_refs_count(self) -> int: ...    # nº de IDs observados distintos
+    def referenced_refs(self) -> pa.Table: ...     # los IDs observados (ref_id, cycle_round, observed_at)
 ```
+
+> **AS-BUILT #54 (2026-06-17) — `referenced_but_not_fetched`.** El backward chaining (§5) dejó de
+> crear filas-fantasma `[candidate:W...]` en el `corpus`. Sus IDs observados se registran en esta
+> tabla append-only (hermana de `loop_state_log`), implementada por `DuckDBBackend` (DDL + migración
+> liviana + copia en snapshot/`_clone`) e `InMemoryBackend`. **No entra al `corpus_hash`** (tabla
+> aparte, no columna del corpus → no toca el schema de [ADR 0013](decisiones/0013-identidad-hash-merge-corpus.md);
+> coherente con [ADR 0017](decisiones/0017-reproducibilidad-historia-snapshot.md): es estado, no
+> contenido). Materializar un observado a fila real vía `fetch_works_by_ids` (#55) está diferido a #71.
 
 | Implementación | Estado | Notas |
 |----------------|--------|-------|
@@ -850,8 +869,11 @@ persistente.
 
 El contrato `TabularBackend` (Protocol) y su firma completa viven en **§1.4** (núcleo): `to_arrow`,
 `add_paper`, `merge(other_table: pa.Table)`, `apply_curation(ids, *, action, by)`, `filter_view`,
-`corpus_hash`, `__len__`, `__eq__`. El `DuckDBBackend` lo implementa en SQL (Hito 3); el `Store` de
-abajo es la costura de persistencia/intercambio **externa**, distinta del backend del `Corpus`.
+`corpus_hash`, `__len__`, `__eq__` y —AS-BUILT #54 (2026-06-17)— `add_referenced_refs(ref_ids, *,
+cycle_round)`/`referenced_refs_count()`/`referenced_refs()` (tabla hermana append-only
+`referenced_but_not_fetched`, fuera del `corpus_hash`; §1.4 + §5). El `DuckDBBackend` lo implementa en
+SQL (Hito 3); el `Store` de abajo es la costura de persistencia/intercambio **externa**, distinta del
+backend del `Corpus`.
 
 ```python
 class Store(Protocol):
@@ -952,6 +974,13 @@ El comando `b2g status` consume `loop_state()`/`loop_round()`/`available_transit
 > proyección** (puro), nunca al revés. El producto **no usa IA generativa**.
 > `explain_candidate`/`foraging/explain.py`/`[llm]` quedaron **eliminados**.
 
+> **AS-BUILT #54 (2026-06-17) — ADR [0020](decisiones/0020-metodo-forrajeo-scent-filtros-reject.md)
+> §AS-BUILT #54:** el backward chaining **deja de persistir placeholders** en el corpus. Los IDs
+> observados salen por `RankedCandidates.observed_refs` y se persisten en la tabla hermana
+> `referenced_but_not_fetched` (§4), **fuera del `corpus_hash`** (arregla la contaminación previa).
+> El **forward arrastra el mismo footgun** (placeholder de título), abierto como **#78** — NO está
+> limpio. Materializador on-demand diferido a #71. Gate verde, 636 tests.
+
 El *information scent* es **estructura bibliométrica de cita con el corpus** (ADR
 [0020](decisiones/0020-metodo-forrajeo-scent-filtros-reject.md), AS-BUILT R4). Es una **función pura**
 sobre el primitivo `collect_item_to_papers` (índice `{ref → corpus-papers que lo citan}`):
@@ -1006,8 +1035,15 @@ class GrowthPreview(BaseModel):
     forward_requires_fetch: bool = False   # True si se pidió forward/both → forward desconocido sin red
 
 class RankedCandidates(BaseModel):
-    corpus: Corpus                     # SOLO los candidatos nuevos (no mergeado con el corpus semilla)
+    corpus: Corpus                     # SOLO los candidatos nuevos (no mergeado con el corpus semilla).
+                                       # Forward: materializa filas (placeholder de título, ver #78).
+                                       # Backward (#54): NO materializa filas — observa, ver observed_refs.
     ranking: list[tuple[str, float]]   # (id, information_scent), desc scent / asc id
+    observed_refs: list[str] = []      # AS-BUILT #54 (2026-06-17): IDs observados por el backward SIN
+                                       # materializarlos en .corpus (orden de ranking, respeta
+                                       # max_candidates). El backward observa; el forward materializa.
+                                       # b2g chain los persiste en `referenced_but_not_fetched` (§4),
+                                       # fuera del corpus_hash. Materializar = diferido a #71.
 
 # RETIRADO (ADR 0022): `explain_candidate` y el extra `[llm]` se ELIMINAN del producto.
 # El producto no usa IA generativa. El "porqué" de un candidato lo explica la ESTRUCTURA
@@ -1043,9 +1079,17 @@ class RankedCandidates(BaseModel):
 - **`fetch_citing` (singular) con retry/backoff** ante 429/5xx (`_fetch_all_with_retry`: exponential
   backoff, 3 intentos) sigue disponible; el forward del Forager lo consume ahora vía la variante
   **batcheada** `fetch_citing_batch`.
-- **Candidatos backward = stubs id-only**: título placeholder `[candidate:{id}]`, `openalex_id`
-  poblado, resto nulo, `is_seed=False`, `curation_status='candidate'`, `provenance` con
-  `chaining_hop=1`. No contaminan las redes; son curables/enriquecibles después (gap conocido).
+- **AS-BUILT (#54, 2026-06-17) — el backward NO materializa stubs: observa sin contaminar.** El
+  backward chaining **ya no crea filas-fantasma `[candidate:W...]` en el corpus** (revierte el
+  comportamiento de Hito 5 — la promesa de "no contaminan" era **falsa**: los stubs llegaron a ser
+  ~la mitad del corpus y entraban al `corpus_hash`; Notas 09/12). Los IDs observados por el ranking
+  backward salen por **`RankedCandidates.observed_refs: list[str]`** (orden de ranking, respeta
+  `max_candidates`) y `b2g chain` los persiste en la tabla hermana **`referenced_but_not_fetched`**
+  (§4), **fuera** del `corpus` y del `corpus_hash`. La materialización on-demand (rehidratar un
+  observado a fila real vía `fetch_works_by_ids`, #55) está **diferida a #71**. El **forward sí sigue
+  materializando** filas en `.corpus` —y con el MISMO footgun de placeholder de título
+  `[candidate:W...]` (IDs de citantes sin metadata completa): **el forward NO está limpio**, abierto
+  como **#78**—.
 - **`preview` y `chain` no mutan** el corpus de entrada (semántica de valor).
 
 ---
@@ -1506,6 +1550,8 @@ forager = Forager(OpenAlexSource(email="luis@sostaina.com"), depth=1, max_candid
 prev = forager.preview(seed.corpus)                     # backward exacto; forward → chain
 print(prev.estimated_new, prev.forward_requires_fetch)  # p. ej. 142  True
 ranked = forager.chain(seed.corpus)                     # forward fetchea citantes
+# AS-BUILT #54: el backward observa sin materializar → ranked.observed_refs (no van a ranked.corpus);
+# el forward sí materializa filas (placeholder de título, #78). Ver §5.
 
 # 3') Curar lo forrajeado, normalizar y aplicar el thesaurus multilingüe determinista
 corpus = seed.corpus.merge(ranked.corpus).accept(ids=[...]).reject(ids=[...])

--- a/docs/decisiones/0020-metodo-forrajeo-scent-filtros-reject.md
+++ b/docs/decisiones/0020-metodo-forrajeo-scent-filtros-reject.md
@@ -278,3 +278,66 @@ semántica.
 
 > **Decidido por:** AS-BUILT verificado del #21 (2026-06-16, rama `feat/forager-cap-batching`); gate
 > verde, 422 tests. Ver `API.md` §5 y §2 (`fetch_citing_batch`).
+
+## AS-BUILT — 2026-06-17 (#54: el backward deja de persistir placeholders; revierte el "no contaminan" de la decisión B)
+
+> El cuerpo del ADR (decisión **B**) afirmaba que los candidatos backward se materializan como
+> **stubs id-only** en el corpus (título placeholder `[candidate:{id}]`, resto nulo) y que **"no
+> contaminan las redes"**. **Esa afirmación era FALSA** y este AS-BUILT la corrige; **no reescribe**
+> el cuerpo histórico (queda como rastro del error). Gate verde, **636 tests**; verifier PASA. Rama
+> `fix/backward-chaining-no-placeholders`.
+
+### El "no contaminan" era falso — los stubs SÍ contaminaron
+
+Las sesiones de QA con datos reales lo destaparon ([Nota 09](../Notas/09-sesion-qa-prueba-ecologia-valoraciones.md),
+[Nota 12](../Notas/12-continuacion-sesion-valoraciones.md), "el bug de fondo del Forager"): los stubs
+`[candidate:W...]` **sí contaminaron**. Llegaron a ser **~la mitad del corpus** (filas-fantasma sin
+metadata real) y, peor, **entraron al `corpus_hash`** (eran filas del `corpus`, no ruido externo) —
+rompiendo la reproducibilidad y las redes legibles. La promesa de "curables/enriquecibles después"
+nunca tuvo un materializador que la sostuviera (la deuda quedó abierta como #71).
+
+### Opción B implementada — observar sin materializar
+
+El backward chaining **ya NO crea filas-fantasma en el corpus**. Los IDs observados (los candidatos
+que el ranking backward detecta) se exponen por **`RankedCandidates.observed_refs: list[str]`** (campo
+nuevo, en orden de ranking, respetando `max_candidates`) y se persisten en una **tabla append-only
+hermana, `referenced_but_not_fetched`** (par de `loop_state_log`, **fuera** de la tabla `corpus`). El
+ranking backward sobrevive intacto en `RankedCandidates.ranking`; se eliminó `_build_backward_candidate_row`.
+
+- **Protocol `TabularBackend`** (`backends/base.py`): tres métodos nuevos —
+  `add_referenced_refs(ref_ids, *, cycle_round)` (idempotente por existencia de `ref_id`),
+  `referenced_refs_count()`, `referenced_refs()`—, implementados por `DuckDBBackend` (DDL + migración
+  liviana + copia en snapshot/`_clone`; `observed_at` vía el `now()` del backend) e `InMemoryBackend`.
+- **`b2g chain`** persiste los `observed_refs` en la tabla (con `cycle_round`) y suma
+  `observed_refs_count` al envelope JSON. **`b2g status`** suma el campo aditivo `referenced_not_fetched`
+  (`schema="1"` intacto).
+
+### `corpus_hash` y materialización on-demand
+
+El **`corpus_hash` NO incluye los observados** (viven en la tabla hermana, no en `corpus`): esto
+**arregla la contaminación previa del hash** (antes los fantasmas SÍ entraban). El materializador
+on-demand —rehidratar un observado a fila real del corpus vía `fetch_works_by_ids` (#55) cuando el
+humano lo pida— está **diferido a #71** (NO construido en #54).
+
+### Coherencia con otros ADR
+
+- **NO toca [ADR 0013](0013-identidad-hash-merge-corpus.md):** el schema del `corpus` queda intacto;
+  `referenced_but_not_fetched` es una tabla aparte, no una columna nueva.
+- **Coherente con [ADR 0017](0017-reproducibilidad-historia-snapshot.md):** los IDs observados son
+  **estado** (qué vio el forrajeo), **no contenido bibliográfico** → fuera del `corpus_hash`, igual que
+  la procedencia y los timestamps. La identidad sigue siendo solo el contenido curado.
+
+### Seguimiento — el forward tiene el MISMO footgun (#78, NO arreglado en #54)
+
+El verifier confirmó que el **forward chaining arrastra el mismo problema**:
+`_build_forward_candidate_row` materializa filas con **título placeholder `[candidate:W...]`** (IDs de
+citantes sin metadata completa). #54 **solo arregló el backward**; el forward queda **abierto como
+issue #78**. Honestidad de estado: el forward **NO está limpio** — sigue poniendo placeholders de
+título en el corpus.
+
+**Lo que NO cambia:** backward = co-citación con el corpus (puro/local), forward = citación directa,
+filtros `rejected` (C), `apply_thesaurus` (D), `depth=1`, desempate por `id`, "solo el Forager toca la
+red".
+
+> **Decidido por:** AS-BUILT verificado del #54 (2026-06-17, rama `fix/backward-chaining-no-placeholders`);
+> gate verde, 636 tests, verifier PASA. Ver `API.md` §5 (`observed_refs`) y §4 (`referenced_but_not_fetched`).

--- a/src/bib2graph/backends/base.py
+++ b/src/bib2graph/backends/base.py
@@ -144,3 +144,33 @@ class TabularBackend(Protocol):
     def __eq__(self, other: object) -> bool:
         """Igualdad canónica por ``corpus_hash`` (D2)."""
         ...
+
+    def add_referenced_refs(self, ref_ids: list[str], *, cycle_round: int) -> int:
+        """Appendea IDs backward observados a ``referenced_but_not_fetched`` (#54).
+
+        Solo inserta los IDs que aún no están en la tabla (idempotente).
+
+        Args:
+            ref_ids: IDs de OpenAlex observados en backward chaining.
+            cycle_round: Número de ronda del ciclo en curso.
+
+        Returns:
+            Número de IDs nuevos insertados.
+        """
+        ...
+
+    def referenced_refs_count(self) -> int:
+        """Número de IDs en ``referenced_but_not_fetched``.
+
+        Returns:
+            Conteo total de filas en la tabla auxiliar.
+        """
+        ...
+
+    def referenced_refs(self) -> list[str]:
+        """Lista de IDs en ``referenced_but_not_fetched``, en orden de inserción.
+
+        Returns:
+            Lista de ``ref_id``.
+        """
+        ...

--- a/src/bib2graph/backends/duckdb.py
+++ b/src/bib2graph/backends/duckdb.py
@@ -110,6 +110,20 @@ _DDL_LOOP_STATE_MIGRATE = """
 ALTER TABLE loop_state_log ADD COLUMN round INTEGER DEFAULT 0
 """
 
+# #54 (opción B): tabla hermana de loop_state_log — acumula IDs observados en
+# backward chaining pero no materializados en el corpus.  Append-only, sin
+# constraint UNIQUE: la idempotencia de escritura la garantiza el comando chain
+# (que solo escribe los IDs nuevos del lote en curso, no re-escribe anteriores).
+# ``observed_at`` usa ``now()`` de DuckDB (mismo patrón que ``recorded_at`` en
+# loop_state_log: reloj en la frontera del backend, no inyectado desde el núcleo).
+_DDL_REFERENCED_BUT_NOT_FETCHED = """
+CREATE TABLE IF NOT EXISTS referenced_but_not_fetched (
+    ref_id      VARCHAR NOT NULL,
+    cycle_round INTEGER NOT NULL DEFAULT 0,
+    observed_at TIMESTAMPTZ NOT NULL DEFAULT now()
+)
+"""
+
 # ADR 0024: migración liviana para bases pre-existentes sin columna ``_seq``.
 # Se suprime el error si la columna ya existe (CatalogException o BinderException).
 # El backfill usa ``rowid`` como proxy de orden de inserción original; es inocuo
@@ -300,6 +314,8 @@ class DuckDBBackend:
         # Backfill: asigna _seq = rowid a filas legacy sin _seq asignado.
         # Es inocuo cuando no hay NULLs (WHERE _seq IS NULL no toca nada).
         self._con.execute(_DDL_CORPUS_BACKFILL_SEQ)
+        # #54: tabla auxiliar para IDs backward observados pero no materializados.
+        self._con.execute(_DDL_REFERENCED_BUT_NOT_FETCHED)
         self._register_udfs()
 
     def _register_udfs(self) -> None:
@@ -395,6 +411,17 @@ class DuckDBBackend:
                 new_backend._con.execute(
                     "INSERT INTO loop_state_log (state, round, recorded_at) VALUES (?, ?, ?)",
                     [state_val, round_val, at_val],
+                )
+            # #54: copiar la tabla referenced_but_not_fetched (hermana de loop_state_log)
+            ref_rows = self._con.execute(
+                "SELECT ref_id, cycle_round, observed_at "
+                "FROM referenced_but_not_fetched ORDER BY observed_at"
+            ).fetchall()
+            for ref_id_val, cycle_round_val, observed_at_val in ref_rows:
+                new_backend._con.execute(
+                    "INSERT INTO referenced_but_not_fetched "
+                    "(ref_id, cycle_round, observed_at) VALUES (?, ?, ?)",
+                    [ref_id_val, cycle_round_val, observed_at_val],
                 )
             return new_backend
         else:
@@ -635,6 +662,62 @@ class DuckDBBackend:
             "INSERT INTO loop_state_log (state, round) VALUES (?, ?)",
             [state.value, current_round],
         )
+
+    # ------------------------------------------------------------------
+    # Extensiones propias: referenced_but_not_fetched (#54)
+    # ------------------------------------------------------------------
+
+    def add_referenced_refs(self, ref_ids: list[str], *, cycle_round: int) -> int:
+        """Appendea IDs backward observados a ``referenced_but_not_fetched``.
+
+        No duplica IDs ya presentes (idempotencia basada en existencia): solo
+        inserta los que aún no están en la tabla, independientemente del
+        ``cycle_round``.  El ``observed_at`` lo provee ``now()`` de DuckDB.
+
+        Args:
+            ref_ids: IDs de OpenAlex observados en backward chaining.
+            cycle_round: Número de ronda del ciclo en curso.
+
+        Returns:
+            Número de IDs nuevos insertados (0 si todos ya existían).
+        """
+        if not ref_ids:
+            return 0
+        # IDs ya presentes (cualquier ronda — el contrato es append sin duplicar).
+        existing_rows = self._con.execute(
+            "SELECT ref_id FROM referenced_but_not_fetched"
+        ).fetchall()
+        existing: set[str] = {r[0] for r in existing_rows}
+        new_ids = [rid for rid in ref_ids if rid not in existing]
+        for rid in new_ids:
+            self._con.execute(
+                "INSERT INTO referenced_but_not_fetched (ref_id, cycle_round) "
+                "VALUES (?, ?)",
+                [rid, cycle_round],
+            )
+        return len(new_ids)
+
+    def referenced_refs_count(self) -> int:
+        """Número de IDs en ``referenced_but_not_fetched``.
+
+        Returns:
+            Conteo total de filas en la tabla auxiliar.
+        """
+        row = self._con.execute(
+            "SELECT COUNT(*) FROM referenced_but_not_fetched"
+        ).fetchone()
+        return int(row[0]) if row else 0
+
+    def referenced_refs(self) -> list[str]:
+        """Lista de IDs en ``referenced_but_not_fetched``, ordenados por ``observed_at``.
+
+        Returns:
+            Lista de ``ref_id`` en orden de inserción.
+        """
+        rows = self._con.execute(
+            "SELECT ref_id FROM referenced_but_not_fetched ORDER BY observed_at"
+        ).fetchall()
+        return [r[0] for r in rows]
 
     # ------------------------------------------------------------------
     # Extensión: query SQL libre

--- a/src/bib2graph/backends/memory.py
+++ b/src/bib2graph/backends/memory.py
@@ -353,16 +353,30 @@ class InMemoryBackend:
 
     Semántica de valor: todas las operaciones mutantes devuelven una nueva
     instancia; la original no cambia nunca.
+
+    #54: almacena también los IDs backward observados en ``_referenced_refs``
+    (lista en memoria, equivalente a la tabla ``referenced_but_not_fetched``
+    de ``DuckDBBackend``).
     """
 
-    def __init__(self, table: pa.Table) -> None:
+    def __init__(
+        self,
+        table: pa.Table,
+        *,
+        referenced_refs: list[str] | None = None,
+    ) -> None:
         """Constructor interno.
 
         Args:
             table: Tabla Arrow con el schema canónico (debe estar validada
                 antes de construir el backend).
+            referenced_refs: Lista de IDs ya registrados en la tabla auxiliar
+                ``referenced_but_not_fetched`` (para clonar el estado en
+                operaciones que devuelven una nueva instancia).
         """
         self._table = table
+        # #54: IDs backward observados, en orden de inserción, sin duplicados.
+        self._referenced_refs: list[str] = list(referenced_refs or [])
 
     # ------------------------------------------------------------------
     # TabularBackend protocol
@@ -387,7 +401,9 @@ class InMemoryBackend:
         """
         existing = self._table.to_pylist()
         existing.append(row)
-        return InMemoryBackend(_rows_to_table(existing))
+        return InMemoryBackend(
+            _rows_to_table(existing), referenced_refs=self._referenced_refs
+        )
 
     def merge(self, other_table: pa.Table) -> InMemoryBackend:
         """Fusiona ``other_table`` respetando D3 y devuelve una nueva instancia.
@@ -422,7 +438,9 @@ class InMemoryBackend:
             if id_ not in rows_self:
                 result_rows.append(row)
 
-        return InMemoryBackend(_rows_to_table(result_rows))
+        return InMemoryBackend(
+            _rows_to_table(result_rows), referenced_refs=self._referenced_refs
+        )
 
     def apply_curation(
         self,
@@ -450,7 +468,9 @@ class InMemoryBackend:
         updated = _apply_curation_to_rows(
             self._table.to_pylist(), ids, action, by, decided_at
         )
-        return InMemoryBackend(_rows_to_table(updated))
+        return InMemoryBackend(
+            _rows_to_table(updated), referenced_refs=self._referenced_refs
+        )
 
     def filter_view(self, view: Literal["seeds", "candidates", "accepted"]) -> pa.Table:
         """Devuelve la tabla filtrada según la vista pedida.
@@ -497,3 +517,42 @@ class InMemoryBackend:
         if not isinstance(other, InMemoryBackend):
             return False
         return self.corpus_hash() == other.corpus_hash()
+
+    # ------------------------------------------------------------------
+    # Extensiones: referenced_but_not_fetched (#54)
+    # ------------------------------------------------------------------
+
+    def add_referenced_refs(self, ref_ids: list[str], *, cycle_round: int) -> int:
+        """Appendea IDs backward observados a la tabla auxiliar en memoria.
+
+        Solo inserta los que aún no están (idempotente).  ``cycle_round`` se
+        acepta por compatibilidad con el protocolo pero no se persiste en
+        memoria (el backend en memoria no necesita auditoría de ronda).
+
+        Args:
+            ref_ids: IDs de OpenAlex observados en backward chaining.
+            cycle_round: Número de ronda del ciclo en curso (ignorado en memoria).
+
+        Returns:
+            Número de IDs nuevos insertados.
+        """
+        existing = set(self._referenced_refs)
+        new_ids = [rid for rid in ref_ids if rid not in existing]
+        self._referenced_refs.extend(new_ids)
+        return len(new_ids)
+
+    def referenced_refs_count(self) -> int:
+        """Número de IDs en la tabla auxiliar.
+
+        Returns:
+            Conteo total.
+        """
+        return len(self._referenced_refs)
+
+    def referenced_refs(self) -> list[str]:
+        """Lista de IDs en la tabla auxiliar, en orden de inserción.
+
+        Returns:
+            Lista de ``ref_id``.
+        """
+        return list(self._referenced_refs)

--- a/src/bib2graph/cli/commands/chain.py
+++ b/src/bib2graph/cli/commands/chain.py
@@ -99,7 +99,9 @@ def run_chain(
         # decorador @handle_errors las captura por tipo y emite exit 4.
         # AttributeError genuino se propaga limpio (no se disfraza de exit 3).
 
-        # Merge de candidatos en el corpus
+        # Merge de candidatos forward materializados en el corpus.
+        # Los IDs backward (ranked.observed_refs) NO van al corpus — se persisten
+        # en la tabla auxiliar ``referenced_but_not_fetched`` (#54, opción B).
         merged = corpus.merge(ranked.corpus)
         candidates_found = len(ranked.corpus)
         total_papers = len(merged)
@@ -108,6 +110,15 @@ def run_chain(
         ]
         merged_backend_close = getattr(merged._backend, "close", None)
         store.persist(merged)
+
+        # #54: persistir IDs backward observados en la tabla auxiliar.
+        # El backend del store (DuckDBBackend) ya tiene add_referenced_refs;
+        # el InMemoryBackend lo implementa también para tests.
+        if ranked.observed_refs:
+            store.backend.add_referenced_refs(
+                ranked.observed_refs, cycle_round=new_round
+            )
+
         store.backend.set_loop_state(new_state, cycle_round=new_round)
     finally:
         # Ver run_seed_from_bib: cierra explícitamente las conexiones DuckDB
@@ -122,6 +133,7 @@ def run_chain(
         "direction": direction,
         "depth": depth,
         "ranking_preview": ranking_preview,
+        "observed_refs_count": len(ranked.observed_refs),
     }
 
 

--- a/src/bib2graph/cli/commands/status.py
+++ b/src/bib2graph/cli/commands/status.py
@@ -87,6 +87,10 @@ def run_status(store_path: str | Path) -> dict[str, Any]:
     # Antes de R3, ``transitions_available`` nunca listaba accept/reject → bug cerrado.
     curation = list(CURATION_ACTIONS)
 
+    # #54: conteo de IDs backward observados pero no materializados.
+    # El campo es aditivo (schema="1" intacto; campos nuevos no rompen agentes).
+    referenced_not_fetched = store.backend.referenced_refs_count()
+
     return {
         "loop_state": state_str,
         "transitions_available": transitions,
@@ -94,6 +98,7 @@ def run_status(store_path: str | Path) -> dict[str, Any]:
         "round": current_round,
         "counts_by_status": counts,
         "total_papers": total,
+        "referenced_not_fetched": referenced_not_fetched,
     }
 
 
@@ -185,5 +190,8 @@ def status_cmd(
         )
         ws_root = data["workspace"]["root"] or "(modo degenerado)"
         emit_human(f"Workspace: {ws_root} (resuelto vía {data['workspace']['source']})")
+        ref_count = data.get("referenced_not_fetched", 0)
+        if ref_count > 0:
+            emit_human(f"Referenciados sin materializar: {ref_count}")
         for w in warnings:
             print(f"AVISO: {w}", file=sys.stderr)

--- a/src/bib2graph/foraging/base.py
+++ b/src/bib2graph/foraging/base.py
@@ -55,16 +55,27 @@ class GrowthPreview(BaseModel):
 class RankedCandidates(BaseModel):
     """Resultado del ``Forager.chain()``: candidatos rankeados por scent.
 
-    El corpus contiene SOLO los candidatos nuevos (no mergeado con el
-    corpus semilla). El ranking es una lista estable ordenada por scent
-    descendente, con desempate por id ascendente.
+    El corpus contiene SOLO los candidatos nuevos materializados (forward:
+    filas reales; backward: vacío — los IDs backward van a ``observed_refs``).
+    El corpus NO se mergeó con el corpus semilla.
+    El ranking es una lista estable ordenada por scent descendente, con
+    desempate por id ascendente.
 
     Attributes:
-        corpus: Corpus de candidatos con ``curation_status='candidate'``.
+        corpus: Corpus de candidatos materializados con
+            ``curation_status='candidate'`` (solo forward; backward = vacío).
         ranking: Lista ``(id, information_scent)`` ordenada por scent desc.
+            Incluye tanto candidatos forward (materializados) como backward
+            (solo IDs observados, sin fila en corpus).
+        observed_refs: IDs de OpenAlex observados en backward chaining pero
+            NO materializados como filas del corpus (opción B — #54).  Son
+            los candidatos backward que se persisten en la tabla auxiliar
+            ``referenced_but_not_fetched`` por el comando CLI, no en el corpus.
+            Vacío en chaining puramente forward.
     """
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
     corpus: Corpus
     ranking: list[tuple[str, float]]
+    observed_refs: list[str] = []

--- a/src/bib2graph/foraging/forager.py
+++ b/src/bib2graph/foraging/forager.py
@@ -4,15 +4,21 @@ El Forager rankea candidatos por *information scent* bibliométrico usando
 funciones puras de ``scent.py`` (R4, ADR 0020/0022):
 
 - **Backward**: score = nº de corpus-papers que listan al candidato en
-  ``references_id`` (acoplamiento hacia atrás).
+  ``references_id`` (acoplamiento hacia atrás).  Los IDs backward NO se
+  materializan como filas del corpus; salen en ``RankedCandidates.observed_refs``
+  para que el comando CLI los persista en ``referenced_but_not_fetched`` (#54,
+  opción B).  El ranking backward SIGUE en ``RankedCandidates.ranking``.
 - **Forward** (fix forward-scent, Wohlin): score = citación directa al corpus.
     corpus_ids = {Pi.id | Pi.openalex_id : Pi ∈ corpus}
     forward_score(Y) = |{ref ∈ Y.references_id : ref ∈ corpus_ids}|
   Robusto ante corpus con ``references_id`` ralas (estado común tras un seed
   sin enriquecimiento); el acoplamiento bibliográfico puro degeneraba a 0.
+  Los candidatos forward SÍ se materializan como filas del corpus.
 
 Solo él toca la red (a través del ``Source`` inyectado).  El núcleo de
 scent es puro.  ``explain_candidate`` fue **eliminado** (R4, ADR 0022).
+``_build_backward_candidate_row`` fue **eliminado** (#54): ya no se fabrica
+ninguna fila-fantasma para candidatos backward.
 
 ``depth > 1`` lanza ``NotImplementedError`` claro (decisión e=A, ADR 0008).
 
@@ -136,59 +142,6 @@ def _build_forward_candidate_row(
         # references_id incluye los seeds citados para que compute_forward_scent
         # pueda calcular el score por intersección con corpus_ids.
         Col.REFERENCES_ID: seed_ids_cited or None,
-        Col.REFERENCES_DOI: None,
-        Col.CITED_BY_ID: None,
-    }
-
-
-def _build_backward_candidate_row(
-    ref_id: str,
-    *,
-    fetched_at: str,
-) -> dict[str, Any]:
-    """Construye una fila mínima (id-only) para un candidato backward.
-
-    El candidato backward es un id de OpenAlex extraído de ``references_id``
-    de los papers del corpus.  Solo tenemos el id; el título se rellena con
-    un placeholder para pasar la validación del schema.
-
-    Args:
-        ref_id: ID de OpenAlex del candidato (p. ej. ``W12345``).
-        fetched_at: Timestamp ISO del fetch.
-
-    Returns:
-        Dict con las columnas mínimas del schema canónico.
-    """
-    provenance_event = ProvenanceEvent(
-        action="fetched",
-        equation_id=None,
-        chaining_hop=1,
-        source="chaining:backward",
-        fetched_at=fetched_at,
-        decided_by=None,
-        decided_at=None,
-    )
-    return {
-        Col.OPENALEX_ID: ref_id,
-        Col.DOI: None,
-        Col.TITLE: f"[candidate:{ref_id}]",
-        Col.YEAR: None,
-        Col.ABSTRACT: None,
-        Col.SOURCE: None,
-        Col.LANGUAGE: None,
-        Col.PUBLISHER: None,
-        Col.RESEARCH_AREAS: None,
-        Col.IS_SEED: False,
-        Col.CURATION_STATUS: CurationStatus.CANDIDATE,
-        Col.PROVENANCE: ProvenanceEvent.dump_list([provenance_event]),
-        Col.AUTHORS_RAW: None,
-        Col.AUTHORS_ID: None,
-        Col.AUTHORS_AFFILIATIONS: None,
-        Col.KEYWORDS_RAW: None,
-        Col.KEYWORDS_ID: None,
-        Col.INSTITUTIONS_RAW: None,
-        Col.INSTITUTIONS_ID: None,
-        Col.REFERENCES_ID: None,
         Col.REFERENCES_DOI: None,
         Col.CITED_BY_ID: None,
     }
@@ -324,9 +277,18 @@ class Forager:
     ) -> RankedCandidates:
         """Computa candidatos rankeados por *information scent*.
 
-        Devuelve un ``RankedCandidates`` con un Corpus SOLO de candidatos
-        nuevos (no mergeado con el corpus de entrada).  El humano hace
-        ``seed_corpus.merge(ranked.corpus)`` para expandir.
+        **Opción B (#54):** los candidatos backward NO se materializan como
+        filas del corpus — sus IDs salen en ``RankedCandidates.observed_refs``
+        para que el comando CLI los persista en ``referenced_but_not_fetched``.
+        El ranking backward SIGUE presente en ``RankedCandidates.ranking``.
+
+        Los candidatos forward SÍ se materializan como filas en
+        ``RankedCandidates.corpus`` (con metadata traída por ``fetch_citing_batch``).
+
+        Devuelve un ``RankedCandidates`` con:
+        - ``corpus``: SOLO candidatos forward (no mergeado con el corpus semilla).
+        - ``ranking``: candidatos backward + forward rankeados por scent.
+        - ``observed_refs``: IDs backward observados (no en corpus, tabla auxiliar).
 
         NO muta el corpus de entrada.
 
@@ -335,41 +297,53 @@ class Forager:
             direction: ``'backward'``, ``'forward'`` o ``'both'``.
 
         Returns:
-            ``RankedCandidates`` con candidatos y ranking por scent.
+            ``RankedCandidates`` con candidatos, ranking y observed_refs.
         """
         rows = corpus.to_arrow().to_pylist()
         fetched_at = datetime.now(UTC).isoformat()
 
         combined_scent: dict[str, float] = {}
-        candidate_rows: dict[str, dict[str, Any]] = {}
+        # Solo los candidatos forward tienen filas materializadas
+        fwd_candidate_rows: dict[str, dict[str, Any]] = {}
+        # IDs backward: se observan pero NO se materializan como corpus rows
+        bwd_observed: set[str] = set()
 
         if direction in ("backward", "both"):
             bwd_scent = compute_backward_scent(rows)
             for ref_id, scent_val in bwd_scent.items():
                 combined_scent[ref_id] = combined_scent.get(ref_id, 0.0) + scent_val
-                if ref_id not in candidate_rows:
-                    candidate_rows[ref_id] = _build_backward_candidate_row(
-                        ref_id, fetched_at=fetched_at
-                    )
+                bwd_observed.add(ref_id)
 
         if direction in ("forward", "both"):
             fwd_scent, fwd_rows = self._fetch_forward(rows, fetched_at=fetched_at)
             for cand_id, scent_val in fwd_scent.items():
                 combined_scent[cand_id] = combined_scent.get(cand_id, 0.0) + scent_val
-                if cand_id not in candidate_rows:
-                    candidate_rows[cand_id] = fwd_rows[cand_id]
+                if cand_id not in fwd_candidate_rows:
+                    fwd_candidate_rows[cand_id] = fwd_rows[cand_id]
 
-        # Ranking estable (desc scent, asc id)
+        # Ranking estable (desc scent, asc id) — incluye backward + forward
         ranking = rank_candidates(combined_scent, max_candidates=self._max_candidates)
 
-        # R5: bulk-load — construir la tabla Arrow de una vez en vez de N add_paper/clone.
-        # El orden del ranking se preserva construyendo la lista en ese orden.
-        candidate_rows_ordered = [
-            candidate_rows[cand_id]
+        # observed_refs: IDs backward presentes en el ranking (respeta el cap),
+        # en orden de ranking para reproducibilidad.
+        ranked_ids_set = {cand_id for cand_id, _ in ranking}
+        observed_refs = [
+            cand_id
             for cand_id, _ in ranking
-            if cand_id in candidate_rows
+            if cand_id in bwd_observed
+            and cand_id in ranked_ids_set
+            # excluir IDs que también aparecen como forward (ya en corpus)
+            and cand_id not in fwd_candidate_rows
         ]
-        rows_with_ids = _rows_with_ids(candidate_rows_ordered)
+
+        # R5: bulk-load — solo filas FORWARD materializadas.
+        # El orden del ranking se preserva construyendo la lista en ese orden.
+        fwd_rows_ordered = [
+            fwd_candidate_rows[cand_id]
+            for cand_id, _ in ranking
+            if cand_id in fwd_candidate_rows
+        ]
+        rows_with_ids = _rows_with_ids(fwd_rows_ordered)
         if rows_with_ids:
             table = pa.Table.from_pylist(rows_with_ids, schema=CORPUS_SCHEMA)
             candidates_corpus = Corpus.from_arrow(table)
@@ -393,6 +367,7 @@ class Forager:
         return RankedCandidates(
             corpus=candidates_corpus,
             ranking=ranking,
+            observed_refs=observed_refs,
         )
 
     # ------------------------------------------------------------------

--- a/tests/unit/test_backward_no_placeholders.py
+++ b/tests/unit/test_backward_no_placeholders.py
@@ -1,0 +1,587 @@
+"""Tests TDD — #54 opción B: backward chaining sin placeholders en corpus.
+
+Verifica que:
+- ``chain(backward)`` produce CERO filas en ``RankedCandidates.corpus``
+  (sin filas-fantasma ``[candidate:...]``).
+- Los IDs observados están en ``RankedCandidates.observed_refs``.
+- El ranking backward sobrevive en ``RankedCandidates.ranking``.
+- Tras el comando ``chain`` backward, la tabla ``referenced_but_not_fetched``
+  tiene los IDs con ``cycle_round``; el corpus NO creció con fantasmas.
+- ``b2g status`` reporta el campo ``referenced_not_fetched``.
+- La tabla sobrevive al snapshot (round-trip en DuckDBBackend).
+- Migración liviana: una DB sin la tabla no falla al abrirla.
+- No-regresión forward: el forward sigue materializando works reales al corpus.
+- ``corpus_hash`` tras backward chaining NO incluye los observados (estable
+  respecto a solo-seeds).
+
+Marcador: ``unit`` (DuckDB en tmp_path / InMemoryBackend, sin red real).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pyarrow as pa
+import pytest
+
+from bib2graph.backends.duckdb import DuckDBBackend
+from bib2graph.backends.memory import InMemoryBackend
+from bib2graph.corpus import Corpus
+from bib2graph.foraging.forager import Forager
+from bib2graph.schemas import CORPUS_SCHEMA
+
+pytestmark = pytest.mark.unit
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _base_row(
+    id: str,
+    *,
+    openalex_id: str | None = None,
+    is_seed: bool = True,
+    references_id: list[str] | None = None,
+    curation_status: str = "candidate",
+) -> dict[str, Any]:
+    return {
+        "id": id,
+        "openalex_id": openalex_id,
+        "doi": None,
+        "title": f"Paper {id}",
+        "year": 2020,
+        "abstract": None,
+        "source": None,
+        "language": None,
+        "publisher": None,
+        "research_areas": None,
+        "is_seed": is_seed,
+        "curation_status": curation_status,
+        "provenance": None,
+        "authors_raw": None,
+        "authors_id": None,
+        "authors_affiliations": None,
+        "keywords_raw": None,
+        "keywords_id": None,
+        "institutions_raw": None,
+        "institutions_id": None,
+        "references_id": references_id,
+        "references_doi": None,
+        "cited_by_id": None,
+    }
+
+
+def _make_corpus(*rows: dict[str, Any]) -> Corpus:
+    table = pa.Table.from_pylist(list(rows), schema=CORPUS_SCHEMA)
+    return Corpus.from_arrow(table)
+
+
+def _make_noop_source() -> Any:
+    """Source mínimo que no tiene fetch_citing_batch (solo backward posible)."""
+
+    class NoopSource:
+        pass
+
+    return NoopSource()
+
+
+# ---------------------------------------------------------------------------
+# Forager puro (sin persistencia)
+# ---------------------------------------------------------------------------
+
+
+class TestBackwardNoCandidateRows:
+    """chain(backward) no produce filas-fantasma en corpus."""
+
+    def test_corpus_backward_vacio(self) -> None:
+        """Backward chaining: corpus del resultado vacío (sin filas-fantasma)."""
+        corpus = _make_corpus(_base_row("P1", references_id=["REF_A", "REF_B"]))
+
+        forager = Forager(_make_noop_source(), depth=1)
+        ranked = forager.chain(corpus, direction="backward")
+
+        rows = ranked.corpus.to_arrow().to_pylist()
+        assert len(rows) == 0, (
+            f"El corpus backward debe estar vacío (#54), tiene {len(rows)} filas"
+        )
+
+    def test_sin_titulo_placeholder_en_corpus(self) -> None:
+        """Nunca hay títulos '[candidate:...]' en el corpus tras backward chaining."""
+        corpus = _make_corpus(
+            _base_row("P1", references_id=["REF_A"]),
+            _base_row("P2", references_id=["REF_A", "REF_B"]),
+        )
+
+        forager = Forager(_make_noop_source(), depth=1)
+        ranked = forager.chain(corpus, direction="backward")
+
+        for row in ranked.corpus.to_arrow().to_pylist():
+            title = row.get("title") or ""
+            assert "[candidate:" not in title, (
+                f"Título placeholder encontrado en corpus: {title!r}"
+            )
+
+    def test_observed_refs_contiene_ids_backward(self) -> None:
+        """Los IDs backward van a observed_refs, no al corpus."""
+        corpus = _make_corpus(
+            _base_row("P1", references_id=["REF_A", "REF_B"]),
+            _base_row("P2", references_id=["REF_A"]),
+        )
+
+        forager = Forager(_make_noop_source(), depth=1)
+        ranked = forager.chain(corpus, direction="backward")
+
+        assert set(ranked.observed_refs) == {"REF_A", "REF_B"}
+
+    def test_ranking_backward_presente(self) -> None:
+        """El ranking backward SOBREVIVE aunque el corpus esté vacío."""
+        corpus = _make_corpus(
+            _base_row("P1", references_id=["REF_A", "REF_B"]),
+            _base_row("P2", references_id=["REF_A"]),
+        )
+
+        forager = Forager(_make_noop_source(), depth=1)
+        ranked = forager.chain(corpus, direction="backward")
+
+        # Ranking: REF_A (score=2) > REF_B (score=1)
+        assert len(ranked.ranking) == 2
+        assert ranked.ranking[0] == ("REF_A", 2.0)
+        assert ranked.ranking[1] == ("REF_B", 1.0)
+
+    def test_observed_refs_respeta_max_candidates(self) -> None:
+        """max_candidates acota también los observed_refs (solo los del ranking)."""
+        corpus = _make_corpus(
+            _base_row("P1", references_id=["REF_A", "REF_B", "REF_C"]),
+        )
+
+        forager = Forager(_make_noop_source(), depth=1, max_candidates=2)
+        ranked = forager.chain(corpus, direction="backward")
+
+        # Con max_candidates=2, solo los 2 primeros del ranking están en observed_refs
+        assert len(ranked.observed_refs) == 2
+        assert len(ranked.ranking) == 2
+
+    def test_corpus_hash_estable_sin_observed(self) -> None:
+        """corpus_hash solo de seeds NO cambia tras backward chaining.
+
+        Los observed_refs no están en el corpus → el hash no los incluye.
+        """
+        seeds = _make_corpus(_base_row("P1", references_id=["REF_A"]))
+
+        hash_antes = seeds.to_arrow().schema  # verificar que el schema no cambia
+        hash_semillas = seeds._backend.corpus_hash()
+
+        forager = Forager(_make_noop_source(), depth=1)
+        ranked = forager.chain(seeds, direction="backward")
+
+        # Simular merge con el corpus del resultado (vacío para backward)
+        merged = seeds.merge(ranked.corpus)
+        hash_despues = merged._backend.corpus_hash()
+
+        # El hash no cambió porque ranked.corpus está vacío
+        assert hash_semillas == hash_despues, (
+            "corpus_hash cambió tras backward chaining: los observed_refs "
+            "no deben contaminar el hash del corpus"
+        )
+        _ = hash_antes  # usado solo para tipo
+
+
+# ---------------------------------------------------------------------------
+# InMemoryBackend — tabla auxiliar
+# ---------------------------------------------------------------------------
+
+
+class TestInMemoryBackendReferencedRefs:
+    """InMemoryBackend.add_referenced_refs / referenced_refs_count / referenced_refs."""
+
+    def test_add_retorna_nuevos(self) -> None:
+        """add_referenced_refs devuelve el número de IDs realmente nuevos."""
+        table = pa.table(
+            {f.name: pa.array([], type=f.type) for f in CORPUS_SCHEMA},
+            schema=CORPUS_SCHEMA,
+        )
+        backend = InMemoryBackend(table)
+
+        n = backend.add_referenced_refs(["W1", "W2", "W3"], cycle_round=1)
+        assert n == 3
+
+    def test_add_idempotente(self) -> None:
+        """Re-agregar los mismos IDs no los duplica."""
+        table = pa.table(
+            {f.name: pa.array([], type=f.type) for f in CORPUS_SCHEMA},
+            schema=CORPUS_SCHEMA,
+        )
+        backend = InMemoryBackend(table)
+
+        backend.add_referenced_refs(["W1", "W2"], cycle_round=1)
+        n2 = backend.add_referenced_refs(["W1", "W3"], cycle_round=1)
+
+        # Solo W3 es nuevo
+        assert n2 == 1
+        assert backend.referenced_refs_count() == 3
+        assert set(backend.referenced_refs()) == {"W1", "W2", "W3"}
+
+    def test_count_inicial_cero(self) -> None:
+        """Backend nuevo tiene 0 referenced_refs."""
+        table = pa.table(
+            {f.name: pa.array([], type=f.type) for f in CORPUS_SCHEMA},
+            schema=CORPUS_SCHEMA,
+        )
+        backend = InMemoryBackend(table)
+        assert backend.referenced_refs_count() == 0
+
+    def test_referenced_refs_lista(self) -> None:
+        """referenced_refs devuelve lista en orden de inserción."""
+        table = pa.table(
+            {f.name: pa.array([], type=f.type) for f in CORPUS_SCHEMA},
+            schema=CORPUS_SCHEMA,
+        )
+        backend = InMemoryBackend(table)
+        backend.add_referenced_refs(["W1", "W2"], cycle_round=1)
+        backend.add_referenced_refs(["W3"], cycle_round=2)
+
+        refs = backend.referenced_refs()
+        assert refs == ["W1", "W2", "W3"]
+
+    def test_corpus_hash_no_incluye_referenced_refs(self) -> None:
+        """corpus_hash no cambia cuando se agregan referenced_refs."""
+        table = pa.table(
+            {f.name: pa.array([], type=f.type) for f in CORPUS_SCHEMA},
+            schema=CORPUS_SCHEMA,
+        )
+        backend = InMemoryBackend(table)
+        hash_antes = backend.corpus_hash()
+
+        backend.add_referenced_refs(["W1", "W2"], cycle_round=1)
+        hash_despues = backend.corpus_hash()
+
+        assert hash_antes == hash_despues, (
+            "corpus_hash no debe cambiar al agregar referenced_refs"
+        )
+
+
+# ---------------------------------------------------------------------------
+# DuckDBBackend — tabla auxiliar
+# ---------------------------------------------------------------------------
+
+
+class TestDuckDBBackendReferencedRefs:
+    """DuckDBBackend: tabla referenced_but_not_fetched (DDL, métodos, migración)."""
+
+    def test_tabla_creada_en_setup(self, tmp_path: Path) -> None:
+        """La tabla referenced_but_not_fetched se crea en _setup."""
+        db_path = tmp_path / "test.duckdb"
+        backend = DuckDBBackend(path=db_path)
+        # Debe poder hacer la query sin error
+        count = backend.referenced_refs_count()
+        assert count == 0
+        backend.close()
+
+    def test_add_referenced_refs(self, tmp_path: Path) -> None:
+        """add_referenced_refs inserta IDs con cycle_round."""
+        db_path = tmp_path / "test.duckdb"
+        backend = DuckDBBackend(path=db_path)
+
+        n = backend.add_referenced_refs(["W1", "W2"], cycle_round=1)
+        assert n == 2
+        assert backend.referenced_refs_count() == 2
+        refs = backend.referenced_refs()
+        assert set(refs) == {"W1", "W2"}
+        backend.close()
+
+    def test_add_idempotente(self, tmp_path: Path) -> None:
+        """Re-agregar los mismos IDs no los duplica."""
+        db_path = tmp_path / "test.duckdb"
+        backend = DuckDBBackend(path=db_path)
+
+        backend.add_referenced_refs(["W1", "W2"], cycle_round=1)
+        n2 = backend.add_referenced_refs(["W1", "W3"], cycle_round=2)
+
+        assert n2 == 1  # solo W3 es nuevo
+        assert backend.referenced_refs_count() == 3
+        backend.close()
+
+    def test_snapshot_round_trip(self, tmp_path: Path) -> None:
+        """La tabla referenced_but_not_fetched sobrevive al _clone (snapshot)."""
+        db_path = tmp_path / "test.duckdb"
+        backend = DuckDBBackend(path=db_path)
+        backend.add_referenced_refs(["W1", "W2", "W3"], cycle_round=1)
+
+        # _clone simula el comportamiento de snapshot para :memory:
+        # Para un archivo en disco, una nueva instancia comparte los datos
+        backend2 = DuckDBBackend(path=db_path)
+        assert backend2.referenced_refs_count() == 3
+        assert set(backend2.referenced_refs()) == {"W1", "W2", "W3"}
+        backend.close()
+        backend2.close()
+
+    def test_migracion_liviana_db_sin_tabla(self, tmp_path: Path) -> None:
+        """Una DB sin referenced_but_not_fetched no falla al abrirla.
+
+        Simula una base pre-#54: creamos la tabla corpus y loop_state_log
+        manualmente sin referenced_but_not_fetched, luego abrimos DuckDBBackend
+        que debe crearla vía el DDL CREATE TABLE IF NOT EXISTS.
+        """
+        import duckdb
+
+        db_path = tmp_path / "legacy.duckdb"
+        # Crear una DB con solo las tablas viejas (sin referenced_but_not_fetched)
+        con = duckdb.connect(str(db_path))
+        con.execute(
+            "CREATE TABLE IF NOT EXISTS corpus (id VARCHAR PRIMARY KEY, "
+            "openalex_id VARCHAR, doi VARCHAR, title VARCHAR NOT NULL, "
+            "year INTEGER, abstract VARCHAR, source VARCHAR, language VARCHAR, "
+            "publisher VARCHAR, research_areas VARCHAR[], is_seed BOOLEAN NOT NULL, "
+            "curation_status VARCHAR NOT NULL, provenance VARCHAR, "
+            "authors_raw VARCHAR[], authors_id VARCHAR[], authors_affiliations VARCHAR[], "
+            "keywords_raw VARCHAR[], keywords_id VARCHAR[], institutions_raw VARCHAR[], "
+            "institutions_id VARCHAR[], references_id VARCHAR[], references_doi VARCHAR[], "
+            "cited_by_id VARCHAR[], _seq BIGINT)"
+        )
+        con.execute(
+            "CREATE TABLE IF NOT EXISTS loop_state_log "
+            "(state VARCHAR NOT NULL, round INTEGER DEFAULT 0, "
+            "recorded_at TIMESTAMPTZ NOT NULL DEFAULT now())"
+        )
+        con.close()
+
+        # Abrir con DuckDBBackend — no debe fallar
+        backend = DuckDBBackend(path=db_path)
+        # La tabla nueva debe existir y estar vacía
+        assert backend.referenced_refs_count() == 0
+        backend.close()
+
+    def test_corpus_hash_no_cambia(self, tmp_path: Path) -> None:
+        """corpus_hash no cambia al agregar referenced_refs al DuckDBBackend."""
+        db_path = tmp_path / "test.duckdb"
+        backend = DuckDBBackend(path=db_path)
+        hash_vacio = backend.corpus_hash()
+
+        backend.add_referenced_refs(["W99"], cycle_round=1)
+        hash_despues = backend.corpus_hash()
+
+        assert hash_vacio == hash_despues
+        backend.close()
+
+
+# ---------------------------------------------------------------------------
+# Comando chain — integración con store
+# ---------------------------------------------------------------------------
+
+
+class TestRunChainBackwardNoPersistePlaceholders:
+    """run_chain backward: no persiste filas-fantasma; persiste en tabla auxiliar."""
+
+    def _seed_store(self, store_path: Path, refs: list[str]) -> None:
+        """Crea un store con una semilla que tiene las referencias dadas."""
+        from bib2graph.corpus import Corpus
+        from bib2graph.stores.duckdb import DuckDBStore
+
+        row = _base_row("P1", references_id=refs)
+        table = pa.Table.from_pylist([row], schema=CORPUS_SCHEMA)
+        corpus = Corpus.from_arrow(table)
+        store = DuckDBStore(store_path)
+        store.persist(corpus)
+        from bib2graph.cycle import CycleState
+
+        store.backend.set_loop_state(CycleState.SEEDED, cycle_round=1)
+        store.close()
+
+    def test_corpus_no_crece_con_backward(self, tmp_path: Path) -> None:
+        """Tras chain backward, el corpus NO tiene filas-fantasma."""
+        from bib2graph.cli.commands.chain import run_chain
+        from bib2graph.stores.duckdb import DuckDBStore
+
+        store_path = tmp_path / "lib.duckdb"
+        self._seed_store(store_path, ["REF_A", "REF_B"])
+
+        store_before = DuckDBStore(store_path)
+        n_before = len(store_before.load())
+        store_before.close()
+
+        run_chain(store_path, direction="backward")
+
+        store_after = DuckDBStore(store_path)
+        corpus_after = store_after.load()
+        n_after = len(corpus_after)
+
+        # El corpus no creció (no hay filas-fantasma backward)
+        assert n_after == n_before, (
+            f"El corpus creció de {n_before} a {n_after} tras backward chaining: "
+            "las filas-fantasma backward no deben estar en el corpus (#54)"
+        )
+        store_after.close()
+
+    def test_sin_titulo_placeholder_tras_chain_backward(self, tmp_path: Path) -> None:
+        """Tras chain backward, no hay títulos '[candidate:...]' en el corpus."""
+        from bib2graph.cli.commands.chain import run_chain
+        from bib2graph.stores.duckdb import DuckDBStore
+
+        store_path = tmp_path / "lib.duckdb"
+        self._seed_store(store_path, ["REF_A"])
+
+        run_chain(store_path, direction="backward")
+
+        store = DuckDBStore(store_path)
+        rows = store.load().to_arrow().to_pylist()
+        store.close()
+
+        for row in rows:
+            title = row.get("title") or ""
+            assert "[candidate:" not in title, (
+                f"Título placeholder en corpus: {title!r}"
+            )
+
+    def test_referenced_but_not_fetched_tiene_ids(self, tmp_path: Path) -> None:
+        """Tras chain backward, referenced_but_not_fetched tiene los IDs."""
+        from bib2graph.backends.duckdb import DuckDBBackend
+        from bib2graph.cli.commands.chain import run_chain
+
+        store_path = tmp_path / "lib.duckdb"
+        self._seed_store(store_path, ["REF_A", "REF_B"])
+
+        run_chain(store_path, direction="backward")
+
+        backend = DuckDBBackend(path=store_path)
+        refs = set(backend.referenced_refs())
+        assert "REF_A" in refs
+        assert "REF_B" in refs
+        backend.close()
+
+    def test_observed_refs_count_en_resultado(self, tmp_path: Path) -> None:
+        """run_chain devuelve observed_refs_count > 0 en backward."""
+        from bib2graph.cli.commands.chain import run_chain
+
+        store_path = tmp_path / "lib.duckdb"
+        self._seed_store(store_path, ["REF_A", "REF_B"])
+
+        result = run_chain(store_path, direction="backward")
+
+        assert "observed_refs_count" in result
+        assert result["observed_refs_count"] == 2
+
+    def test_chain_idempotente_referenced(self, tmp_path: Path) -> None:
+        """Correr chain backward dos veces no duplica los IDs en la tabla auxiliar."""
+        from bib2graph.backends.duckdb import DuckDBBackend
+        from bib2graph.cli.commands.chain import run_chain
+
+        store_path = tmp_path / "lib.duckdb"
+        self._seed_store(store_path, ["REF_A", "REF_B"])
+
+        run_chain(store_path, direction="backward")
+        run_chain(store_path, direction="backward")
+
+        backend = DuckDBBackend(path=store_path)
+        count = backend.referenced_refs_count()
+        # No debe haber duplicados — sigue siendo 2
+        assert count == 2, (
+            f"Esperado 2 IDs únicos, encontrado {count} (posibles duplicados)"
+        )
+        backend.close()
+
+
+# ---------------------------------------------------------------------------
+# b2g status — campo referenced_not_fetched
+# ---------------------------------------------------------------------------
+
+
+class TestStatusReferencedNotFetched:
+    """run_status devuelve el campo referenced_not_fetched."""
+
+    def test_status_campo_referenced_not_fetched(self, tmp_path: Path) -> None:
+        """run_status incluye referenced_not_fetched (cuenta de IDs observados)."""
+        from bib2graph.cli.commands.chain import run_chain
+        from bib2graph.cli.commands.status import run_status
+        from bib2graph.corpus import Corpus
+        from bib2graph.cycle import CycleState
+        from bib2graph.stores.duckdb import DuckDBStore
+
+        store_path = tmp_path / "lib.duckdb"
+        row = _base_row("P1", references_id=["REF_A", "REF_B"])
+        table = pa.Table.from_pylist([row], schema=CORPUS_SCHEMA)
+        corpus = Corpus.from_arrow(table)
+        store = DuckDBStore(store_path)
+        store.persist(corpus)
+        store.backend.set_loop_state(CycleState.SEEDED, cycle_round=1)
+        store.close()
+
+        run_chain(store_path, direction="backward")
+
+        data = run_status(store_path)
+
+        assert "referenced_not_fetched" in data, (
+            "run_status debe incluir el campo 'referenced_not_fetched'"
+        )
+        assert data["referenced_not_fetched"] == 2
+
+    def test_status_campo_cero_sin_backward(self, tmp_path: Path) -> None:
+        """run_status devuelve referenced_not_fetched=0 sin backward chaining."""
+        from bib2graph.cli.commands.status import run_status
+        from bib2graph.corpus import Corpus
+        from bib2graph.stores.duckdb import DuckDBStore
+
+        store_path = tmp_path / "lib.duckdb"
+        row = _base_row("P1")
+        table = pa.Table.from_pylist([row], schema=CORPUS_SCHEMA)
+        corpus = Corpus.from_arrow(table)
+        store = DuckDBStore(store_path)
+        store.persist(corpus)
+        store.close()
+
+        data = run_status(store_path)
+        assert data.get("referenced_not_fetched", 0) == 0
+
+
+# ---------------------------------------------------------------------------
+# No-regresión forward
+# ---------------------------------------------------------------------------
+
+
+class TestForwardNoRegression:
+    """chain(forward) sigue materializando works reales al corpus."""
+
+    def test_forward_materializa_en_corpus(self) -> None:
+        """Forward chaining: los candidatos SÍ van al corpus (no cambia)."""
+
+        class TrackingSource:
+            def fetch_citing_batch(
+                self, ids: list[str], *, max_per_paper: int | None = None
+            ) -> dict[str, list[str]]:
+                return {"W1": ["W9999"]}
+
+        rows = [_base_row("P1", openalex_id="W1", curation_status="candidate")]
+        corpus = _make_corpus(*rows)
+        forager = Forager(TrackingSource(), depth=1)  # type: ignore[arg-type]
+        ranked = forager.chain(corpus, direction="forward")
+
+        # Forward: el corpus tiene el candidato
+        cand_rows = ranked.corpus.to_arrow().to_pylist()
+        assert len(cand_rows) == 1, (
+            f"Forward chaining debe materializar 1 candidato, hay {len(cand_rows)}"
+        )
+        # observed_refs está vacío (solo backward genera observed_refs)
+        assert ranked.observed_refs == []
+
+    def test_forward_corpus_hash_crece(self) -> None:
+        """Tras forward chaining, el corpus crece y el hash cambia."""
+
+        class TrackingSource:
+            def fetch_citing_batch(
+                self, ids: list[str], *, max_per_paper: int | None = None
+            ) -> dict[str, list[str]]:
+                return {"W1": ["W9999"]}
+
+        rows = [_base_row("P1", openalex_id="W1")]
+        corpus = _make_corpus(*rows)
+        hash_antes = corpus._backend.corpus_hash()
+
+        forager = Forager(TrackingSource(), depth=1)  # type: ignore[arg-type]
+        ranked = forager.chain(corpus, direction="forward")
+        merged = corpus.merge(ranked.corpus)
+
+        hash_despues = merged._backend.corpus_hash()
+        assert hash_antes != hash_despues, (
+            "El corpus_hash debe cambiar tras forward chaining (se agregó un candidato)"
+        )

--- a/tests/unit/test_foraging.py
+++ b/tests/unit/test_foraging.py
@@ -30,7 +30,6 @@ Marcador: ``unit`` (sin red, sin I/O real).
 
 from __future__ import annotations
 
-import json
 from typing import Any
 from unittest.mock import MagicMock
 
@@ -306,8 +305,13 @@ class TestForagerBackward:
         assert isinstance(ranked, RankedCandidates)
         assert len(ranked.ranking) == 2
 
-    def test_candidatos_marcados_correctamente(self) -> None:
-        """Los candidatos tienen is_seed=False, candidate, provenance hop=1."""
+    def test_candidatos_backward_en_observed_refs(self) -> None:
+        """Backward chaining: IDs observados van a observed_refs, NO al corpus (#54).
+
+        Opción B: los candidatos backward no se materializan como filas-fantasma.
+        El ranking sigue presente; los IDs salen por observed_refs para persistirse
+        en referenced_but_not_fetched.
+        """
         rows = [_base_row("P1", references_id=["REF_A"])]
         corpus = _make_corpus(*rows)
 
@@ -315,19 +319,16 @@ class TestForagerBackward:
         forager = Forager(source, depth=1)
         ranked = forager.chain(corpus, direction="backward")
 
+        # El corpus NO tiene filas-fantasma backward
         cand_table = ranked.corpus.to_arrow().to_pylist()
-        assert len(cand_table) == 1
-        cand = cand_table[0]
-
-        assert cand["is_seed"] is False
-        assert cand["curation_status"] == "candidate"
-
-        provenance = json.loads(cand["provenance"])
-        assert isinstance(provenance, list)
-        assert len(provenance) >= 1
-        event = provenance[0]
-        assert event["chaining_hop"] == 1
-        assert "backward" in event["source"]
+        assert len(cand_table) == 0, (
+            "Backward chaining no debe materializar filas en corpus (#54)"
+        )
+        # Los IDs backward van a observed_refs
+        assert "REF_A" in ranked.observed_refs
+        # El ranking sigue presente (la señal de scent es útil)
+        assert len(ranked.ranking) == 1
+        assert ranked.ranking[0][0] == "REF_A"
 
     def test_chain_no_muta_corpus_entrada(self) -> None:
         """chain() no muta el corpus de entrada."""

--- a/tests/unit/test_r3_commands_domain.py
+++ b/tests/unit/test_r3_commands_domain.py
@@ -92,7 +92,10 @@ def _make_noop_transport() -> Any:
 
 
 def _make_empty_forage_result() -> Any:
-    """Resultado de foraging vacío compatible con run_chain (Forager.chain mock)."""
+    """Resultado de foraging vacío compatible con run_chain (Forager.chain mock).
+
+    Incluye ``observed_refs`` (campo #54) para que run_chain no falle al accederlo.
+    """
     from bib2graph.corpus import Corpus
 
     empty = Corpus.from_arrow(
@@ -105,6 +108,7 @@ def _make_empty_forage_result() -> Any:
     class _FakeResult:
         corpus = empty
         ranking: ClassVar[list[Any]] = []
+        observed_refs: ClassVar[list[str]] = []
 
     return _FakeResult()
 


### PR DESCRIPTION
Cierra **#54** — el footgun invisible que tus pruebas manuales destaparon (~mitad del corpus eran filas `[candidate:W...]` vacías que contaminaban corpus y `corpus_hash`).

**Opción B (tu decisión):** el backward observa sin materializar.
- `chain(backward)` → IDs por `RankedCandidates.observed_refs` (no al corpus); ranking sobrevive.
- Tabla hermana **`referenced_but_not_fetched`** (patrón `loop_state_log`) en ambos backends, copiada en snapshot, fuera del `corpus_hash`.
- `b2g status` → `referenced_not_fetched`; `b2g chain` → `observed_refs_count`.
- Materializador on-demand diferido a **#71**.

verifier **PASA** (636 tests; forward sin regresión; corpus_hash limpio). **Enmienda ADR 0020** reconoce que el 'no contaminan' original era falso. ⚠️ El verifier confirmó que el **forward arrastra el mismo footgun** → abierto en **#78** (no scope de #54).