### PR TITLE
fix(curate): --dump excluye semillas + --scope + columnas de revisión (#72, #58, #59)

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -280,12 +280,21 @@ rehidratación de corpus curado sin red, Ciclo 9a, ADR
   viable con `accept`/`reject` por `--ids` uno a uno). **Dos modos mutuamente excluyentes** (exactamente
   uno; pasar ambos o ninguno → error de uso, exit 1):
   - **`--dump`** escribe un CSV revisable offline (Excel/Calc). Default
-    `<workspace>/exports/curacion.csv`; **`--out`** lo override. Por defecto solo los **candidatos**
-    (`curation_status == 'candidate'`); **`--all`** vuelca **todo** el corpus. Columnas (orden estable):
-    `id, openalex_id, title, year, authors, scent_score, cluster, decision, note`. **`id`/`openalex_id`/
-    `title`/`year`/`authors` son read-only**; el humano edita **`decision`** y **`note`**. `decision`
-    refleja el `curation_status` actual (`candidate`→`undecided`, `accepted`→`accepted`,
-    `rejected`→`rejected`). `data` = `{csv_path, papers_exported, columns}`.
+    `<workspace>/exports/curacion.csv`; **`--out`** lo override. **`--scope [candidates|seeds|all]`**
+    (default `candidates`) elige qué papers volcar: `candidates` = forrajeados a revisar
+    (`curation_status == 'candidate'` **AND** `is_seed == False`, **excluye semillas** —arregla #72,
+    donde el dump arrastraba seeds); `seeds` = semillas originales (`is_seed == True`); `all` = todo el
+    corpus. **`--all`** queda como **alias deprecado de `--scope all`** (tiene precedencia si se pasan
+    ambos). Sin candidatos (scope `candidates`/`seeds` vacío) → error accionable que sugiere `--scope all`
+    o `b2g chain`. Columnas (16, orden estable): `id, openalex_id, title, year, authors, venue, doi,
+    keywords, cited_by_count, references_count, is_seed, openalex_url, scent_score, cluster, decision,
+    note`. **Todas read-only salvo `decision` y `note`** (las editables por el humano). `venue` sale de
+    `source`; `keywords` se une con `" | "` (igual que `authors`); `openalex_url` se deriva del
+    `openalex_id` (`https://openalex.org/<id>`). **`cited_by_count`/`references_count` hoy salen vacías**:
+    no existen como escalares en el schema canónico de 23 columnas, así que la columna queda como
+    placeholder para llenado manual (limitación conocida, no falla). `decision` refleja el
+    `curation_status` actual (`candidate`→`undecided`, `accepted`→`accepted`, `rejected`→`rejected`).
+    `data` = `{csv_path, papers_exported, columns}`.
   - **`--from-csv <archivo>`** aplica las decisiones en lote y persiste: `accepted`→`accept`,
     `rejected`→`reject`, `undecided`→no-op (case-insensitive). **Idempotente** (reimportar el mismo CSV
     = mismo `corpus_hash`; el reloj `decided_at` se inyecta en la **frontera CLI**, R2/ADR 0017, fuera

--- a/src/bib2graph/cli/commands/curate.py
+++ b/src/bib2graph/cli/commands/curate.py
@@ -1,27 +1,44 @@
 """cli.commands.curate — Subcomando ``b2g curate``.
 
-Curación en lote (#22 dump + #26 import): permite revisar y marcar papers
-en una tabla externa (Excel/Calc) y reimportar las decisiones al corpus.
+Curación en lote (#22 dump + #26 import + #72 fix scope + #58 columnas):
+permite revisar y marcar papers en una tabla externa (Excel/Calc) y
+reimportar las decisiones al corpus.
 
 Flujo canónico:
-    b2g curate --dump                   # exporta <workspace>/exports/curacion.csv
-    b2g curate --dump --out mi.csv      # override de ruta de salida
-    b2g curate --dump --all             # incluye también aceptados y rechazados
-    b2g curate --from-csv mi.csv        # reimporta las decisiones del CSV
+    b2g curate --dump                       # exporta candidatos forrajeados
+    b2g curate --dump --scope seeds         # exporta semillas
+    b2g curate --dump --scope all           # exporta todo el corpus
+    b2g curate --dump --all                 # alias de --scope all (deprecado)
+    b2g curate --dump --out mi.csv          # override de ruta de salida
+    b2g curate --from-csv mi.csv            # reimporta las decisiones del CSV
 
 El CSV que ``--dump`` produce tiene exactamente las columnas que ``--from-csv``
 lee, lo que garantiza el round-trip sin fricción.
 
-Columnas:
-    id           — identificador canónico del paper (readonly)
-    openalex_id  — identificador OpenAlex (readonly)
-    title        — título (readonly)
-    year         — año de publicación (readonly)
-    authors      — lista de autores separada por \" | \" (readonly)
-    scent_score  — best-effort desde provenance del candidato; vacío si no hay
-    cluster      — reservado para futura integración de redes; siempre vacío hoy
-    decision     — editable: accepted | rejected | undecided
-    note         — editable: texto libre, advisory (round-trip solo)
+Columnas (readonly salvo decision/note):
+    id              — identificador canónico del paper (readonly)
+    openalex_id     — identificador OpenAlex (readonly)
+    title           — título (readonly)
+    year            — año de publicación (readonly)
+    authors         — lista de autores separada por \" | \" (readonly)
+    venue           — nombre de la revista/fuente (readonly)
+    doi             — DOI del paper (readonly)
+    keywords        — lista de keywords separada por \" | \" (readonly)
+    cited_by_count  — conteo de citaciones; vacío si no está en el corpus (readonly)
+    references_count— conteo de referencias; vacío si no está en el corpus (readonly)
+    is_seed         — True si es semilla original (readonly)
+    openalex_url    — URL directa a OpenAlex (derivada de openalex_id) (readonly)
+    scent_score     — best-effort desde provenance del candidato; vacío si no hay
+    cluster         — reservado para futura integración de redes; siempre vacío hoy
+    decision        — editable: accepted | rejected | undecided
+    note            — editable: texto libre, advisory (round-trip solo)
+
+Semántica de scope (#72 / #58):
+    candidates (default) — papers forrajeados a revisar:
+        curation_status == 'candidate' AND is_seed == False.
+        Excluye semillas (que nacen con is_seed=True y status=candidate).
+    seeds               — papers con is_seed == True.
+    all                 — todo el corpus (candidates + seeds + accepted + rejected).
 
 ``note`` es advisory:
     ``ProvenanceEvent`` no tiene un campo genérico de anotación. Registrar la
@@ -37,6 +54,15 @@ Columnas:
 ``cluster`` best-effort:
     Reservado para cuando los grafos de red estén disponibles. Siempre vacío
     en esta versión. No se falla por ausencia.
+
+``cited_by_count`` / ``references_count`` best-effort:
+    No están en el schema canónico de 23 columnas (no los almacena OpenAlex
+    pipeline). Se dejan vacíos; la columna existe para que el humano la llene
+    manualmente si quiere.
+
+``openalex_url`` derivada:
+    Si hay ``openalex_id`` (ej. ``W2741809807``), la URL es
+    ``https://openalex.org/<openalex_id>``. Si no hay id, queda vacío.
 
 Idempotencia:
     Reimportar el mismo CSV produce el mismo estado. ``accept``/``reject`` del
@@ -72,12 +98,20 @@ from bib2graph.constants import Col, CurationStatus
 CURATE_CSV_FILENAME = "curacion.csv"
 
 # Columnas del CSV: orden estable y conocido por el humano y la reimportación.
+# Las columnas readonly van primero; decision y note son las editables.
 CSV_COLUMNS = [
     "id",
     "openalex_id",
     "title",
     "year",
     "authors",
+    "venue",
+    "doi",
+    "keywords",
+    "cited_by_count",
+    "references_count",
+    "is_seed",
+    "openalex_url",
     "scent_score",
     "cluster",
     "decision",
@@ -100,6 +134,9 @@ _STATUS_TO_DECISION: dict[str, str] = {
     CurationStatus.ACCEPTED: "accepted",
     CurationStatus.REJECTED: "rejected",
 }
+
+# Scope válidos para --dump
+VALID_SCOPES = {"candidates", "seeds", "all"}
 
 
 # ---------------------------------------------------------------------------
@@ -125,6 +162,46 @@ def _authors_display(row: dict[str, Any]) -> str:
     ids = row.get(Col.AUTHORS_ID)
     if ids and isinstance(ids, list):
         return " | ".join(str(a) for a in ids if a)
+    return ""
+
+
+def _keywords_display(row: dict[str, Any]) -> str:
+    """Extrae las keywords de una fila del corpus y las une con ' | '.
+
+    Usa ``keywords_id`` si disponible (identificadores OpenAlex), con
+    ``keywords_raw`` como fallback. Mismo patrón que ``_authors_display``.
+    Devuelve cadena vacía si no hay datos.
+
+    Args:
+        row: Fila de la tabla Arrow convertida a dict.
+
+    Returns:
+        Cadena de keywords separada por \" | \" o cadena vacía.
+    """
+    ids = row.get(Col.KEYWORDS_ID)
+    if ids and isinstance(ids, list):
+        return " | ".join(str(k) for k in ids if k)
+    raw = row.get(Col.KEYWORDS_RAW)
+    if raw and isinstance(raw, list):
+        return " | ".join(str(k) for k in raw if k)
+    return ""
+
+
+def _openalex_url(row: dict[str, Any]) -> str:
+    """Deriva la URL de OpenAlex a partir del openalex_id de la fila.
+
+    Formato: ``https://openalex.org/<openalex_id>``.
+    Devuelve cadena vacía si no hay openalex_id.
+
+    Args:
+        row: Fila de la tabla Arrow convertida a dict.
+
+    Returns:
+        URL de OpenAlex o cadena vacía.
+    """
+    oa_id = row.get(Col.OPENALEX_ID)
+    if oa_id:
+        return f"https://openalex.org/{oa_id}"
     return ""
 
 
@@ -164,6 +241,14 @@ def _scent_score_display(row: dict[str, Any]) -> str:
 def _row_to_csv_dict(row: dict[str, Any]) -> dict[str, str]:
     """Convierte una fila del corpus al dict para el CSV de curación.
 
+    Incluye las columnas readonly enriquecidas (venue, doi, keywords,
+    cited_by_count, references_count, is_seed, openalex_url) además de
+    las columnas base (id, openalex_id, title, year, authors, scent_score,
+    cluster) y las columnas editables (decision, note).
+
+    ``cited_by_count`` y ``references_count`` no están en el schema canónico;
+    se dejan vacíos (best-effort).
+
     Args:
         row: Fila de la tabla Arrow convertida a dict.
 
@@ -172,6 +257,8 @@ def _row_to_csv_dict(row: dict[str, Any]) -> dict[str, str]:
     """
     status = str(row.get(Col.CURATION_STATUS, CurationStatus.CANDIDATE))
     decision = _STATUS_TO_DECISION.get(status, "undecided")
+    is_seed_val = row.get(Col.IS_SEED)
+    is_seed_str = str(is_seed_val) if is_seed_val is not None else ""
 
     return {
         "id": str(row.get(Col.ID) or ""),
@@ -179,11 +266,57 @@ def _row_to_csv_dict(row: dict[str, Any]) -> dict[str, str]:
         "title": str(row.get(Col.TITLE) or ""),
         "year": str(row.get(Col.YEAR) or ""),
         "authors": _authors_display(row),
+        "venue": str(row.get(Col.SOURCE) or ""),
+        "doi": str(row.get(Col.DOI) or ""),
+        "keywords": _keywords_display(row),
+        "cited_by_count": "",  # no está en el schema canónico; best-effort vacío
+        "references_count": "",  # no está en el schema canónico; best-effort vacío
+        "is_seed": is_seed_str,
+        "openalex_url": _openalex_url(row),
         "scent_score": _scent_score_display(row),
         "cluster": "",  # reservado para integración con redes
         "decision": decision,
         "note": "",
     }
+
+
+# ---------------------------------------------------------------------------
+# Helpers de filtrado por scope
+# ---------------------------------------------------------------------------
+
+
+def _filter_table_by_scope(table: Any, scope: str) -> Any:
+    """Filtra una tabla Arrow según el scope de dump.
+
+    Scope 'candidates': curation_status == 'candidate' AND is_seed == False.
+    Scope 'seeds':      is_seed == True.
+    Scope 'all':        sin filtro.
+
+    Se importa pyarrow.compute localmente para mantener el módulo libre de
+    efectos de import globales (AGENTS.md §Imports).
+
+    Args:
+        table: Tabla Arrow del corpus.
+        scope: Uno de 'candidates', 'seeds', 'all'.
+
+    Returns:
+        Tabla Arrow filtrada.
+    """
+    import pyarrow.compute as pc
+
+    if scope == "all":
+        return table
+    elif scope == "seeds":
+        mask = table.column(Col.IS_SEED)
+        return table.filter(mask)
+    else:
+        # candidates: status == candidate AND NOT is_seed
+        status_col = table.column(Col.CURATION_STATUS)
+        is_candidate = pc.equal(status_col, CurationStatus.CANDIDATE)  # type: ignore[attr-defined]
+        is_seed_col = table.column(Col.IS_SEED)
+        not_seed = pc.invert(is_seed_col)  # type: ignore[attr-defined]
+        mask = pc.and_(is_candidate, not_seed)  # type: ignore[attr-defined]
+        return table.filter(mask)
 
 
 # ---------------------------------------------------------------------------
@@ -195,46 +328,59 @@ def run_curate_dump(
     store_path: str | Path,
     *,
     out_path: Path,
+    scope: str = "candidates",
     include_all: bool = False,
 ) -> dict[str, Any]:
     """Exporta el corpus a un CSV para revisión offline.
 
-    Por defecto exporta solo los candidatos (``curation_status == 'candidate'``).
-    Con ``include_all=True`` exporta todos los papers del corpus.
+    Por defecto exporta solo los candidatos forrajeados (``scope='candidates'``:
+    ``curation_status == 'candidate'`` AND ``is_seed == False``), que excluye
+    semillas. Con ``scope='seeds'`` exporta las semillas; con ``scope='all'``
+    exporta todo el corpus.
 
-    Columnas del CSV: id, openalex_id, title, year, authors, scent_score,
-    cluster, decision, note. La columna ``decision`` refleja el
-    ``curation_status`` actual (candidate → undecided). Las columnas
-    ``decision`` y ``note`` son las editables por el humano.
+    El parámetro ``include_all`` es un alias deprecado de ``scope='all'``:
+    si es ``True``, equivale a forzar ``scope='all'``.
 
-    ``scent_score`` y ``cluster`` son best-effort: se incluyen si están
-    disponibles en el provenance; si no, quedan vacíos.
+    Columnas del CSV: id, openalex_id, title, year, authors, venue, doi,
+    keywords, cited_by_count, references_count, is_seed, openalex_url,
+    scent_score, cluster, decision, note.
+    Las columnas ``decision`` y ``note`` son las editables por el humano.
 
     Args:
         store_path: Ruta al archivo ``.duckdb``.
         out_path: Ruta completa del archivo CSV de salida.
-        include_all: Si True, incluye todos los papers; si False (default),
-            solo los candidatos.
+        scope: 'candidates' (default), 'seeds' o 'all'.
+            'candidates' = curation_status=='candidate' AND is_seed==False.
+            'seeds' = is_seed==True.
+            'all' = todo el corpus.
+        include_all: Alias deprecado de scope='all'. Si True, fuerza scope='all'.
 
     Returns:
         Dict con ``csv_path``, ``papers_exported``, ``columns``.
 
     Raises:
-        DataError: Si el corpus está vacío o no hay papers candidatos y
-            ``include_all`` es False.
+        DataError: Si el corpus está vacío o no hay papers en el scope dado
+            cuando el scope no es 'all'.
         StoreError: Si el store está bloqueado.
     """
+    # include_all es alias deprecado de scope='all'
+    effective_scope = "all" if include_all else scope
+
     store = open_store(store_path)
     corpus = store.load()
 
-    table = corpus.to_arrow() if include_all else corpus.candidates()
+    all_table = corpus.to_arrow()
+    table = _filter_table_by_scope(all_table, effective_scope)
 
     rows = table.to_pylist()
 
-    if not rows and not include_all:
+    if not rows and effective_scope != "all":
+        scope_label = (
+            "candidatos forrajeados" if effective_scope == "candidates" else "semillas"
+        )
         raise DataError(
-            "No hay papers candidatos para exportar. "
-            "Usá --all para exportar todo el corpus, o ejecutá "
+            f"No hay {scope_label} para exportar. "
+            "Usá --scope all para exportar todo el corpus, o ejecutá "
             "``b2g chain`` para agregar candidatos."
         )
 
@@ -269,6 +415,10 @@ def run_curate_from_csv(
 
     Lee el CSV producido por ``--dump`` (u otro CSV con columnas ``id`` y
     ``decision``), aplica las decisiones en lote e persiste.
+
+    Las columnas extra del CSV enriquecido (venue, doi, keywords, etc.) se
+    ignoran; solo se requieren ``id`` y ``decision``. Esto garantiza el
+    round-trip dump→from-csv aunque el CSV tenga más columnas que el mínimo.
 
     Mapeo de ``decision``:
       - ``accepted``  → ``Corpus.accept``
@@ -424,11 +574,27 @@ def run_curate_from_csv(
     ),
 )
 @click.option(
+    "--scope",
+    "scope",
+    default="candidates",
+    type=click.Choice(["candidates", "seeds", "all"]),
+    show_default=True,
+    help=(
+        "Con --dump: qué papers exportar. "
+        "'candidates' (default) = forrajeados a revisar (is_seed=False, status=candidate). "
+        "'seeds' = semillas originales. "
+        "'all' = todo el corpus."
+    ),
+)
+@click.option(
     "--all",
     "include_all",
     is_flag=True,
     default=False,
-    help=("Con --dump: incluye todos los papers del corpus, no solo los candidatos."),
+    help=(
+        "Con --dump: incluye todos los papers del corpus. "
+        "Alias deprecado de --scope all; tiene precedencia sobre --scope si ambos se pasan."
+    ),
 )
 @click.option(
     "--by",
@@ -450,6 +616,7 @@ def curate_cmd(
     do_dump: bool,
     from_csv: str | None,
     out_override: str | None,
+    scope: str,
     include_all: bool,
     by: str,
     json_output: bool,
@@ -459,13 +626,15 @@ def curate_cmd(
     Dos modos mutuamente excluyentes (exactamente uno requerido):
 
     \b
-      --dump          exporta candidatos a CSV para revisión offline.
+      --dump          exporta papers a CSV para revisión offline.
       --from-csv CSV  reimporta decisiones desde el CSV dado.
 
     Flujo típico:
 
     \b
-      b2g curate --dump                  # genera curacion.csv
+      b2g curate --dump                  # genera curacion.csv (solo candidatos forrajeados)
+      b2g curate --dump --scope seeds    # genera curacion.csv con semillas
+      b2g curate --dump --scope all      # genera curacion.csv con todo el corpus
       # (editar curacion.csv en Excel: columnas decision y note)
       b2g curate --from-csv curacion.csv  # aplica decisiones
 
@@ -491,7 +660,12 @@ def curate_cmd(
         else:
             out_path = ws.exports_dir / CURATE_CSV_FILENAME
 
-        data = run_curate_dump(store_path, out_path=out_path, include_all=include_all)
+        data = run_curate_dump(
+            store_path,
+            out_path=out_path,
+            scope=scope,
+            include_all=include_all,
+        )
 
         if json_output:
             envelope = build_envelope(

--- a/tests/unit/test_curate.py
+++ b/tests/unit/test_curate.py
@@ -1,4 +1,4 @@
-"""Tests TDD para ``b2g curate`` (#22 dump + #26 from-csv).
+"""Tests TDD para ``b2g curate`` (#22 dump + #26 from-csv + #72 scope + #58 columnas).
 
 Casos cubiertos (tarea §Tests):
 
@@ -15,6 +15,19 @@ Casos cubiertos (tarea §Tests):
 11. Contrato --json del comando (forma estable).
 12. Mutuamente excluyente: --dump y --from-csv juntos → UsageError.
 13. Ningún modo → UsageError.
+14. dump --all incluye accepted y rejected además de candidate.
+15. dump sin --all solo candidatos (con is_seed=False).
+16. Autores en columna authors.
+17. CSV vacío (solo header) → from-csv no falla.
+18. CSV inexistente → DataError.
+19. IDs huérfanos → not_found_count, sin abort.
+--- nuevos (#72 / #58) ---
+20. Regresión #72: scope default (candidates) excluye semillas.
+21. scope='seeds' exporta solo is_seed=True.
+22. scope='all' exporta todo el corpus.
+23. --all (alias) exporta todo.
+24. Columnas nuevas existen en el CSV y traen valores correctos.
+25. Round-trip con columnas nuevas: --from-csv ignora columnas extra.
 
 Filosofía (AGENTS.md): se testea la FUNCIÓN detrás del comando, NO el parser
 Click. Marcador: ``unit`` (DuckDB en tmp_path, sin red).
@@ -45,27 +58,32 @@ def _make_corpus_row(
     curation_status: str = "candidate",
     openalex_id: str | None = None,
     authors_raw: list[str] | None = None,
+    is_seed: bool = False,
+    doi: str | None = None,
+    source: str | None = None,
+    keywords_raw: list[str] | None = None,
+    keywords_id: list[str] | None = None,
 ) -> dict[str, Any]:
     """Fila mínima con schema completo para tests."""
     return {
         "id": id,
         "openalex_id": openalex_id,
-        "doi": None,
+        "doi": doi,
         "title": title,
         "year": year,
         "abstract": None,
-        "source": None,
+        "source": source,
         "language": "en",
         "publisher": None,
         "research_areas": None,
-        "is_seed": False,
+        "is_seed": is_seed,
         "curation_status": curation_status,
         "provenance": None,
         "authors_raw": authors_raw,
         "authors_id": None,
         "authors_affiliations": None,
-        "keywords_raw": None,
-        "keywords_id": None,
+        "keywords_raw": keywords_raw,
+        "keywords_id": keywords_id,
         "institutions_raw": None,
         "institutions_id": None,
         "references_id": None,
@@ -800,3 +818,288 @@ def test_from_csv_ids_huerfanos_reporta_not_found_count(tmp_path: Path) -> None:
     all_ids = {r["id"] for r in corpus.to_arrow().to_pylist()}
     assert "P_FANTASMA" not in all_ids
     assert corpus.to_arrow().to_pylist()[0]["curation_status"] == "accepted"
+
+
+# ---------------------------------------------------------------------------
+# 20. Regresión #72: scope default excluye semillas (candidates = NOT is_seed)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_dump_scope_candidates_excluye_semillas(tmp_path: Path) -> None:
+    """Regresión #72: scope default 'candidates' exporta solo forrajeados (is_seed=False).
+
+    Un corpus de N seeds (is_seed=True, status=candidate) + M candidatos
+    (is_seed=False, status=candidate) debe exportar solo M filas en el dump
+    default, no N+M.
+    """
+    from bib2graph.cli.commands.curate import run_curate_dump
+
+    store_path = tmp_path / "test.duckdb"
+    # 3 semillas: is_seed=True, status=candidate
+    seeds = [
+        _make_corpus_row(id=f"S{i}", is_seed=True, curation_status="candidate")
+        for i in range(3)
+    ]
+    # 2 candidatos forrajeados: is_seed=False, status=candidate
+    candidates = [
+        _make_corpus_row(id=f"C{i}", is_seed=False, curation_status="candidate")
+        for i in range(2)
+    ]
+    _seed_store(store_path, seeds + candidates)
+
+    out = tmp_path / "curacion.csv"
+    data = run_curate_dump(store_path, out_path=out)
+
+    # Debe exportar solo los 2 candidatos forrajeados, no las 3 semillas
+    assert data["papers_exported"] == 2, (
+        f"Regresión #72: se esperaban 2 candidatos, se obtuvieron {data['papers_exported']}"
+    )
+    csv_rows = _read_csv(out)
+    exported_ids = {r["id"] for r in csv_rows}
+    assert "C0" in exported_ids
+    assert "C1" in exported_ids
+    # Ninguna semilla debe aparecer
+    assert "S0" not in exported_ids
+    assert "S1" not in exported_ids
+    assert "S2" not in exported_ids
+
+
+# ---------------------------------------------------------------------------
+# 21. scope='seeds' exporta solo semillas
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_dump_scope_seeds_exporta_solo_semillas(tmp_path: Path) -> None:
+    """scope='seeds' exporta solo los papers con is_seed=True."""
+    from bib2graph.cli.commands.curate import run_curate_dump
+
+    store_path = tmp_path / "test.duckdb"
+    rows = [
+        _make_corpus_row(id="S1", is_seed=True, curation_status="candidate"),
+        _make_corpus_row(id="S2", is_seed=True, curation_status="accepted"),
+        _make_corpus_row(id="C1", is_seed=False, curation_status="candidate"),
+    ]
+    _seed_store(store_path, rows)
+
+    out = tmp_path / "curacion.csv"
+    data = run_curate_dump(store_path, out_path=out, scope="seeds")
+
+    assert data["papers_exported"] == 2
+    csv_rows = _read_csv(out)
+    exported_ids = {r["id"] for r in csv_rows}
+    assert "S1" in exported_ids
+    assert "S2" in exported_ids
+    assert "C1" not in exported_ids
+
+
+# ---------------------------------------------------------------------------
+# 22. scope='all' exporta todo el corpus
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_dump_scope_all_exporta_todo(tmp_path: Path) -> None:
+    """scope='all' exporta todos los papers sin importar is_seed ni status."""
+    from bib2graph.cli.commands.curate import run_curate_dump
+
+    store_path = tmp_path / "test.duckdb"
+    rows = [
+        _make_corpus_row(id="S1", is_seed=True, curation_status="candidate"),
+        _make_corpus_row(id="C1", is_seed=False, curation_status="candidate"),
+        _make_corpus_row(id="A1", is_seed=False, curation_status="accepted"),
+        _make_corpus_row(id="R1", is_seed=False, curation_status="rejected"),
+    ]
+    _seed_store(store_path, rows)
+
+    out = tmp_path / "curacion.csv"
+    data = run_curate_dump(store_path, out_path=out, scope="all")
+
+    assert data["papers_exported"] == 4
+    csv_rows = _read_csv(out)
+    exported_ids = {r["id"] for r in csv_rows}
+    assert {"S1", "C1", "A1", "R1"} == exported_ids
+
+
+# ---------------------------------------------------------------------------
+# 23. --all (alias deprecado) equivale a scope='all'
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_dump_include_all_alias_scope_all(tmp_path: Path) -> None:
+    """include_all=True es alias de scope='all': exporta todo el corpus."""
+    from bib2graph.cli.commands.curate import run_curate_dump
+
+    store_path = tmp_path / "test.duckdb"
+    rows = [
+        _make_corpus_row(id="S1", is_seed=True, curation_status="candidate"),
+        _make_corpus_row(id="C1", is_seed=False, curation_status="candidate"),
+        _make_corpus_row(id="A1", is_seed=False, curation_status="accepted"),
+    ]
+    _seed_store(store_path, rows)
+
+    out = tmp_path / "curacion.csv"
+    # include_all=True debe producir el mismo resultado que scope='all'
+    data = run_curate_dump(store_path, out_path=out, include_all=True)
+
+    assert data["papers_exported"] == 3
+    csv_rows = _read_csv(out)
+    exported_ids = {r["id"] for r in csv_rows}
+    assert {"S1", "C1", "A1"} == exported_ids
+
+
+# ---------------------------------------------------------------------------
+# 24. Columnas nuevas existen en el CSV y traen valores correctos
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_dump_columnas_nuevas_existen_y_traen_datos(tmp_path: Path) -> None:
+    """venue, doi, keywords, is_seed y openalex_url aparecen en el CSV.
+
+    Verifica que las columnas enriquecidas (#58) se incluyen en el dump
+    con los valores correctos para una fila con metadatos conocidos.
+    """
+    from bib2graph.cli.commands.curate import run_curate_dump
+
+    store_path = tmp_path / "test.duckdb"
+    rows = [
+        _make_corpus_row(
+            id="P1",
+            openalex_id="W12345",
+            doi="10.1234/test",
+            source="Journal of Testing",
+            keywords_raw=["machine learning", "graphs"],
+            keywords_id=["KW001", "KW002"],
+            is_seed=False,
+        )
+    ]
+    _seed_store(store_path, rows)
+
+    out = tmp_path / "curacion.csv"
+    run_curate_dump(store_path, out_path=out, scope="candidates")
+
+    csv_rows = _read_csv(out)
+    assert len(csv_rows) == 1
+    row = csv_rows[0]
+
+    # venue (de Col.SOURCE)
+    assert row["venue"] == "Journal of Testing"
+    # doi
+    assert row["doi"] == "10.1234/test"
+    # keywords: usa keywords_id primero
+    assert row["keywords"] == "KW001 | KW002"
+    # is_seed
+    assert row["is_seed"] == "False"
+    # openalex_url derivada
+    assert row["openalex_url"] == "https://openalex.org/W12345"
+    # cited_by_count y references_count vacíos (no en schema)
+    assert row["cited_by_count"] == ""
+    assert row["references_count"] == ""
+
+
+@pytest.mark.unit
+def test_dump_keywords_fallback_a_raw(tmp_path: Path) -> None:
+    """keywords usa keywords_raw como fallback cuando keywords_id es None."""
+    from bib2graph.cli.commands.curate import run_curate_dump
+
+    store_path = tmp_path / "test.duckdb"
+    rows = [
+        _make_corpus_row(
+            id="P1",
+            keywords_raw=["ciencia abierta", "metadatos"],
+            keywords_id=None,
+            is_seed=False,
+        )
+    ]
+    _seed_store(store_path, rows)
+
+    out = tmp_path / "curacion.csv"
+    run_curate_dump(store_path, out_path=out)
+
+    csv_rows = _read_csv(out)
+    assert csv_rows[0]["keywords"] == "ciencia abierta | metadatos"
+
+
+@pytest.mark.unit
+def test_dump_openalex_url_vacio_sin_id(tmp_path: Path) -> None:
+    """openalex_url queda vacío si no hay openalex_id."""
+    from bib2graph.cli.commands.curate import run_curate_dump
+
+    store_path = tmp_path / "test.duckdb"
+    rows = [_make_corpus_row(id="P1", openalex_id=None)]
+    _seed_store(store_path, rows)
+
+    out = tmp_path / "curacion.csv"
+    run_curate_dump(store_path, out_path=out)
+
+    csv_rows = _read_csv(out)
+    assert csv_rows[0]["openalex_url"] == ""
+
+
+# ---------------------------------------------------------------------------
+# 25. Round-trip con columnas nuevas: --from-csv ignora columnas extra
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_round_trip_con_columnas_nuevas(tmp_path: Path) -> None:
+    """dump con columnas enriquecidas → from-csv aplica decisiones correctamente.
+
+    Verifica que run_curate_from_csv no se rompe con las columnas extra
+    introducidas en #58 (venue, doi, keywords, etc.). Solo requiere id y decision.
+    """
+    from bib2graph.cli.commands.curate import run_curate_dump, run_curate_from_csv
+    from bib2graph.stores.duckdb import DuckDBStore
+
+    store_path = tmp_path / "test.duckdb"
+    rows = [
+        _make_corpus_row(
+            id="PA",
+            openalex_id="W111",
+            doi="10.1/a",
+            source="Nature",
+            keywords_raw=["ecology"],
+            is_seed=False,
+        ),
+        _make_corpus_row(id="PB", is_seed=False),
+    ]
+    _seed_store(store_path, rows)
+
+    # dump genera CSV con columnas enriquecidas
+    out = tmp_path / "curacion.csv"
+    dump_data = run_curate_dump(store_path, out_path=out)
+    assert dump_data["papers_exported"] == 2
+
+    # Editar el CSV: PA → accepted, PB → rejected
+    csv_rows = _read_csv(out)
+    for row in csv_rows:
+        if row["id"] == "PA":
+            row["decision"] = "accepted"
+        elif row["id"] == "PB":
+            row["decision"] = "rejected"
+
+    # Reescribir el CSV con las columnas nuevas presentes
+    from bib2graph.cli.commands.curate import CSV_COLUMNS
+
+    with open(out, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=CSV_COLUMNS)
+        writer.writeheader()
+        writer.writerows(csv_rows)
+
+    # from-csv no debe fallar por las columnas extra
+    now = datetime.now(UTC)
+    result = run_curate_from_csv(store_path, out, decided_at=now)
+
+    assert result["accepted_count"] == 1
+    assert result["rejected_count"] == 1
+    assert result["skipped_count"] == 0
+
+    # Verificar estado del corpus
+    store = DuckDBStore(store_path)
+    corpus = store.load()
+    by_id = {r["id"]: r for r in corpus.to_arrow().to_pylist()}
+    assert by_id["PA"]["curation_status"] == "accepted"
+    assert by_id["PB"]["curation_status"] == "rejected"


### PR DESCRIPTION
## Qué

`b2g curate --dump` por defecto exportaba todo el corpus (seeds + candidatos) en vez de solo los candidatos forrajeados — las semillas nacen `curation_status='candidate'` y `corpus.candidates()` las incluía (**bug #72**).

- **#72** Nueva opción `--scope [candidates|seeds|all]` (default `candidates` = `candidate AND NOT is_seed`). El filtro vive en la capa dump; `Corpus.candidates()` queda intacto. `--all` se conserva como alias deprecado de `--scope all`.
- **#58/#59** El CSV de dump pasa de 9 → 16 columnas (`venue, doi, keywords, cited_by_count, references_count, is_seed, openalex_url`) para que revisar a escala en Excel/Calc no sea a ciegas. Round-trip `dump → --from-csv` intacto (from-csv solo requiere `id`+`decision`). Estos issues reabrían #22/#26, ya cubiertos por `b2g curate`; acá se cierran con columnas enriquecidas.

`cited_by_count`/`references_count` salen vacías hoy (no son escalares en el schema canónico) — documentado.

## Tests
8 tests nuevos en `test_curate.py` (regresión #72, los 3 scopes, alias `--all`, columnas nuevas, round-trip). Gate verde: **653 passed**, ruff/mypy limpios. Revisado por `verifier` → PASA.

Closes #72, #58, #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)