### PR TITLE
fix(foraging): forward chaining materializa metadata real (#78)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@
   El **CLI `b2g` es real** —paquete `cli/` con 17 subcomandos en `cli/commands/`, no un
   placeholder (el 16° `b2g networks` es la capa declarativa YAML del Hito 9; el 17° `b2g restore`
   rehidrata un corpus curado sin red, Ciclo 9a, abajo)—.
-  **636 tests verdes** (mypy/ruff limpios; el núcleo importa sin `duckdb`). Entre las
+  **645 tests verdes** (mypy/ruff limpios; el núcleo importa sin `duckdb`). Entre las
   redes, la **composición de comunidades es exportable**: `networks/cluster_table` (función pura)
   resume cada comunidad de una red de paper en una fila y `b2g build` la escribe como `clusters.csv`
   (#31, AS-BUILT 2026-06-17; ver `docs/API.md` §7.2). **`b2g snapshot`/`b2g export` resuelven por
@@ -97,6 +97,17 @@
   trayendo los citantes de las semillas aceptadas vía `OpenAlexSource.fetch_citing_batch` (batcheo OR
   ≤50 con presupuesto por semilla) y los une (idempotente, sin crecer el corpus). `b2g enrich` con
   `--max-citing` (tope por semilla); `Networks.quick` → 4 o 5 redes según haya `cited_by_id`.
+- **Forward chaining materializa metadata REAL** (#78, 2026-06-17, AS-BUILT CERRADO): el forward del
+  `Forager` (`b2g chain`) **ya no persiste placeholders `[candidate:W...]`** — materializa filas reales
+  (título/año/autores). Causa raíz: `fetch_citing_batch` traía la metadata completa (`_FIELDS`) y la
+  descartaba; el fix A1 (cero red extra) la conserva vía el método nuevo
+  **`OpenAlexSource.fetch_citing_batch_with_works(ids, *, max_per_paper) -> (attribution, works_map)`**
+  (`fetch_citing_batch` queda intacto, thin wrapper). `_build_forward_candidate_row` eliminado; `_work_to_row`
+  ganó `chaining_hop`/`source_tag` (defaults backward-compat). **Asimetría deliberada** con el backward
+  (#54): el backward observa sin materializar, el forward materializa (citantes pocos, acotados, se curan,
+  metadata ya en la request). Con #78, el materializador on-demand #71 queda **solo para backward**.
+  **645 tests verdes**, verifier PASA. Ver `docs/API.md` §2 (`fetch_citing_batch_with_works`)/§5 y ADR
+  [0020](docs/decisiones/0020-metodo-forrajeo-scent-filtros-reject.md) §AS-BUILT #78.
 - **Backward chaining sin placeholders** (#54, 2026-06-17): el backward del `Forager`
   (`b2g chain`) **ya no persiste filas-fantasma `[candidate:W...]` en el corpus** (revierte el
   comportamiento de Hito 5 — la promesa de "no contaminan" era **falsa**: los stubs llegaron a ser
@@ -105,8 +116,7 @@
   **`referenced_but_not_fetched`** (`backends/base.py` Protocol + `DuckDBBackend`/`InMemoryBackend`:
   `add_referenced_refs`/`referenced_refs_count`/`referenced_refs`), **fuera del `corpus_hash`** (arregla
   la contaminación previa). `b2g status` suma `referenced_not_fetched`; `b2g chain` suma
-  `observed_refs_count`. **El forward arrastra el MISMO footgun** (placeholder de título), abierto como
-  **#78** — NO está limpio. Materializador on-demand diferido a #71. **636 tests verdes.** Ver
+  `observed_refs_count`. **El forward arrastraba el MISMO footgun**, **cerrado en #78** (arriba). Ver
   `docs/API.md` §5/§4 y ADR [0020](docs/decisiones/0020-metodo-forrajeo-scent-filtros-reject.md)
   §AS-BUILT #54.
 - **Forward chaining del `Forager` batcheado** (#21, 2026-06-16): el forward del `Forager`

--- a/docs/API.md
+++ b/docs/API.md
@@ -762,6 +762,13 @@ def load_equation_spec(path: str | Path) -> EquationSpec:
 | `ScieloSource` / `RedalycSource` / `LaReferenciaSource` | futuro | Fuentes regionales, mínimo universal. Declaradas, no implementadas (ADR 0018). |
 | `RisSource` / `CsvSource` | futuro | No implementados. |
 
+> **AS-BUILT #78 (2026-06-17) — el forward materializa metadata REAL (ADR
+> [0020](decisiones/0020-metodo-forrajeo-scent-filtros-reject.md) §AS-BUILT #78).** Se agrega
+> `OpenAlexSource.fetch_citing_batch_with_works` (abajo): el forward chaining (§5) deja de persistir
+> placeholders `[candidate:W...]` y materializa filas reales conservando la metadata que
+> `fetch_citing_batch` ya traía y descartaba (**cero red extra**). `fetch_citing_batch` queda intacto
+> (thin wrapper). Gate verde, 645 tests.
+
 **Capacidades de `OpenAlexSource` fuera del Protocol `Source`** (específicas del backbone, no
 contrato universal; las consumen el `Forager` y el `Enricher`):
 
@@ -773,7 +780,18 @@ contrato universal; las consumen el `Forager` y el `Enricher`):
   página a página** (cruza `referenced_works` del citante con el set objetivo, por short-id). Con
   **presupuesto por semilla**: corta la paginación cuando **todas** las semillas del lote alcanzan
   `max_per_paper` (acota el *fetch*, no solo la columna; **sin starvation** entre semillas; mata el
-  N+1 diferido de R5). Lo consume el `OpenAlexEnricher` (§3) para poblar `cited_by_id`.
+  N+1 diferido de R5). Lo consume el `OpenAlexEnricher` (§3) para poblar `cited_by_id`. **AS-BUILT
+  #78 (2026-06-17): firma y contrato INTACTOS** —sigue devolviendo solo el mapeo de atribución— pero
+  internamente es un **thin wrapper** sobre `_fetch_citing_pages` que **descarta `works_map`** (la
+  metadata que ya viaja en la misma request). El Enricher 8b no cambia.
+- **`fetch_citing_batch_with_works(ids, *, max_per_paper) -> tuple[dict[seed_id, list[citer_id]], dict[citer_id, work]]`**
+  (#78, 2026-06-17, Forager forward chaining): la **variante que conserva la metadata**. Misma red,
+  mismo batcheo/atribución/presupuesto que `fetch_citing_batch` (comparten `_fetch_citing_pages`),
+  pero devuelve además el `works_map` (`citer_id → work JSON con _FIELDS`) que `fetch_citing_batch`
+  tira. **Cero red extra**: la metadata ya venía en la query de citantes y antes se descartaba. La
+  consume `Forager._fetch_forward` para materializar filas REALES (título/año/autores) en vez de
+  placeholders `[candidate:W...]`. Ver §5 y ADR
+  [0020](decisiones/0020-metodo-forrajeo-scent-filtros-reject.md) §AS-BUILT #78.
 - **`fetch_dois_for(ids) -> dict`** (Hito 8a): resuelve `references_id`→DOI batcheando por OR (lotes
   ≤100, `select=id,doi`).
 - **`fetch_works_by_ids(ids) -> Corpus`** (#55): materializa works arbitrarios desde sus IDs OpenAlex,
@@ -782,8 +800,11 @@ contrato universal; las consumen el `Forager` y el `Enricher`):
   inexistentes se **omiten sin error**; orden **determinista** (filas ordenadas por `id` canónico);
   lista vacía → `Corpus` vacío **sin tocar la red**. Es el primitivo que materializa lo observado por
   el backward chaining (ver #54). Reusa `_work_to_row` parametrizado (`is_seed`/`action`), que centraliza
-  el mapeo JSON→Arrow para `seed`/`fetch_citing`/`fetch_works_by_ids` (sin duplicar). *(Validado contra
-  OpenAlex real vía test `@pytest.mark.network`.)*
+  el mapeo JSON→Arrow para `seed`/`fetch_citing`/`fetch_works_by_ids`/forward chaining (sin duplicar).
+  **AS-BUILT #78 (2026-06-17): `_work_to_row` ganó `chaining_hop: int | None = None` y
+  `source_tag: str = "openalex"`** (defaults backward-compat → los callers viejos no cambian); el
+  forward chaining lo invoca con `chaining_hop=1, source_tag="chaining:forward"` para materializar
+  citantes reales. *(Validado contra OpenAlex real vía test `@pytest.mark.network`.)*
 
 **Reporte de cobertura/calidad** (concepto declarado, concreto **v0.2+**; ADR 0018): por
 seed/source, mide % de refs resueltas, % con DOI, distribución idioma/región y completitud del
@@ -981,6 +1002,16 @@ El comando `b2g status` consume `loop_state()`/`loop_round()`/`available_transit
 > El **forward arrastra el mismo footgun** (placeholder de título), abierto como **#78** — NO está
 > limpio. Materializador on-demand diferido a #71. Gate verde, 636 tests.
 
+> **AS-BUILT #78 (2026-06-17) — ADR [0020](decisiones/0020-metodo-forrajeo-scent-filtros-reject.md)
+> §AS-BUILT #78:** el **forward chaining ya NO persiste placeholders** `[candidate:W...]` — materializa
+> **filas REALES** (título/año/autores) con la metadata que `fetch_citing_batch` ya traía de la red y
+> descartaba (opción A1, **cero red extra**, vía el método nuevo `fetch_citing_batch_with_works`, §2).
+> `_build_forward_candidate_row` eliminado. **Asimetría deliberada** (no incoherencia): el backward
+> *observa sin materializar* (refs numerosas, no curadas, sin metadata local → `referenced_but_not_fetched`),
+> el forward *materializa* (citantes pocos, acotados por cap, **se curan**, metadata ya en la request).
+> Regla común: **el corpus nunca contiene placeholders**. Con esto, el materializador on-demand #71
+> queda **solo para backward**. Gate verde, **645 tests**, verifier PASA.
+
 El *information scent* es **estructura bibliométrica de cita con el corpus** (ADR
 [0020](decisiones/0020-metodo-forrajeo-scent-filtros-reject.md), AS-BUILT R4). Es una **función pura**
 sobre el primitivo `collect_item_to_papers` (índice `{ref → corpus-papers que lo citan}`):
@@ -1036,7 +1067,8 @@ class GrowthPreview(BaseModel):
 
 class RankedCandidates(BaseModel):
     corpus: Corpus                     # SOLO los candidatos nuevos (no mergeado con el corpus semilla).
-                                       # Forward: materializa filas (placeholder de título, ver #78).
+                                       # Forward (#78): materializa filas con metadata REAL (título/año/
+                                       # autores), NO placeholders — vía fetch_citing_batch_with_works.
                                        # Backward (#54): NO materializa filas — observa, ver observed_refs.
     ranking: list[tuple[str, float]]   # (id, information_scent), desc scent / asc id
     observed_refs: list[str] = []      # AS-BUILT #54 (2026-06-17): IDs observados por el backward SIN
@@ -1086,10 +1118,11 @@ class RankedCandidates(BaseModel):
   backward salen por **`RankedCandidates.observed_refs: list[str]`** (orden de ranking, respeta
   `max_candidates`) y `b2g chain` los persiste en la tabla hermana **`referenced_but_not_fetched`**
   (§4), **fuera** del `corpus` y del `corpus_hash`. La materialización on-demand (rehidratar un
-  observado a fila real vía `fetch_works_by_ids`, #55) está **diferida a #71**. El **forward sí sigue
-  materializando** filas en `.corpus` —y con el MISMO footgun de placeholder de título
-  `[candidate:W...]` (IDs de citantes sin metadata completa): **el forward NO está limpio**, abierto
-  como **#78**—.
+  observado a fila real vía `fetch_works_by_ids`, #55) está **diferida a #71** (con #78 cerrado, #71
+  queda **solo para backward**). El **forward sí materializa** filas en `.corpus` —y **con #78
+  (2026-06-17) lo hace con metadata REAL** (título/año/autores), **ya no** con placeholders
+  `[candidate:W...]`: la metadata viaja en la misma request de citantes (`fetch_citing_batch_with_works`,
+  §2). Asimetría deliberada: el backward observa, el forward materializa (ver §AS-BUILT #78 arriba).
 - **`preview` y `chain` no mutan** el corpus de entrada (semántica de valor).
 
 ---
@@ -1551,7 +1584,7 @@ prev = forager.preview(seed.corpus)                     # backward exacto; forwa
 print(prev.estimated_new, prev.forward_requires_fetch)  # p. ej. 142  True
 ranked = forager.chain(seed.corpus)                     # forward fetchea citantes
 # AS-BUILT #54: el backward observa sin materializar → ranked.observed_refs (no van a ranked.corpus);
-# el forward sí materializa filas (placeholder de título, #78). Ver §5.
+# AS-BUILT #78: el forward materializa filas con metadata REAL (no placeholders). Ver §5.
 
 # 3') Curar lo forrajeado, normalizar y aplicar el thesaurus multilingüe determinista
 corpus = seed.corpus.merge(ranked.corpus).accept(ids=[...]).reject(ids=[...])

--- a/docs/decisiones/0020-metodo-forrajeo-scent-filtros-reject.md
+++ b/docs/decisiones/0020-metodo-forrajeo-scent-filtros-reject.md
@@ -341,3 +341,68 @@ red".
 
 > **Decidido por:** AS-BUILT verificado del #54 (2026-06-17, rama `fix/backward-chaining-no-placeholders`);
 > gate verde, 636 tests, verifier PASA. Ver `API.md` §5 (`observed_refs`) y §4 (`referenced_but_not_fetched`).
+
+## AS-BUILT — 2026-06-17 (#78: el forward materializa metadata REAL; cierra el footgun de placeholder forward)
+
+> Seguimiento directo del AS-BUILT #54 (que reconoció el footgun forward como abierto). El cuerpo del
+> ADR (decisión **B**) describía el forward como dirección que **materializa filas** en el corpus, y
+> el AS-BUILT inicial las creaba con **título placeholder `[candidate:W...]`** (IDs de citantes sin
+> metadata). **Esa materialización era defectuosa** y este AS-BUILT la corrige; **no reescribe** el
+> cuerpo histórico (queda como rastro). Gate verde, **645 tests**; verifier PASA. Rama
+> `fix/forward-chaining-materialize`. **No reabre la decisión de método de forrajeo** (backward
+> puro/forward red, scent, filtros): solo corrige *cómo* el forward materializa la metadata — por eso
+> es enmienda al 0020, su dominio, y no un ADR nuevo.
+
+### El forward también arrastraba el footgun — causa raíz: la metadata se traía y se descartaba
+
+El verifier de #54 confirmó que el forward repetía el problema del backward: `_build_forward_candidate_row`
+materializaba filas con título placeholder `[candidate:W...]`. La causa raíz, sin embargo, **no** era
+falta de datos: `fetch_citing_batch` **ya pedía `_FIELDS` (metadata completa)** a OpenAlex y luego
+**los descartaba**, devolviendo solo el mapeo de atribución `dict[str, list[str]]`. La metadata real
+(título/año/autores) **ya viajaba en la misma request de red** y se tiraba.
+
+### Opción A1 implementada — conservar la metadata que ya viaja (cero red extra)
+
+El forward **ya NO persiste placeholders**; materializa **filas reales** (título/año/autores) **sin una
+sola request adicional**:
+
+- Se extrajo `_fetch_citing_pages` (privado, comparte paginación/atribución/presupuesto-por-semilla)
+  que devuelve `(attribution, works_map)`.
+- **`fetch_citing_batch(ids, *, max_per_paper) -> dict[str, list[str]]` queda como thin wrapper con su
+  firma y contrato INTACTOS** (descarta `works_map`) → el `OpenAlexEnricher` (8b, §3 de API.md) **no
+  se rompe**.
+- **Método público nuevo `OpenAlexSource.fetch_citing_batch_with_works(ids, *, max_per_paper) ->
+  (attribution, works_map)`**, que el `_fetch_forward` del Forager consume.
+- `_work_to_row` ganó params `chaining_hop: int | None = None` y `source_tag: str = "openalex"`
+  (defaults backward-compat; los callers viejos —`seed`/`fetch_citing`/`fetch_works_by_ids`— no
+  cambian). El forward llama `_work_to_row(work, is_seed=False, chaining_hop=1,
+  source_tag="chaining:forward")`.
+- `_build_forward_candidate_row` **ELIMINADO**.
+
+**Garantía verificada:** con `OpenAlexSource` real, todo citante atribuido está en `works_map` →
+nunca cae al fallback-placeholder (ese fallback solo aplica a sources sintéticos de test).
+
+### La regla común y la asimetría forward/backward (no es incoherencia)
+
+La **regla común** que mata el footgun en ambas direcciones: **el corpus nunca contiene placeholders
+`[candidate:W...]`**. Las direcciones la cumplen de forma distinta, y esa asimetría es **deliberada**,
+no un descuido:
+
+- **Backward observa sin materializar** (#54): las referencias son **numerosas**, **no se curan
+  activamente** y **su metadata no viaja** en la request local del seed (solo IDs en `references_id`).
+  Materializarlas inflaría el corpus con miles de filas-fantasma → se registran en la tabla hermana
+  `referenced_but_not_fetched` y se rehidratan on-demand (#71).
+- **Forward materializa** (#78): los citantes son **pocos** (acotados por `max_citing_per_paper`), **se
+  curan** (el humano los acepta/rechaza), y **su metadata ya viene** en la misma request de red de
+  `fetch_citing_batch_with_works`. Materializarlos con datos reales es lo correcto y es gratis.
+
+Por eso #71 (materializador on-demand) queda, con #78 en A, **solo para backward**: el forward ya no
+necesita rehidratar nada.
+
+**Lo que NO cambia:** backward = co-citación con el corpus (puro/local), forward = citación directa,
+filtros `rejected` (C), `apply_thesaurus` (D), `depth=1`, desempate por `id`, "solo el Forager toca la
+red", y el contrato de `fetch_citing_batch` (intacto).
+
+> **Decidido por:** AS-BUILT verificado del #78 (2026-06-17, rama `fix/forward-chaining-materialize`);
+> gate verde, 645 tests, verifier PASA. Seguimiento de #54/#55. Ver `API.md` §2
+> (`fetch_citing_batch_with_works`) y §5 (forward materializa metadata real).

--- a/src/bib2graph/foraging/forager.py
+++ b/src/bib2graph/foraging/forager.py
@@ -19,6 +19,10 @@ Solo él toca la red (a través del ``Source`` inyectado).  El núcleo de
 scent es puro.  ``explain_candidate`` fue **eliminado** (R4, ADR 0022).
 ``_build_backward_candidate_row`` fue **eliminado** (#54): ya no se fabrica
 ninguna fila-fantasma para candidatos backward.
+``_build_forward_candidate_row`` fue **eliminado** (#78, opción A1): el forward
+materializa metadata real vía ``fetch_citing_batch_with_works`` +
+``_work_to_row`` (cero red extra: los works viajan en las mismas páginas de
+atribución).
 
 ``depth > 1`` lanza ``NotImplementedError`` claro (decisión e=A, ADR 0008).
 
@@ -42,14 +46,15 @@ from typing import Any
 
 import pyarrow as pa
 
-from bib2graph.constants import Col, CurationStatus
+from bib2graph.constants import Col
 from bib2graph.corpus import Corpus, _rows_with_ids
 from bib2graph.foraging.base import Direction, GrowthPreview, RankedCandidates
 from bib2graph.foraging.scent import (
     compute_backward_scent,
     rank_candidates,
 )
-from bib2graph.schemas import CORPUS_SCHEMA, ProvenanceEvent
+from bib2graph.schemas import CORPUS_SCHEMA
+from bib2graph.sources.openalex import _work_to_row
 
 
 def _make_empty_corpus() -> Corpus:
@@ -86,65 +91,6 @@ def _extract_seed_ids(corpus_rows: list[dict[str, Any]]) -> list[str]:
         if row.get(Col.IS_SEED) and row.get(Col.OPENALEX_ID):
             result.append(str(row[Col.OPENALEX_ID]))
     return result
-
-
-def _build_forward_candidate_row(
-    citer_id: str,
-    *,
-    seed_ids_cited: list[str],
-    fetched_at: str,
-) -> dict[str, Any]:
-    """Construye una fila mínima para un candidato forward.
-
-    A diferencia del candidato backward (que tiene solo el id), el candidato
-    forward incorpora en ``references_id`` los IDs de las semillas que él cita
-    (atribuidos por ``fetch_citing_batch``).  Esto permite calcular el score
-    por intersección con ``corpus_ids`` sin re-fetchear los datos de red.
-
-    Args:
-        citer_id: ID corto de OpenAlex del citante (p. ej. ``W99999``).
-        seed_ids_cited: IDs de las semillas del corpus que este citante cita,
-            según la re-atribución de ``fetch_citing_batch``.
-        fetched_at: Timestamp ISO del fetch.
-
-    Returns:
-        Dict con las columnas mínimas del schema canónico.
-    """
-    provenance_event = ProvenanceEvent(
-        action="fetched",
-        equation_id=None,
-        chaining_hop=1,
-        source="chaining:forward",
-        fetched_at=fetched_at,
-        decided_by=None,
-        decided_at=None,
-    )
-    return {
-        Col.OPENALEX_ID: citer_id,
-        Col.DOI: None,
-        Col.TITLE: f"[candidate:{citer_id}]",
-        Col.YEAR: None,
-        Col.ABSTRACT: None,
-        Col.SOURCE: None,
-        Col.LANGUAGE: None,
-        Col.PUBLISHER: None,
-        Col.RESEARCH_AREAS: None,
-        Col.IS_SEED: False,
-        Col.CURATION_STATUS: CurationStatus.CANDIDATE,
-        Col.PROVENANCE: ProvenanceEvent.dump_list([provenance_event]),
-        Col.AUTHORS_RAW: None,
-        Col.AUTHORS_ID: None,
-        Col.AUTHORS_AFFILIATIONS: None,
-        Col.KEYWORDS_RAW: None,
-        Col.KEYWORDS_ID: None,
-        Col.INSTITUTIONS_RAW: None,
-        Col.INSTITUTIONS_ID: None,
-        # references_id incluye los seeds citados para que compute_forward_scent
-        # pueda calcular el score por intersección con corpus_ids.
-        Col.REFERENCES_ID: seed_ids_cited or None,
-        Col.REFERENCES_DOI: None,
-        Col.CITED_BY_ID: None,
-    }
 
 
 class Forager:
@@ -382,16 +328,24 @@ class Forager:
     ) -> tuple[dict[str, float], dict[str, dict[str, Any]]]:
         """Trae citantes via batcheo y calcula scent forward.
 
-        Usa ``fetch_citing_batch`` del source (batcheo OR ≤50 IDs por request,
-        presupuesto por semilla, retry/backoff incluidos) en lugar del loop N+1.
+        Usa ``fetch_citing_batch_with_works`` del source (batcheo OR ≤50 IDs
+        por request, presupuesto por semilla, retry/backoff incluidos) para
+        materializar filas con metadata real (título/año/autores/etc.) en vez
+        de placeholders ``[candidate:W...]`` (#78, opción A1).  CERO red extra:
+        los works ya viajan en las mismas páginas que se usan para la atribución.
+
         Opera sobre todas las semillas (``is_seed=True``), independientemente
         del ``curation_status`` — el chaining corre antes de la curación.
 
-        El scent forward se computa desde la re-atribución que ya realiza
-        ``fetch_citing_batch``: para cada citante, los seed IDs que él cita
-        están en el dict resultado; con eso se construye una fila mínima con
-        ``references_id=seed_ids_citados`` y el score se calcula por
-        intersección con ``corpus_ids``.
+        El scent forward se calcula directamente desde la re-atribución que
+        devuelve ``fetch_citing_batch_with_works``: para cada citante, los
+        seed IDs que cita ya están en el ``attribution`` dict.  El score es
+        la intersección de esos seeds con ``corpus_ids`` (trivial: seed_ids ⊆
+        corpus_ids porque son los openalex_id de las semillas).
+
+        Cada fila candidata se construye con ``_work_to_row`` (el mapeador
+        canónico), con ``is_seed=False``, ``chaining_hop=1`` y
+        ``source_tag='chaining:forward'``.
 
         Args:
             corpus_rows: Filas del corpus actual.
@@ -399,8 +353,8 @@ class Forager:
 
         Returns:
             Tupla ``(scent_map, candidate_rows)`` donde ``candidate_rows``
-            tiene la fila mínima de cada candidato forward (con
-            ``references_id`` = seeds citadas, para el scent).
+            tiene la fila completa (con metadata real) de cada candidato
+            forward con score > 0.
 
         Raises:
             AttributeError: Si el ``source`` no tiene ``fetch_citing_batch``.
@@ -418,7 +372,7 @@ class Forager:
             return {}, {}
 
         # corpus_ids: ids y openalex_ids de todos los papers del corpus
-        # (para compute_forward_scent y para excluir candidatos ya presentes)
+        # (para excluir candidatos ya presentes y calcular el score)
         corpus_ids: set[str] = set()
         for row in corpus_rows:
             id_val = row.get(Col.ID)
@@ -428,31 +382,43 @@ class Forager:
             if oa_id_val:
                 corpus_ids.add(str(oa_id_val))
 
-        # Batcheo: fetch_citing_batch hace ≤50 IDs por request, presupuesto
-        # por semilla y retry/backoff.  Devuelve {seed_id: [citer_id]}.
-        # tqdm es dependencia del núcleo; el import perezoso evita efectos de módulo.
+        # Batcheo: trae atribución Y works JSON en un solo ciclo de páginas.
+        # tqdm es dependencia del núcleo; import perezoso para evitar efectos de módulo.
+        use_with_works = hasattr(self._source, "fetch_citing_batch_with_works")
+        citing_dict: dict[str, list[str]]
+        works_map: dict[str, dict[str, Any]]
+
         try:
             from tqdm import tqdm as _tqdm
 
-            # Barra de progreso: una iteración por llamada batch (no por semilla)
             with _tqdm(
                 total=1,
                 desc="forward chaining",
                 unit="lote",
                 leave=False,
             ) as pbar:
+                if use_with_works:
+                    citing_dict, works_map = self._source.fetch_citing_batch_with_works(
+                        seed_ids, max_per_paper=self._max_citing_per_paper
+                    )
+                else:
+                    citing_dict = self._source.fetch_citing_batch(
+                        seed_ids, max_per_paper=self._max_citing_per_paper
+                    )
+                    works_map = {}
+                pbar.update(1)
+        except ImportError:
+            if use_with_works:
+                citing_dict, works_map = self._source.fetch_citing_batch_with_works(
+                    seed_ids, max_per_paper=self._max_citing_per_paper
+                )
+            else:
                 citing_dict = self._source.fetch_citing_batch(
                     seed_ids, max_per_paper=self._max_citing_per_paper
                 )
-                pbar.update(1)
-        except ImportError:
-            # tqdm no disponible: continuar sin barra de progreso
-            citing_dict = self._source.fetch_citing_batch(
-                seed_ids, max_per_paper=self._max_citing_per_paper
-            )
+                works_map = {}
 
         # Invertir: {citer_id → [seed_ids que este citante cita]}
-        # para construir las filas mínimas y calcular el scent.
         citer_to_seeds: dict[str, list[str]] = {}
         for seed_id, citer_ids in citing_dict.items():
             for citer_id in citer_ids:
@@ -462,21 +428,67 @@ class Forager:
         if not citer_to_seeds:
             return {}, {}
 
-        # Construir filas mínimas de candidatos (con references_id = seeds citadas)
-        # y calcular scent forward directamente desde la re-atribución.
-        # score(Y) = |{ref ∈ Y.references_id : ref ∈ corpus_ids}|
-        # Como seed_ids ⊆ corpus_ids (openalex_id de las semillas), la
-        # intersección es trivial: score = len(seed_ids_citados por Y).
+        # Construir filas con metadata real (vía _work_to_row) cuando el source
+        # proveyó los works; el score es len(seeds_citados ∩ corpus_ids).
         candidate_rows: dict[str, dict[str, Any]] = {}
         scent_map: dict[str, float] = {}
         for citer_id, seeds_cited in citer_to_seeds.items():
             score = float(sum(1 for s in seeds_cited if s in corpus_ids))
             if score > 0:
                 scent_map[citer_id] = score
-                candidate_rows[citer_id] = _build_forward_candidate_row(
-                    citer_id,
-                    seed_ids_cited=seeds_cited,
-                    fetched_at=fetched_at,
-                )
+                work = works_map.get(citer_id)
+                if work is not None:
+                    # Metadata real disponible: construir fila canónica completa.
+                    row = _work_to_row(
+                        work,
+                        equation_id="chaining:forward",
+                        fetched_at=fetched_at,
+                        is_seed=False,
+                        action="fetched",
+                        chaining_hop=1,
+                        source_tag="chaining:forward",
+                    )
+                else:
+                    # Fallback (source sin fetch_citing_batch_with_works): fila
+                    # con solo las seeds citadas en references_id para el score.
+                    # No debería ocurrir con OpenAlexSource (#78 A1 requiere works).
+                    from bib2graph.schemas import ProvenanceEvent
+
+                    prov = ProvenanceEvent(
+                        action="fetched",
+                        equation_id=None,
+                        chaining_hop=1,
+                        source="chaining:forward",
+                        fetched_at=fetched_at,
+                        decided_by=None,
+                        decided_at=None,
+                    )
+                    from bib2graph.constants import CurationStatus
+
+                    row = {
+                        Col.OPENALEX_ID: citer_id,
+                        Col.DOI: None,
+                        Col.TITLE: f"[candidate:{citer_id}]",
+                        Col.YEAR: None,
+                        Col.ABSTRACT: None,
+                        Col.SOURCE: None,
+                        Col.LANGUAGE: None,
+                        Col.PUBLISHER: None,
+                        Col.RESEARCH_AREAS: None,
+                        Col.IS_SEED: False,
+                        Col.CURATION_STATUS: CurationStatus.CANDIDATE,
+                        Col.PROVENANCE: ProvenanceEvent.dump_list([prov]),
+                        Col.AUTHORS_RAW: None,
+                        Col.AUTHORS_ID: None,
+                        Col.AUTHORS_AFFILIATIONS: None,
+                        Col.KEYWORDS_RAW: None,
+                        Col.KEYWORDS_ID: None,
+                        Col.INSTITUTIONS_RAW: None,
+                        Col.INSTITUTIONS_ID: None,
+                        Col.REFERENCES_ID: seeds_cited or None,
+                        Col.REFERENCES_DOI: None,
+                        Col.CITED_BY_ID: None,
+                    }
+                candidate_rows[citer_id] = row
 
         return scent_map, candidate_rows

--- a/src/bib2graph/sources/openalex.py
+++ b/src/bib2graph/sources/openalex.py
@@ -253,6 +253,8 @@ def _work_to_row(
     fetched_at: str,
     is_seed: bool = True,
     action: str = "fetched",
+    chaining_hop: int | None = None,
+    source_tag: str = "openalex",
 ) -> dict[str, Any]:
     """Mapea un objeto JSON de OpenAlex a la fila del schema canónico.
 
@@ -268,6 +270,11 @@ def _work_to_row(
             Default ``True`` (comportamiento histórico para ``seed``/``load``).
         action: Tipo de evento de provenance (``'fetched'``, ``'fetched_by_id'``,
             etc.).  Default ``'fetched'`` (comportamiento histórico).
+        chaining_hop: Profundidad del chaining (1 = primera expansión), o
+            ``None`` si no aplica (seed/load).  Default ``None``.
+        source_tag: Etiqueta de fuente para el evento de provenance.
+            Default ``'openalex'``; usar ``'chaining:forward'`` para el forward
+            chaining.
 
     Returns:
         Dict con todas las columnas del schema canónico.
@@ -337,8 +344,8 @@ def _work_to_row(
     provenance_event = ProvenanceEvent(
         action=action,
         equation_id=equation_id,
-        chaining_hop=None,
-        source="openalex",
+        chaining_hop=chaining_hop,
+        source=source_tag,
         fetched_at=fetched_at,
         decided_by=None,
         decided_at=None,
@@ -850,6 +857,95 @@ class OpenAlexSource:
         assert last_exc is not None
         raise last_exc
 
+    def _fetch_citing_pages(
+        self,
+        ids: list[str],
+        *,
+        max_per_paper: int | None = None,
+    ) -> tuple[dict[str, list[str]], dict[str, dict[str, Any]]]:
+        """Núcleo compartido de paginación y atribución para los citantes en lote.
+
+        Realiza el batcheo OR (≤50 IDs por request), la paginación con cursor,
+        la atribución semilla-a-semilla y el presupuesto por semilla.  Conserva
+        el objeto ``work`` completo de cada citante único, de modo que los
+        llamadores pueden elegir descartarlo (``fetch_citing_batch``) o
+        aprovecharlo (``fetch_citing_batch_with_works``).
+
+        Args:
+            ids: IDs cortos de OpenAlex ya normalizados (p. ej. ``["W111"]``).
+            max_per_paper: Presupuesto máximo de citantes por semilla.
+                ``None`` = sin tope.
+
+        Returns:
+            Tupla ``(attribution, works_map)`` donde:
+            - ``attribution``: ``{seed_id: [citer_id, ...]}``, orden alfabético,
+              acotado a ``max_per_paper``.
+            - ``works_map``: ``{citer_id: work_json}`` con el objeto JSON completo
+              (campos ``_FIELDS``) de cada citante distinto.  El último objeto
+              visto gana si el mismo citante aparece en varias páginas (idempotente
+              porque el JSON es el mismo).
+        """
+        batch_size = 50  # límite empírico de OpenAlex para OR en cites:
+
+        result: dict[str, list[str]] = {}
+        works_map: dict[str, dict[str, Any]] = {}
+
+        for start in range(0, len(ids), batch_size):
+            lote = ids[start : start + batch_size]
+            lote_set = set(lote)
+            batch_acc: dict[str, set[str]] = {tid: set() for tid in lote}
+
+            filter_str = "cites:" + "|".join(lote)
+
+            cursor: str = "*"
+            with self._client() as client:
+                while True:
+                    if max_per_paper is not None and all(
+                        len(batch_acc[tid]) >= max_per_paper for tid in lote
+                    ):
+                        break
+
+                    page_works = self._fetch_page_with_retry(
+                        client, filter_str, cursor=cursor
+                    )
+                    if page_works is None:
+                        break  # pragma: no cover
+
+                    works_list, next_cursor = page_works
+
+                    for work in works_list:
+                        citer_oa_id = _oa_id_short(work.get("id"))
+                        if not citer_oa_id:
+                            continue
+                        ref_urls: list[str] = work.get("referenced_works") or []
+                        citer_refs: set[str] = {
+                            short
+                            for r in ref_urls
+                            if r and (short := _oa_id_short(r)) is not None
+                        }
+                        for tid in lote_set & citer_refs:
+                            if (
+                                max_per_paper is None
+                                or len(batch_acc[tid]) < max_per_paper
+                            ):
+                                batch_acc[tid].add(citer_oa_id)
+                        # Conservar el work JSON (último visto gana, es idempotente)
+                        works_map[citer_oa_id] = work
+
+                    if not next_cursor or not works_list:
+                        break
+                    cursor = next_cursor
+
+            for tid in lote:
+                existing = set(result.get(tid) or [])
+                merged = existing | batch_acc[tid]
+                if max_per_paper is not None:
+                    result[tid] = sorted(merged)[:max_per_paper]
+                else:
+                    result[tid] = sorted(merged)
+
+        return result, works_map
+
     def fetch_citing_batch(
         self, ids: list[str], *, max_per_paper: int | None = None
     ) -> dict[str, list[str]]:
@@ -869,6 +965,10 @@ class OpenAlexSource:
         El filtro ``cites:W1|W2`` es un OR válido en la API de OpenAlex: devuelve
         todos los works que citan al menos uno de los IDs listados.
 
+        Thin wrapper sobre ``_fetch_citing_pages`` que descarta el mapa de works
+        para mantener la firma/contrato actual (usado por el ``OpenAlexEnricher``,
+        Hito 8b).
+
         Args:
             ids: Lista de IDs cortos de OpenAlex (p. ej. ``["W111", "W222"]``).
                 Se normalizan a ID corto internamente.
@@ -884,75 +984,44 @@ class OpenAlexSource:
         """
         if not ids:
             return {}
-
         normalized = [_oa_id_short(i) or i for i in ids]
-        batch_size = 50  # límite empírico de OpenAlex para OR en cites:
+        attribution, _ = self._fetch_citing_pages(
+            normalized, max_per_paper=max_per_paper
+        )
+        return attribution
 
-        result: dict[str, list[str]] = {}
+    def fetch_citing_batch_with_works(
+        self, ids: list[str], *, max_per_paper: int | None = None
+    ) -> tuple[dict[str, list[str]], dict[str, dict[str, Any]]]:
+        """Como ``fetch_citing_batch`` pero conserva los objetos JSON completos.
 
-        for start in range(0, len(normalized), batch_size):
-            lote = normalized[start : start + batch_size]
-            lote_set = set(lote)
-            # Acumulador de sets para idempotencia interna (elimina dupes entre páginas)
-            batch_acc: dict[str, set[str]] = {tid: set() for tid in lote}
+        Misma lógica de paginación, atribución y presupuesto que
+        ``fetch_citing_batch``, sin red extra: los works ya vienen en las
+        páginas que se traen para la atribución.  Reutiliza ``_fetch_citing_pages``
+        (no duplica la lógica).
 
-            # Filtro OR: cites:W1|W2 es un OR válido en OpenAlex (devuelve works que
-            # citan al menos uno de los IDs; no requiere repetir el predicado por ID).
-            filter_str = "cites:" + "|".join(lote)
+        Diseñado para el forward chaining del ``Forager`` (#78, opción A1):
+        permite materializar filas con metadata real (título/año/autores) en vez
+        de placeholders ``[candidate:W...]``.
 
-            # Paginar con cursor, atribuyendo página a página con presupuesto por semilla
-            cursor: str = "*"
-            with self._client() as client:
-                while True:
-                    # Verificar si todas las semillas del lote ya están satisfechas
-                    if max_per_paper is not None and all(
-                        len(batch_acc[tid]) >= max_per_paper for tid in lote
-                    ):
-                        break
+        Args:
+            ids: Lista de IDs cortos de OpenAlex (p. ej. ``["W111", "W222"]``).
+                Se normalizan a ID corto internamente.
+            max_per_paper: Presupuesto máximo de citantes por semilla.
+                ``None`` = sin tope.
 
-                    # Fetch con retry/backoff
-                    page_works = self._fetch_page_with_retry(
-                        client, filter_str, cursor=cursor
-                    )
-                    if page_works is None:
-                        # Error irrecuperable tras reintentos (ya propagado)
-                        break  # pragma: no cover
-
-                    works_list, next_cursor = page_works
-
-                    # Atribuir cada citante de la página a los seeds que realmente cita
-                    for work in works_list:
-                        citer_oa_id = _oa_id_short(work.get("id"))
-                        if not citer_oa_id:
-                            continue
-                        ref_urls: list[str] = work.get("referenced_works") or []
-                        citer_refs: set[str] = {
-                            short
-                            for r in ref_urls
-                            if r and (short := _oa_id_short(r)) is not None
-                        }
-                        # Intersección: seeds que este citante realmente cita
-                        for tid in lote_set & citer_refs:
-                            if (
-                                max_per_paper is None
-                                or len(batch_acc[tid]) < max_per_paper
-                            ):
-                                batch_acc[tid].add(citer_oa_id)
-
-                    if not next_cursor or not works_list:
-                        break
-                    cursor = next_cursor
-
-            # Consolidar en el resultado global (orden determinista: alfabético)
-            for tid in lote:
-                existing = set(result.get(tid) or [])
-                merged = existing | batch_acc[tid]
-                if max_per_paper is not None:
-                    result[tid] = sorted(merged)[:max_per_paper]
-                else:
-                    result[tid] = sorted(merged)
-
-        return result
+        Returns:
+            Tupla ``(attribution, works_map)`` donde:
+            - ``attribution``: ``{seed_id: [citer_id, ...]}``, orden alfabético,
+              idéntico al retorno de ``fetch_citing_batch`` con los mismos args.
+            - ``works_map``: ``{citer_id: work_json}`` con el objeto JSON completo
+              (campos ``_FIELDS``: título, año, autores, referencias, etc.) de
+              cada citante distinto traído en las páginas de la atribución.
+        """
+        if not ids:
+            return {}, {}
+        normalized = [_oa_id_short(i) or i for i in ids]
+        return self._fetch_citing_pages(normalized, max_per_paper=max_per_paper)
 
     def _fetch_page_with_retry(
         self,

--- a/tests/unit/test_foraging.py
+++ b/tests/unit/test_foraging.py
@@ -786,3 +786,365 @@ class TestExplainCandidateRetirado:
 
         with pytest.raises(ModuleNotFoundError):
             importlib.import_module("bib2graph.foraging.explain")
+
+
+# ---------------------------------------------------------------------------
+# #78 — Forward chaining materializa metadata real (opción A1)
+# ---------------------------------------------------------------------------
+
+
+def _citing_work_full(
+    citer_oa_id: str,
+    *,
+    cites_ids: list[str],
+    title: str = "Real Title",
+    year: int = 2024,
+    authors: list[str] | None = None,
+) -> dict[str, Any]:
+    """Objeto Work de OpenAlex con todos los campos de ``_FIELDS`` poblados.
+
+    Simula el JSON que devuelve la API de OpenAlex con ``select=_FIELDS``:
+    los mismos campos que ``fetch_citing_batch_with_works`` conserva para
+    que ``_work_to_row`` pueda mapearlos al schema canónico.
+    """
+    authorships: list[dict[str, Any]] = []
+    for i, name in enumerate(authors or ["Autor Uno"]):
+        authorships.append(
+            {
+                "author": {
+                    "id": f"https://openalex.org/A{i + 1}",
+                    "display_name": name,
+                    "orcid": None,
+                },
+                "institutions": [],
+            }
+        )
+    return {
+        "id": f"https://openalex.org/{citer_oa_id}",
+        "doi": f"https://doi.org/10.9999/{citer_oa_id.lower()}",
+        "title": title,
+        "display_name": title,
+        "publication_year": year,
+        "language": "en",
+        "abstract_inverted_index": {"Resumen": [0], "real": [1]},
+        "authorships": authorships,
+        "keywords": [{"id": "https://openalex.org/K1", "display_name": "test kw"}],
+        "referenced_works": [f"https://openalex.org/{oa_id}" for oa_id in cites_ids],
+        "primary_location": {
+            "source": {"display_name": "Journal of Tests", "id": None}
+        },
+        "type": "article",
+    }
+
+
+def _make_batch_transport_full(
+    citing_works: list[dict[str, Any]],
+) -> httpx.MockTransport:
+    """MockTransport que responde a ``cites:`` con works con _FIELDS completos."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        url_str = str(request.url)
+        if "cites" in url_str:
+            payload = {
+                "results": citing_works,
+                "meta": {"next_cursor": None},
+            }
+        else:
+            payload = {"results": [], "meta": {"next_cursor": None}}
+        return httpx.Response(200, json=payload)
+
+    return httpx.MockTransport(handler)
+
+
+class TestForwardChainingMetadataReal:
+    """#78 — Forward chaining materializa metadata real (opción A1).
+
+    Las filas forward del corpus deben tener título real (no ``[candidate:W...]``),
+    año, autores y referencias correctas. El método viejo ``fetch_citing_batch``
+    (usado por el Enricher, Hito 8b) debe mantener su firma y contrato intactos.
+    """
+
+    def test_forward_filas_tienen_titulo_real(self) -> None:
+        """Filas forward del corpus: título real, no placeholder ``[candidate:``.
+
+        Espejo del test del backward en #54: la materialización forward ya no
+        usa ``[candidate:W...]`` sino el título real de OpenAlex.
+        """
+        rows = [
+            _base_row(
+                "P1",
+                openalex_id="W1",
+                references_id=None,
+                curation_status="candidate",
+            )
+        ]
+        corpus = _make_corpus(*rows)
+
+        citing_work = _citing_work_full(
+            "W9999",
+            cites_ids=["W1"],
+            title="Artículo de Prueba Real",
+            year=2023,
+            authors=["García López, A.", "Pérez Ruiz, B."],
+        )
+        transport = _make_batch_transport_full([citing_work])
+        source = OpenAlexSource(transport=transport)
+
+        forager = Forager(source, depth=1)
+        ranked = forager.chain(corpus, direction="forward")
+
+        cand_rows = ranked.corpus.to_arrow().to_pylist()
+        assert len(cand_rows) == 1, "Debe haber exactamente 1 candidato forward"
+        titulo = cand_rows[0].get("title", "")
+        assert not titulo.startswith("[candidate:"), (
+            f"El título no debe ser un placeholder; es: {titulo!r}"
+        )
+        assert titulo == "Artículo de Prueba Real", (
+            f"El título debe ser el real de OpenAlex; es: {titulo!r}"
+        )
+
+    def test_forward_filas_tienen_anio_y_autores(self) -> None:
+        """Filas forward: año y autores poblados (no None)."""
+        rows = [_base_row("P1", openalex_id="W1", references_id=None)]
+        corpus = _make_corpus(*rows)
+
+        citing_work = _citing_work_full(
+            "W8888",
+            cites_ids=["W1"],
+            title="Paper con Autores",
+            year=2022,
+            authors=["Autor Uno"],
+        )
+        transport = _make_batch_transport_full([citing_work])
+        source = OpenAlexSource(transport=transport)
+
+        forager = Forager(source, depth=1)
+        ranked = forager.chain(corpus, direction="forward")
+
+        cand_rows = ranked.corpus.to_arrow().to_pylist()
+        assert len(cand_rows) == 1
+        assert cand_rows[0]["year"] == 2022, (
+            f"El año debe ser 2022; es {cand_rows[0]['year']}"
+        )
+        assert cand_rows[0]["authors_raw"] is not None, "Los autores no deben ser None"
+        assert "Autor Uno" in (cand_rows[0]["authors_raw"] or []), (
+            "El autor real debe aparecer en authors_raw"
+        )
+
+    def test_corpus_forward_sin_placeholders(self) -> None:
+        """Ninguna fila del corpus forward matchea el patrón ``^\\[candidate:``."""
+        rows = [
+            _base_row(f"P{i}", openalex_id=f"W{i}", references_id=None)
+            for i in range(1, 4)
+        ]
+        corpus = _make_corpus(*rows)
+
+        # 3 citantes, cada uno cita al menos una semilla
+        citing_works = [
+            _citing_work_full(
+                f"W{900 + i}",
+                cites_ids=[f"W{i}"],
+                title=f"Paper Real {i}",
+                year=2020 + i,
+            )
+            for i in range(1, 4)
+        ]
+        transport = _make_batch_transport_full(citing_works)
+        source = OpenAlexSource(transport=transport)
+
+        forager = Forager(source, depth=1)
+        ranked = forager.chain(corpus, direction="forward")
+
+        cand_rows = ranked.corpus.to_arrow().to_pylist()
+        assert len(cand_rows) > 0, "Deben existir candidatos forward"
+        placeholders = [
+            r["title"]
+            for r in cand_rows
+            if (r.get("title") or "").startswith("[candidate:")
+        ]
+        assert placeholders == [], (
+            f"El corpus forward no debe tener placeholders; hay: {placeholders}"
+        )
+
+    def test_forward_is_seed_false_chaining_hop_1(self) -> None:
+        """Filas forward: is_seed=False y provenance con chaining_hop=1."""
+        import json
+
+        rows = [_base_row("P1", openalex_id="W1", references_id=None)]
+        corpus = _make_corpus(*rows)
+
+        citing_work = _citing_work_full("W7777", cites_ids=["W1"])
+        transport = _make_batch_transport_full([citing_work])
+        source = OpenAlexSource(transport=transport)
+
+        forager = Forager(source, depth=1)
+        ranked = forager.chain(corpus, direction="forward")
+
+        cand_rows = ranked.corpus.to_arrow().to_pylist()
+        assert len(cand_rows) == 1
+        row = cand_rows[0]
+        assert row["is_seed"] is False, "Los candidatos forward deben ser is_seed=False"
+        # Verificar chaining_hop=1 en provenance
+        provenance_raw = row.get("provenance")
+        assert provenance_raw is not None, "La provenance no debe ser None"
+        events = json.loads(provenance_raw) if isinstance(provenance_raw, str) else []
+        assert len(events) >= 1
+        assert events[0].get("chaining_hop") == 1, (
+            f"chaining_hop debe ser 1; es {events[0].get('chaining_hop')!r}"
+        )
+
+    def test_corpus_hash_estable_entre_corridas(self) -> None:
+        """Mismo corpus + mismo mock → mismo corpus_hash (determinismo #78)."""
+        rows = [_base_row("P1", openalex_id="W1", references_id=None)]
+        corpus = _make_corpus(*rows)
+
+        citing_work = _citing_work_full(
+            "W6666", cites_ids=["W1"], title="Paper Determinista"
+        )
+
+        def make_run() -> str:
+            transport = _make_batch_transport_full([citing_work])
+            source = OpenAlexSource(transport=transport)
+            forager = Forager(source, depth=1)
+            ranked = forager.chain(corpus, direction="forward")
+            return ranked.corpus._backend.corpus_hash()
+
+        hash1 = make_run()
+        hash2 = make_run()
+        assert hash1 == hash2, (
+            f"corpus_hash debe ser estable entre corridas; "
+            f"primera={hash1!r}, segunda={hash2!r}"
+        )
+
+    def test_fetch_citing_batch_no_regresion_firma(self) -> None:
+        """``fetch_citing_batch`` devuelve ``dict[str, list[str]]`` (no-regresión Enricher).
+
+        El Enricher de Hito 8b llama a ``fetch_citing_batch`` y espera solo la
+        atribución, sin works. Este test verifica que la firma y el contrato del
+        método viejo se mantienen intactos tras la refactorización de #78.
+        """
+        citing_work = _citing_work_full("W5555", cites_ids=["W1"])
+        transport = _make_batch_transport_full([citing_work])
+        source = OpenAlexSource(transport=transport)
+
+        result = source.fetch_citing_batch(["W1"])
+
+        # La firma debe ser dict[str, list[str]]
+        assert isinstance(result, dict), (
+            f"fetch_citing_batch debe devolver dict; devuelve {type(result)}"
+        )
+        assert "W1" in result, "W1 debe aparecer como clave"
+        citer_ids = result["W1"]
+        assert isinstance(citer_ids, list), (
+            f"Los valores deben ser list[str]; son {type(citer_ids)}"
+        )
+        assert all(isinstance(c, str) for c in citer_ids), (
+            "Todos los citer_ids deben ser strings"
+        )
+        assert "W5555" in citer_ids, "W5555 debe estar atribuido a W1"
+
+    def test_fetch_citing_batch_with_works_devuelve_tupla(self) -> None:
+        """``fetch_citing_batch_with_works`` devuelve ``(dict, dict)`` con works JSON.
+
+        Verifica la firma del método nuevo (#78 A1): primera componente = atribución
+        idéntica a ``fetch_citing_batch``; segunda = ``{citer_id: work_json}``.
+        """
+        citing_work = _citing_work_full(
+            "W4444",
+            cites_ids=["W1"],
+            title="Paper con Works",
+        )
+        transport = _make_batch_transport_full([citing_work])
+        source = OpenAlexSource(transport=transport)
+
+        result = source.fetch_citing_batch_with_works(["W1"])
+
+        assert isinstance(result, tuple) and len(result) == 2, (
+            "fetch_citing_batch_with_works debe devolver una tupla (attribution, works_map)"
+        )
+        attribution, works_map = result
+
+        # Atribución idéntica a fetch_citing_batch
+        assert isinstance(attribution, dict)
+        assert "W1" in attribution
+        assert "W4444" in attribution["W1"]
+
+        # works_map tiene el JSON completo del citante
+        assert isinstance(works_map, dict)
+        assert "W4444" in works_map, "El works_map debe tener la entrada del citante"
+        work_json = works_map["W4444"]
+        assert work_json.get("title") == "Paper con Works", (
+            f"El work_json debe tener el título real; tiene {work_json.get('title')!r}"
+        )
+
+    def test_backward_no_regresion_observed_refs(self) -> None:
+        """No-regresión #54: backward sigue generando observed_refs, no corpus rows.
+
+        El backward chaining no se toca en #78; este test verifica que la
+        refactorización no lo rompió.
+        """
+        rows = [_base_row("P1", references_id=["REF_B"], openalex_id="W1")]
+        corpus = _make_corpus(*rows)
+
+        source = OpenAlexSource(transport=_make_batch_transport_full([]))
+        forager = Forager(source, depth=1)
+        ranked = forager.chain(corpus, direction="backward")
+
+        # El corpus backward NO tiene filas materializadas
+        cand_rows = ranked.corpus.to_arrow().to_pylist()
+        assert len(cand_rows) == 0, (
+            "Backward chaining no debe materializar filas en corpus (#54)"
+        )
+        # Los IDs backward van a observed_refs
+        assert "REF_B" in ranked.observed_refs, "REF_B debe estar en observed_refs"
+
+    def test_build_forward_candidate_row_eliminado(self) -> None:
+        """``_build_forward_candidate_row`` fue eliminado (#78, como #54 eliminó backward).
+
+        No debe existir en bib2graph.foraging.forager.
+        """
+        import bib2graph.foraging.forager as forager_mod
+
+        assert not hasattr(forager_mod, "_build_forward_candidate_row"), (
+            "_build_forward_candidate_row fue eliminado en #78: "
+            "no debe existir en bib2graph.foraging.forager"
+        )
+
+
+# ---------------------------------------------------------------------------
+# #78 — Test de red real (fuera del gate por defecto)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.network
+def test_forward_chaining_red_real_titulo_no_nulo() -> None:
+    """Forward chaining contra OpenAlex real: los citantes tienen título no nulo.
+
+    Fuera del gate por defecto (``addopts -m "not network"``).
+    Correr explícito con: ``uv run pytest -m network``.
+
+    Usa un paper conocido como semilla para verificar que los citantes
+    traídos por el forward chaining tienen metadata real.
+    """
+    # W2741809807 = "Attention is all you need" (Vaswani et al., 2017)
+    # — paper muy citado, garantiza ≥1 citante devuelto
+    rows = [
+        _base_row(
+            "attn",
+            openalex_id="W2741809807",
+            references_id=None,
+        )
+    ]
+    corpus = _make_corpus(*rows)
+
+    source = OpenAlexSource(email="trama.complejidad@gmail.com")
+    forager = Forager(source, depth=1, max_citing_per_paper=3)
+    ranked = forager.chain(corpus, direction="forward")
+
+    cand_rows = ranked.corpus.to_arrow().to_pylist()
+    assert len(cand_rows) > 0, "Debe haber al menos 1 citante forward real"
+    for row in cand_rows:
+        titulo = row.get("title") or ""
+        assert titulo and not titulo.startswith("[candidate:"), (
+            f"El título debe ser real (no placeholder); es: {titulo!r}"
+        )


### PR DESCRIPTION
Cierra **#78** — la otra mitad del footgun de placeholders (#54 arregló backward; este arregla forward).

**Hallazgo:** `fetch_citing_batch` YA traía la metadata completa (`_FIELDS`) y la **descartaba**. Opción A1 (tu decisión): conservarla, **cero red extra**.
- `_fetch_citing_pages` (paginado compartido) → `fetch_citing_batch` queda thin wrapper **intacto** (Enricher 8b safe); nuevo `fetch_citing_batch_with_works`.
- `_fetch_forward` materializa con `_work_to_row` → filas reales (título/año/autores). `_build_forward_candidate_row` eliminado.

verifier **PASA** (645 tests; con OpenAlexSource real **nunca** cae al placeholder —todo citante atribuido tiene work—; Enricher sin regresión; backward #54 intacto). Enmienda ADR 0020 (asimetría justificada; regla común: **cero placeholders en el corpus**). Con esto el footgun queda cerrado por **ambos lados**.