### PR TITLE
chore(mypy): override ignore_missing_imports para rapidfuzz (gate limpio sin [dedup])

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -170,6 +170,10 @@ plugins = ["pydantic.mypy"]
 module = "bibtexparser.*"
 ignore_missing_imports = true
 
+[[tool.mypy.overrides]]
+module = "rapidfuzz.*"
+ignore_missing_imports = true
+
 [tool.pytest.ini_options]
 minversion = "8.0"
 testpaths = ["tests"]


### PR DESCRIPTION
## Qué
`src/bib2graph/preprocessors/dedup.py` importa `rapidfuzz` de forma perezosa (extra opcional `[dedup]`). El repo ya tiene un override de mypy para `bibtexparser.*` pero **faltaba el análogo para `rapidfuzz.*`**: sin el extra instalado, `uv run mypy src` fallaba con *"Cannot find implementation or library stub for module named rapidfuzz"*.

Se agrega `[[tool.mypy.overrides]] module = "rapidfuzz.*"  ignore_missing_imports = true`, idéntico al de bibtexparser. Con el extra instalado es un no-op; sin él, suprime el error → el gate queda limpio.

## Nota
Los tests de `test_dedup.py` siguen requiriendo el extra para correr (igual que los de bibtexparser) — esa es la convención actual del repo (CI instala los extras). Hacer que esos tests *skippeen* sin el extra sería un cambio de convención más amplio (tocaría también bibtexparser), fuera de alcance acá.

🤖 Generated with [Claude Code](https://claude.com/claude-code)