### PR TITLE
docs(features): escenarios BDD/Gherkin por historia de usuario (PRD §7)

### DIFF
--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -363,9 +363,9 @@ precisada por el ADR [0015](decisiones/0015-corpus-tabular-backend.md):
   persistencia de 1.0 (DuckDB nativo lo es). Reabrible solo si aparece demanda real, como hito nuevo.
 
 Esta reconciliación ya está reflejada en `ARCHITECTURE.md` (§3.1, §4.3, §6.2), `API.md` (§1, §4) y
-`ROADMAP.md` (Hitos 1.5/3). El estado de construcción (Hitos 0–6 + 1.5 terminados; v0.2 cubre el
-**flujo**, con la **tanda de remediación R1–R5 pendiente** antes de los Hitos 7–11) vive en el
-`ROADMAP.md`.
+`ROADMAP.md` (Hitos 1.5/3). El estado de construcción —**Hitos 0–9 + 1.5 terminados** y la **tanda de
+remediación R1–R5 completa** (2026-06-16)— vive en el `ROADMAP.md`: el terreno **pre-GUI está completo**
+(Hito 10 viz absorbido en la epic GUI #34; Hito 11 Zotero/Neo4j descartado, PO 2026-06-17).
 
 ## 9. Criterios de "V1 hecha"
 
@@ -397,10 +397,13 @@ Esta reconciliación ya está reflejada en `ARCHITECTURE.md` (§3.1, §4.3, §6.
 
 ## 11. Próximos pasos
 
-> ⚠️ **Corrección 2026-06-15:** el punto 1 es **planning histórico ya saldado** (los ADR 0007–0021
+> ⚠️ **Corrección 2026-06-17:** el punto 1 es **planning histórico ya saldado** (los ADR 0007–0021
 > están escritos). Donde dice "tensiones a v2", leer **"tensiones RETIRADAS del producto"** (ADR
-> 0022); el thesaurus es **determinista sin fallback fuzzy/LLM** (ADR 0011 enmendado). El próximo
-> trabajo real es la **tanda de remediación R1–R5** del [`ROADMAP.md`](ROADMAP/README.md).
+> 0022); el thesaurus es **determinista sin fallback fuzzy/LLM** (ADR 0011 enmendado). La **tanda de
+> remediación R1–R5 ya está completa** (2026-06-16) y, sobre ella, los **Hitos 1–9 están construidos**
+> (ver punto 3, actualizado). El **terreno pre-GUI está completo**: el próximo trabajo real es la
+> **epic GUI #34** (la capa de lectura visual), no más backend. Estado vivo en el
+> [`ROADMAP.md`](ROADMAP/README.md).
 
 1. **Nuevos ADRs** (architect), además del [0007](decisiones/0007-openalex-backbone.md) ya
    redactado: wedge = forrajeo (~~tensiones a v2~~ → **retiradas**, ADR 0022); **biblioteca viva en

--- a/docs/features/A-sembrar.feature
+++ b/docs/features/A-sembrar.feature
@@ -1,0 +1,112 @@
+# language: es
+# Épica A — Sembrar con ecuaciones de búsqueda (consciente y estándar)
+# Historias PRD §7: A1, A2, A3, A4, A5
+# Anclado a: src/bib2graph/cli/commands/seed.py, status.py, snapshot.py
+# Realidad post-#75: el estado vive en el library.duckdb del workspace; no existe --store.
+
+Característica: Sembrar el corpus desde la ecuación de búsqueda
+  Como investigador
+  Quiero partir del artefacto estándar (la ecuación) o de papers semilla
+  Para definir mi corpus de forma consciente y reproducible
+
+  Antecedentes:
+    Dado un workspace recién creado con "b2g init mi-investigacion"
+    Y que trabajo dentro de esa carpeta (el workspace se resuelve por cwd)
+
+  # --- A1 · Definir el corpus con una ecuación de búsqueda ---
+  Escenario: A1 — Sembrar desde una ecuación cruda
+    Cuando ejecuto "b2g seed --equation 'unequal exchange' --max-results 50 --json"
+    Entonces el exit code es 0
+    Y el envelope tiene "schema" igual a "1"
+    Y "command" es "seed"
+    Y "data.papers_added" es un entero >= 0
+    Y "data.total_papers" es un entero >= "data.papers_added"
+    Y "data.reseeded" es false
+    Y "data.round" es 1
+
+  # --- A1 (variante) · Sembrar parametrizado por YAML versionable ---
+  Escenario: A1 — Sembrar desde un YAML declarativo (equation.yaml)
+    Dado un archivo "equation.yaml" con la clave raíz "equation:" (modelo EquationSpec)
+    Cuando ejecuto "b2g seed --spec equation.yaml --json"
+    Entonces el exit code es 0
+    Y "data.executed_query" está presente (mismo resultado que --equation + flags)
+    Y "data.round" es 1
+
+  Escenario: A1 — Modos de seed mutuamente excluyentes
+    Cuando ejecuto "b2g seed --equation 'x' --from-bib semillas.bib"
+    Entonces el exit code es 1
+    # Error de USO: Click aborta antes del comando; sale SIN envelope JSON (mensaje en stderr).
+
+  Escenario: A1 — Sin ningún modo de seed
+    Cuando ejecuto "b2g seed --json"
+    Entonces el exit code es 1
+    # UsageError: "Debés especificar un modo: --equation / --spec / --from-bib."
+
+  # --- A2 · Query ejecutada visible + reporte de traducción ---
+  Escenario: A2 — La query ejecutada y el reporte de traducción quedan visibles
+    Cuando ejecuto "b2g seed --equation 'unequal exchange' --exclude 'gas exchange' --json"
+    Entonces el exit code es 0
+    Y "data.executed_query" contiene la query OpenAlex efectivamente ejecutada
+    Y la exclusión queda registrada en "data.translation_report"
+    Y "warnings" refleja "data.translation_report" (ejercicio consciente, no silencioso)
+    # La negación va DENTRO de title_and_abstract.search:((query) AND NOT "gas exchange").
+
+  Escenario: A2 — El filtro de año se reporta en la traducción
+    Cuando ejecuto "b2g seed --equation 'unequal exchange' --min-year 2010 --max-year 2020 --json"
+    Entonces el exit code es 0
+    Y "data.executed_query" incluye "from_publication_date:2010-01-01"
+    Y "data.executed_query" incluye "to_publication_date:2020-12-31"
+    # Ciclo 10 (#50): --min-year/--max-year filtran de verdad contra OpenAlex.
+
+  # --- A3 · Sembrar desde papers semilla (BibTeX, sin red) ---
+  Escenario: A3 — Sembrar desde un archivo BibTeX local sin red
+    Dado un archivo "semillas.bib" válido y el extra [bibtex] instalado
+    Cuando ejecuto "b2g seed --from-bib semillas.bib --json"
+    Entonces el exit code es 0
+    Y "data.papers_added" es un entero >= 0
+    Y el envelope NO incluye "data.executed_query" (no aplica a BibTeX)
+    Y el envelope NO incluye "data.translation_report"
+
+  Escenario: A3 — --from-bib rechaza flags de OpenAlex
+    Cuando ejecuto "b2g seed --from-bib semillas.bib --max-results 10"
+    Entonces el exit code es 1
+    # UsageError: los flags de OpenAlex son exclusivos de --equation/--spec.
+
+  Escenario: A3 — Falta el extra [bibtex]
+    Dado que bibtexparser NO está instalado
+    Cuando ejecuto "b2g seed --from-bib semillas.bib --json"
+    Entonces el exit code es 3
+    Y "error.code" indica una dependencia faltante (DependencyError)
+    # Sugiere: uv sync --extra bibtex.
+
+  Escenario: A3 — Archivo .bib inexistente o malformado
+    Cuando ejecuto "b2g seed --from-bib no-existe.bib --json"
+    Entonces el exit code es 2
+    Y "error.code" indica un error de datos (DataError)
+
+  # --- A4 · Ecuación registrada y versionada con la corrida ---
+  Escenario: A4 — La ecuación queda registrada para reportar y reproducir
+    Dado que sembré con "b2g seed --equation 'unequal exchange' --json"
+    Cuando ejecuto "b2g snapshot --json"
+    Entonces el exit code es 0
+    Y se escribe un parquet + "manifest.json" bajo "snapshots/"
+    Y "data.corpus_hash" no está vacío
+    # El Manifest sella equations/query/filtros; la procedencia vive en la columna provenance.
+
+  # --- A5 · Ecuaciones que mutan entre iteraciones (berrypicking) + acumular ---
+  Escenario: A5 — Re-sembrar con otra ecuación acumula sobre lo curado
+    Dado que sembré y curé una primera ronda en el mismo workspace
+    Cuando ejecuto "b2g seed --equation 'ecological debt' --json"
+    Entonces el exit code es 0
+    Y "data.reseeded" es true
+    Y "data.round" es 2
+    Y "data.total_papers" incluye lo acumulado de la ronda anterior
+    # reseed: loop-back a SEEDED, ronda++, sin perder la biblioteca viva (ADR 0016).
+
+  Escenario: A5 — El estado del lazo refleja la ronda
+    Dado que re-sembré (segunda ronda)
+    Cuando ejecuto "b2g status --json"
+    Entonces el exit code es 0
+    Y "data.loop_state" es "SEEDED"
+    Y "data.round" es 2
+    Y "data.workspace.root" apunta a la carpeta del workspace resuelto

--- a/docs/features/B-forrajear.feature
+++ b/docs/features/B-forrajear.feature
@@ -1,0 +1,82 @@
+# language: es
+# Épica B — Forrajear: chaining asistido por estructura bibliométrica (sin IA)
+# Historias PRD §7: B1, B2, B3, B4 (RETIRADA)
+# Anclado a: src/bib2graph/cli/commands/chain.py
+# Realidad post-#75: workspace por cwd; no existe --store.
+
+Característica: Forrajear con chaining backward/forward rankeado por scent
+  Como investigador
+  Quiero expandir el corpus con las referencias y los citantes de mis semillas
+  Para no hacer snowballing a mano (Wohlin) y revisar primero lo más relevante
+
+  Antecedentes:
+    Dado un workspace con un corpus sembrado (estado SEEDED)
+    Y que trabajo dentro de esa carpeta
+
+  # --- B1 · Backward + forward chaining automáticos ---
+  Escenario: B1 — Chaining en ambas direcciones
+    Cuando ejecuto "b2g chain --direction both --depth 1 --max-citing 25 --json"
+    Entonces el exit code es 0
+    Y "command" es "chain"
+    Y "data.candidates_found" es un entero >= 0
+    Y "data.direction" es "both"
+    Y "data.depth" es 1
+    Y "data.total_papers" es un entero >= "data.candidates_found"
+    Y tras el chain el estado del lazo transiciona a "FORAGED"
+
+  Escenario: B1 — Solo backward chaining (referencias de las semillas)
+    Cuando ejecuto "b2g chain --direction backward --json"
+    Entonces el exit code es 0
+    Y "data.direction" es "backward"
+    Y "data.observed_refs_count" es un entero >= 0
+    # #54: los IDs backward observados sin materializar se cuentan acá y en status.referenced_not_fetched.
+
+  Escenario: B1 — Forward chaining requiere un source con fetch_citing
+    Dado un source sin "fetch_citing_batch" ni "fetch_citing"
+    Cuando ejecuto "b2g chain --direction forward --json"
+    Entonces el exit code es 3
+    Y "error.code" indica una dependencia/capacidad faltante (DependencyError)
+    # Pre-check hasattr en el comando (R5): un AttributeError real no se disfraza de exit 3.
+
+  # --- B2 · Controlar profundidad + preview de crecimiento ---
+  Escenario: B2 — Profundidad 1 es el camino soportado
+    Cuando ejecuto "b2g chain --depth 1 --json"
+    Entonces el exit code es 0
+    Y "data.depth" es 1
+
+  @pendiente @no-implementado
+  Escenario: B2 — Profundidad mayor a 1 (opt-in a depth=2)
+    # PRD §5.1/§7 B2 prometen "opt-in a 2". El CLI lo rechaza hoy.
+    # ROADMAP README: "B2 depth>1 futuro". Forager.chain lanza NotImplementedError,
+    # que chain.py mapea a DependencyError → exit 3.
+    Cuando ejecuto "b2g chain --depth 2 --json"
+    Entonces el exit code es 3
+    Y "error.code" indica que la profundidad 2 no está soportada aún
+    # Cuando se implemente, este escenario pasa a verde con un preview de crecimiento.
+
+  @pendiente @no-implementado
+  Escenario: B2 — Preview de crecimiento antes de traer ("sumaría ~N papers")
+    # PRD §4/§5.1/§7 B2 prometen un "preview de cuánto crece el corpus antes de traer".
+    # AS-BUILT: existe Forager.preview (sin red) en la librería, pero NO hay un
+    # subcomando/flag CLI que lo exponga (no hay `b2g chain --preview` ni `b2g preview`).
+    # API.md §5 lo declara como API de librería, no de CLI.
+    Cuando ejecuto un comando que reporte el crecimiento estimado sin materializar
+    Entonces obtengo el conteo previsto de la expansión antes del fetch
+    # Gap real: encuadre necesario (¿flag --dry-run de chain?). No escribir en verde.
+
+  # --- B3 · Candidatos rankeados por estructura (information scent, sin IA) ---
+  Escenario: B3 — Los candidatos vienen rankeados por scent
+    Cuando ejecuto "b2g chain --direction both --json"
+    Entonces el exit code es 0
+    Y "data.ranking_preview" es una lista de objetos "{id, scent}"
+    Y la lista está ordenada de mayor a menor "scent" (lo más relevante primero)
+    # HONESTIDAD: el scent AS-BUILT es frecuencia de enlace (ADR 0020), determinista y sin IA.
+    # La promesa "scent bibliométrico vía proyectores (acoplamiento/centralidad)" es la
+    # remediación R4 declarada; verificá el método real del Forager antes de afirmar más.
+
+  # --- B4 · RETIRADA (no es un Scenario) ---
+  # B4 ("paso opcional de IA que explica por qué un candidato es relevante") fue RETIRADA
+  # del producto por ADR 0022 (2026-06-15): bib2graph NO usa IA generativa.
+  # explain_candidate y el extra [llm] se ELIMINARON. El "porqué" de un candidato lo da la
+  # estructura visible (con qué del corpus se acopla/co-cita), no un LLM.
+  # No hay escenario verde ni @pendiente: es historia retirada, no trabajo diferido.

--- a/docs/features/C-curar.feature
+++ b/docs/features/C-curar.feature
@@ -1,0 +1,120 @@
+# language: es
+# Épica C — Ejercicio bibliotecario y biblioteca viva (curar y conservar)
+# Historias PRD §7: C1 (no-CLI), C2 (no-CLI), C3, C4
+# Anclado a: src/bib2graph/cli/commands/filter.py, curate.py, accept.py, reject.py
+# Realidad post-#75: workspace por cwd; no existe --store.
+
+Característica: Curar el corpus con filtros PRISMA y biblioteca viva
+  Como investigador
+  Quiero aplicar criterios de inclusión/exclusión con conteo y aceptar/rechazar candidatos
+  Para curar con trazabilidad y cultivar una colección que crece entre corridas
+
+  Antecedentes:
+    Dado un workspace con un corpus forrajeado (estado FORAGED)
+    Y que trabajo dentro de esa carpeta
+
+  # --- C1 · Dedup y normalización de autores/instituciones ---
+  @pendiente @no-implementado
+  Escenario: C1 — Dedup/normalización de autores e instituciones por CLI
+    # PRD §7 C1 pide dedup/normalización apoyada en IDs OpenAlex (ORCID/ROR/DOI).
+    # AS-BUILT: normalize_authors_id / deduplicate_keywords / Preprocessor existen como
+    # API de librería (src/bib2graph/preprocessors/), pero NINGÚN subcomando b2g los expone
+    # (no hay `b2g normalize` ni `b2g preprocess`). Instituciones: DIFERIDAS (ROADMAP C1).
+    # Por eso no hay receta CLI verde para esta historia hoy.
+    Cuando ejecuto un comando que normalice/deduplique autores e instituciones
+    Entonces las variantes de nombre colapsan apoyadas en ORCID/ROR
+    # Gap real: el preprocesamiento vive en la librería; falta encuadre de su superficie CLI.
+
+  # --- C2 · Normalizar keywords con thesaurus multilingüe ---
+  @pendiente @no-implementado
+  Escenario: C2 — Aplicar el thesaurus multilingüe (en/es/pt) por CLI
+    # PRD §7 C2 pide normalizar keywords con un thesaurus curado y auditable, para que
+    # conceptos equivalentes en distintos idiomas colapsen (p. ej. "intercambio ecológico
+    # desigual" ≡ "unequal exchange").
+    # AS-BUILT: apply_thesaurus vive en src/bib2graph/preprocessors/thesaurus.py (determinista,
+    # SIN fallback LLM — ADR 0022/0011), pero NO hay subcomando b2g que lo exponga.
+    # API.md §5/§6 lo declara como API de librería.
+    Cuando ejecuto un comando que aplique el thesaurus al corpus
+    Entonces "keywords_id" se reescribe con los conceptos canónicos del thesaurus
+    # Gap real: falta superficie CLI del Preprocessor.
+
+  # --- C3 · Filtros de inclusión/exclusión con conteo por paso (PRISMA) ---
+  Escenario: C3 — Filtrar por año e idioma con conteo en cada paso
+    Cuando ejecuto "b2g filter --year-gte 2010 --language en --language es --json"
+    Entonces el exit code es 0
+    Y "command" es "filter"
+    Y "data.criteria_applied" es 2
+    Y "data.steps" es una lista, una entrada por criterio
+    Y cada entrada tiene "count_before", "count_after" y "excluded"
+    Y "excluded" es igual a "count_before" menos "count_after"
+    Y tras el filtro el estado del lazo transiciona a "FILTERED"
+    # Los filtros MARCAN rejected (no borran): el corpus conserva la trazabilidad PRISMA.
+
+  Escenario: C3 — Filtrar sin ningún criterio es un error de datos
+    Cuando ejecuto "b2g filter --json"
+    Entonces el exit code es 2
+    Y "error.code" indica un error de datos (DataError)
+    # "Debés especificar al menos un criterio: --year-gte/--year-lte/--language/--type/--min-citations."
+
+  Escenario: C3 — Filtro por mínimo de citas
+    Cuando ejecuto "b2g filter --min-citations 5 --json"
+    Entonces el exit code es 0
+    Y "data.steps" incluye un paso de mínimo de citas (len(cited_by_id) >= 5)
+
+  # --- C4 · Aceptar/rechazar + biblioteca viva persistida que crece ---
+  Escenario: C4 — Aceptar candidatos por ID
+    Dado un candidato con id "oa:abc123def456" en el corpus
+    Cuando ejecuto "b2g accept --ids oa:abc123def456 --json"
+    Entonces el exit code es 0
+    Y "command" es "accept"
+    Y "data.accepted_count" es 1
+    Y "accept" NO transiciona el estado del lazo (curación transversal)
+
+  Escenario: C4 — Aceptar un ID inexistente
+    Cuando ejecuto "b2g accept --ids oa:no-existe --json"
+    Entonces el exit code es 2
+    Y "error.code" indica un error de datos (DataError)
+    # "IDs no encontrados en el corpus: [...]. Verificá con b2g inspect."
+
+  Escenario: C4 — Rechazar candidatos por ID
+    Cuando ejecuto "b2g reject --ids oa:abc123def456 --json"
+    Entonces el exit code es 0
+    Y "command" es "reject"
+    # reject tampoco transiciona el lazo (curación transversal).
+
+  # --- C4 (escala) · Curación en lote vía CSV ---
+  Escenario: C4 — Volcar candidatos a CSV para revisión offline
+    Cuando ejecuto "b2g curate --dump --json"
+    Entonces el exit code es 0
+    Y se escribe "exports/curacion.csv" con las 16 columnas estables
+    Y "data.papers_exported" es un entero >= 0
+    # Default scope=candidates: status==candidate AND is_seed==False (EXCLUYE semillas, #72).
+    # Solo "decision" y "note" son editables por el humano.
+
+  Escenario: C4 — Volcar semillas o todo el corpus con --scope
+    Cuando ejecuto "b2g curate --dump --scope all --json"
+    Entonces el exit code es 0
+    Y "data.papers_exported" cubre todo el corpus (candidates + seeds + accepted + rejected)
+
+  Escenario: C4 — Reimportar las decisiones del CSV en lote (idempotente)
+    Dado un "exports/curacion.csv" con la columna "decision" editada
+    Cuando ejecuto "b2g curate --from-csv exports/curacion.csv --json"
+    Entonces el exit code es 0
+    Y "data.accepted_count" cuenta papers efectivamente marcados como accepted
+    Y "data.rejected_count" cuenta papers efectivamente marcados como rejected
+    Y "data.skipped_count" cuenta las filas "undecided" (no-op)
+    Y "data.not_found_count" cuenta IDs del CSV ausentes del corpus (huérfanos, sin abortar)
+    # Idempotente: reimportar el mismo CSV deja el mismo corpus_hash (note se ignora al importar).
+
+  Escenario: C4 — from-csv con una decision inválida falla accionable
+    Dado un CSV con un valor de "decision" fuera de {accepted, rejected, undecided}
+    Cuando ejecuto "b2g curate --from-csv exports/curacion.csv --json"
+    Entonces el exit code es 2
+    Y "error.code" indica un error de datos (DataError)
+
+  Escenario: C4 — La biblioteca viva crece y persiste entre corridas
+    Dado que acepté papers en una ronda anterior
+    Cuando vuelvo a sembrar y curar en el mismo workspace
+    Entonces los papers aceptados previos siguen en el corpus
+    Y "b2g status --json" muestra los conteos por "curation_status" acumulados
+    # La biblioteca viva es DuckDB nativo; la sincronización con Zotero está DESCARTADA (PO 2026-06-17).

--- a/docs/features/D-redes.feature
+++ b/docs/features/D-redes.feature
@@ -1,0 +1,111 @@
+# language: es
+# Épica D — Proyectar a redes (el final sigue siendo las redes)
+# Historias PRD §7: D1, D2, D3 (no-CLI), D4
+# Anclado a: src/bib2graph/cli/commands/build.py, networks.py, export.py, enrich.py
+#            src/bib2graph/networks/facade.py, analyzer.py, spec.py
+# Realidad post-#75: workspace por cwd; no existe --store.
+
+Característica: Proyectar el corpus a redes bibliométricas y exportarlas
+  Como investigador
+  Quiero proyectar el corpus a redes con métricas y comunidades, y exportarlas
+  Para analizar la estructura intelectual del campo en Gephi/VOSviewer/pandas
+
+  Antecedentes:
+    Dado un workspace con un corpus curado (estado FILTERED o posterior)
+    Y que trabajo dentro de esa carpeta
+
+  # --- D1 · Cinco proyecciones ---
+  Escenario: D1 — Construir las redes principales con build
+    Cuando ejecuto "b2g build --json"
+    Entonces el exit code es 0
+    Y "command" es "build"
+    Y "data.networks_built" es 4 o 5
+    Y "data.networks" incluye los kinds "bibliographic_coupling", "author_collab", "institution_collab" y "keyword_cooccurrence"
+    Y cada red escribe "networks/<kind>/network.graphml" y "networks/<kind>/metrics.json"
+    Y tras el build el estado del lazo transiciona a "BUILT"
+    Y "networks/.corpus_hash" queda sellado con el hash del corpus filtrado
+
+  Escenario: D1 — La co-citación aparece solo tras enriquecer (cited_by_id)
+    Dado un corpus sin "cited_by_id" poblado
+    Cuando ejecuto "b2g enrich --max-citing 25 --json"
+    Y luego ejecuto "b2g build --json"
+    Entonces "data.networks_built" es 5
+    Y "data.networks" incluye el kind "cocitation"
+    # Networks.quick agrega cocitación solo si algún paper tiene cited_by_id (Hito 8b).
+    # enrich NO transiciona el lazo (ortogonal al FSM).
+
+  Escenario: D1 — Filtrar el corpus por curación antes de proyectar
+    Cuando ejecuto "b2g build --corpus-scope accepted --json"
+    Entonces el exit code es 0
+    Y "data.corpus_scope" es "accepted"
+    # accepted = semillas (is_seed=True) + papers aceptados. NO confundir con NetworkSpec.scope.
+
+  Escenario: D1 — Scope que deja 0 papers no es error
+    Cuando ejecuto "b2g build --corpus-scope seeds_only --json" sobre un corpus sin semillas
+    Entonces el exit code es 0
+    Y "data.networks_built" es 0
+    Y "warnings" sugiere correr "b2g curate" o usar "--corpus-scope=all"
+
+  # --- D2 · Métricas y comunidades ---
+  Escenario: D2 — Cada red emite métricas y comunidades
+    Dado que ejecuté "b2g build --json"
+    Cuando leo "networks/<kind>/metrics.json"
+    Entonces incluye "density", "nodes" y "edges"
+    Y las redes de paper (bibliographic_coupling, cocitation) con comunidades escriben "networks/<kind>/clusters.csv"
+    Y en el envelope la entrada de esa red suma "clusters_csv"
+    # Comunidades por Louvain (sembrado por corpus_hash → reproducible, R2).
+    # author_collab/institution_collab/keyword_cooccurrence NO emiten clusters.csv por diseño.
+
+  # --- D3 · Asortatividad + composición de comunidades + disclaimer de proxy ---
+  @pendiente @no-implementado
+  Escenario: D3 — Asortatividad por atributo y composición de comunidades, con disclaimer de proxy
+    # PRD §7 D3 pide asortatividad (por atributo categórico configurable y por grado) y la
+    # composición de cada comunidad por ese atributo, con el disclaimer si el atributo es proxy.
+    # AS-BUILT: assortativity() y community_composition() EXISTEN como funciones puras en
+    # networks/analyzer.py (con 'proxy_disclaimer') y se re-exportan en networks/__init__.py,
+    # PERO no hay camino CLI: facade._build_artifact fija siempre assortativity=None y NO
+    # consume NetworkSpec.assortativity_attribute; ni build, ni networks, ni export las invocan.
+    # Es API de librería (Python), no de CLI.
+    Cuando ejecuto un comando que calcule asortatividad/composición con el disclaimer de proxy
+    Entonces obtengo el coeficiente por atributo y por grado, y la composición por comunidad
+    Y, si el atributo es un proxy, un "proxy_disclaimer" lo advierte
+    # Gap real: cablear assortativity_attribute en el camino del artefacto y exponerlo en el CLI.
+
+  # --- D4 · Export GraphML/CSV ---
+  Escenario: D4 — Exportar las redes a GraphML
+    Dado que ejecuté "b2g build --json"
+    Cuando ejecuto "b2g export --format graphml --json"
+    Entonces el exit code es 0
+    Y "command" es "export"
+    Y "data.format" es "graphml"
+    Y los archivos se escriben bajo "exports/<kind>/network.graphml"
+    Y "export" NO transiciona el estado del lazo
+
+  Escenario: D4 — Exportar las redes a CSV (nodos y aristas)
+    Dado que ejecuté "b2g build --json"
+    Cuando ejecuto "b2g export --format csv --json"
+    Entonces el exit code es 0
+    Y "data.format" es "csv"
+    Y por cada red se escriben "nodos.csv" y "aristas.csv"
+
+  Escenario: D4 — Exportar sin haber construido falla accionable
+    Dado un workspace sin artefactos en "networks/"
+    Cuando ejecuto "b2g export --format graphml --json"
+    Entonces el exit code es 2
+    Y "error.code" indica un error de datos (DataError)
+    # "No hay artefactos de build. Ejecutá primero b2g build."
+
+  # --- D (capa declarativa) · Redes ad-hoc desde YAML ---
+  Escenario: D1 — Construir redes declarativas desde un YAML (networks --spec)
+    Dado un archivo "redes.yaml" con la clave raíz "networks:" (lista de NetworkSpec)
+    Cuando ejecuto "b2g networks --spec redes.yaml --json"
+    Entonces el exit code es 0
+    Y "command" es "networks"
+    Y "data.networks" tiene una entrada por red definida en el YAML
+    Y "networks --spec" NO transiciona el lazo ni sella "networks/.corpus_hash"
+
+  Escenario: D1 — YAML de redes malformado o spec inválida
+    Dado un "redes.yaml" con un campo desconocido (extra="forbid")
+    Cuando ejecuto "b2g networks --spec redes.yaml --json"
+    Entonces el exit code es 2
+    Y "error.code" indica un error de datos (DataError)

--- a/docs/features/E-reproducibilidad-agente.feature
+++ b/docs/features/E-reproducibilidad-agente.feature
@@ -1,0 +1,95 @@
+# language: es
+# Épica E — Reproducibilidad y agente-native
+# Historias PRD §7: E1, E2
+# Anclado a: src/bib2graph/cli/commands/snapshot.py, restore.py, status.py
+#            src/bib2graph/cli/__init__.py (envelope, exit codes, --workspace global)
+# Realidad post-#75: el estado vive en el library.duckdb del workspace; --store ELIMINADA.
+
+Característica: Snapshot reproducible y orquestación agente-native por CLI
+  Como investigador y como agente/automatización
+  Quiero exportar una foto reproducible y orquestar cada paso por CLI con --json
+  Para auditar/reportar la corrida y operar bib2graph sin GUI
+
+  Antecedentes:
+    Dado un workspace con un corpus curado
+    Y que trabajo dentro de esa carpeta
+
+  # --- E1 · Snapshot reproducible del estado vivo ---
+  Escenario: E1 — Exportar un snapshot sellado
+    Cuando ejecuto "b2g snapshot --json"
+    Entonces el exit code es 0
+    Y "command" es "snapshot"
+    Y se escribe un parquet + "manifest.json" bajo "snapshots/"
+    Y "data.corpus_hash" no está vacío
+    Y "data.total_papers" es el número de papers del corpus
+    Y "snapshot" NO transiciona el estado del lazo
+
+  Escenario: E1 — Reproducir = re-leer el snapshot, no re-correr la ecuación
+    Dado un parquet "corpus.parquet" producido por "b2g snapshot"
+    Y un workspace nuevo distinto
+    Cuando ejecuto "b2g restore --from-corpus corpus.parquet --json"
+    Entonces el exit code es 0
+    Y "command" es "restore"
+    Y "data.papers_loaded" es el número de papers del parquet
+    Y "data.state" es "FILTERED"
+    Y la restauración NO hace ninguna llamada a OpenAlex (sin red)
+    # restore preserva la curación (curation_status/is_seed); reproducir NO re-corre la
+    # ecuación (ADR 0017). OpenAlex cambia en el tiempo: re-correr es re-investigar, no reproducir.
+
+  Escenario: E1 — El corpus_hash es estable entre corridas (identidad por contenido)
+    Dado dos corridas que aceptan los mismos IDs en el mismo corpus
+    Cuando comparo "data.corpus_hash" de sus snapshots
+    Entonces ambos hashes coinciden
+    # R2 (ADR 0017 enmendado): el hash excluye provenance/timestamps e incluye curation_status.
+
+  Escenario: E1 — Restaurar un parquet con schema no canónico falla accionable
+    Cuando ejecuto "b2g restore --from-corpus ajeno.parquet --json"
+    Entonces el exit code es 2
+    Y "error.code" indica un error de datos (DataError)
+
+  # --- E2 · CLI con --json y exit codes para agentes ---
+  Escenario: E2 — Cada subcomando emite el envelope versionado
+    Cuando ejecuto cualquier subcomando con "--json"
+    Entonces la salida es un único objeto JSON
+    Y tiene los campos "schema", "ok", "command", "exit_code", "data", "warnings", "error"
+    Y "schema" es "1"
+    Y en éxito "ok" es true y "error" es null
+
+  Escenario: E2 — Mapeo de exit codes por tipo de error
+    # ADR 0021 §D — el decorador @handle_errors mapea por tipo:
+    #   0 éxito · 1 uso · 2 datos (DataError) · 3 dependencia (DependencyError/ImportError/
+    #   NotImplementedError) · 4 red (httpx.HTTPError) · 5 store bloqueado/corrupto
+    #   (StoreLockedError/OSError).
+    Cuando un comando falla con un DataError conocido
+    Entonces el exit code es 2
+    Y "ok" es false
+    Y "data" es un objeto vacío
+    Y "error.code" y "error.message" describen el fallo de forma accionable
+
+  Escenario: E2 — El error de USO sale SIN envelope JSON
+    Cuando ejecuto "b2g seed --store x.duckdb --json"
+    Entonces el exit code es 1
+    Y NO se emite envelope JSON (Click aborta el parseo antes del comando)
+    # --store fue ELIMINADA (#75): produce "No such option: --store" en stderr.
+
+  Escenario: E2 — Sin workspace resoluble, error accionable
+    Dado un directorio que no es un workspace y sin B2G_WORKSPACE
+    Cuando ejecuto "b2g status" fuera de cualquier workspace
+    Entonces el exit code es 1
+    Y el mensaje sugiere "b2g init" o "--workspace"
+
+  Escenario: E2 — status expone el mapa del lazo para el agente
+    Cuando ejecuto "b2g status --json"
+    Entonces el exit code es 0
+    Y "data.loop_state" refleja el estado del FSM (SEEDED/FORAGED/FILTERED/BUILT/MONITORED o null)
+    Y "data.transitions_available" lista las transiciones del estado actual
+    Y "data.curation_available" lista "accept" y "reject" (curación transversal siempre disponible)
+    Y "data.round" es el contador de ronda
+    Y "data.counts_by_status" tiene los conteos por "curation_status"
+    Y "data.workspace" tiene "root" y "source" (de dónde se resolvió el workspace)
+    Y "data.networks_cache_stale" indica si la cache de redes quedó obsoleta
+
+  Escenario: E2 — Sin estado entre invocaciones (stateful vía archivo)
+    Dado que ejecuté un seed en una invocación previa
+    Cuando ejecuto "b2g status --json" en una invocación nueva
+    Entonces el estado persiste (vive en el library.duckdb del workspace, no en el proceso)

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -1,0 +1,104 @@
+# Escenarios BDD/Gherkin — bib2graph
+
+> Especificación ejecutable-en-prosa del CLI `b2g`, anclada a la **verdad del código**
+> (`src/bib2graph/cli/commands/*.py`) y a las historias de usuario del [`PRD.md`](../PRD.md) §7.
+> Cada `.feature` cubre una épica; cada historia (A1…E2) tiene uno o más `Scenario`.
+> Fecha: 2026-06-17. Realidad post-#75 (`--store` eliminada; workspace por `b2g init`).
+
+Estos escenarios son hoy **recetas CLI reproducibles** (se corren a mano, ver abajo). A futuro se
+vuelven **ejecutables con `pytest-bdd`** apuntando a este mismo directorio, sin mover archivos.
+
+## Índice — qué historia cubre cada feature
+
+| Feature | Épica (PRD §7) | Historias | Subcomandos anclados |
+|---|---|---|---|
+| [`A-sembrar.feature`](A-sembrar.feature) | A — Sembrar con ecuaciones | A1, A2, A3, A4, A5 | `seed` (`--equation`/`--spec`/`--from-bib`), `status`, `snapshot` |
+| [`B-forrajear.feature`](B-forrajear.feature) | B — Forrajear (chaining) | B1, B2, ~~B3~~, ~~B4~~ | `chain` (`--direction`/`--depth`/`--max-citing`) |
+| [`C-curar.feature`](C-curar.feature) | C — Ejercicio bibliotecario | ~~C1~~, ~~C2~~, C3, C4 | `filter`, `curate`, `accept`, `reject` |
+| [`D-redes.feature`](D-redes.feature) | D — Proyectar a redes | D1, D2, ~~D3~~, D4 | `build`, `networks`, `export`, `enrich` |
+| [`E-reproducibilidad-agente.feature`](E-reproducibilidad-agente.feature) | E — Reproducibilidad + agente | E1, E2 | `snapshot`, `restore`, todos con `--json` |
+
+### Estado por historia (verde = soportado hoy por el CLI · `@pendiente` = gap honesto)
+
+| Historia | Estado | Motivo / fuente del gap |
+|---|---|---|
+| A1 ecuación de búsqueda | verde | `seed --equation` |
+| A2 query ejecutada + reporte | verde | `data.executed_query` + `data.translation_report` |
+| A3 semillas / `.bib` | verde | `seed --from-bib` (Ciclo 10, #50) |
+| A4 ecuación registrada/versionada | verde (parcial) | persistida en `provenance`/`Manifest`; el sello reproducible se ve en `snapshot` |
+| A5 ecuaciones que mutan + acumular | verde | reseed: `seed` con estado previo → `round++`, acumula sobre lo curado |
+| B1 back/forward chaining | verde | `chain --direction backward\|forward\|both` |
+| B2 profundidad + preview | **parcial / `@pendiente`** | `--depth 1` OK; `depth>1` → `DependencyError` (exit 3). **No existe un comando de "preview de crecimiento" previo al fetch** (PRD §5.1 lo promete; el AS-BUILT lo dejó como `Forager.preview` de librería, no CLI). ROADMAP B2: "`depth>1` futuro" |
+| B3 ranking por estructura | verde (parcial) | `chain` devuelve `data.ranking_preview` (lista `{id, scent}`). El scent AS-BUILT es **frecuencia de enlace** (ADR 0020), no acoplamiento/centralidad puro — la promesa "scent bibliométrico vía proyectores" (R4) está como heurística |
+| ~~B4~~ explicación por IA | **RETIRADA** | ADR 0022: el producto no usa IA generativa. `explain_candidate`/`[llm]` eliminados. Documentada como retirada, sin `Scenario` verde |
+| C1 dedup/normalización autores+inst. | **`@pendiente`** | **No hay subcomando CLI**: `normalize`/`deduplicate_keywords` son API de librería (`preprocessors/`), no `b2g`. Instituciones diferidas (ROADMAP C1). El CLI no expone preprocesamiento |
+| C2 thesaurus multilingüe | **`@pendiente`** | **No hay subcomando CLI**: `apply_thesaurus` es API de librería (`preprocessors/thesaurus.py`), no `b2g`. Determinista, sin fallback LLM (ADR 0022/0011) |
+| C3 filtros incl/excl con conteo | verde | `filter` con `data.steps[].count_before/count_after/excluded` (flujo PRISMA) |
+| C4 aceptar/rechazar + biblioteca viva | verde | `accept`/`reject --ids`, `curate --dump`/`--from-csv`; persiste y crece entre corridas |
+| D1 cinco proyecciones | verde (parcial) | `build` da 4 redes; la 5ª (cocitación) requiere `enrich` previo (cited_by_id). Instituciones salen si hay `institutions_id` |
+| D2 métricas y comunidades | verde | `metrics.json` (density, etc.) + comunidades Louvain; `clusters.csv` en redes de paper |
+| D3 asortatividad + composición + proxy | **`@pendiente`** | **No hay camino CLI**: `assortativity()`/`community_composition()` existen como funciones puras en `networks/analyzer.py` y se re-exportan en `networks/__init__.py`, pero `facade._build_artifact` fija `assortativity=None` y **no consume** `NetworkSpec.assortativity_attribute`. Es API de librería, no de CLI |
+| D4 export GraphML/CSV | verde | `build` (GraphML+metrics+clusters), `export --format graphml\|csv` |
+| E1 snapshot reproducible | verde | `snapshot` (parquet + `manifest.json` con `corpus_hash`); `restore` re-lee sin red |
+| E2 CLI `--json` + exit codes | verde | envelope `schema="1"` en todos; exit codes 0–5 |
+
+## Cómo correr los escenarios a mano hoy (recetas CLI reproducibles)
+
+Todo arranca con un **workspace** (post-#75: no existe `--store`; el estado vive en el
+`library.duckdb` del workspace, resuelto por `b2g init` + cwd, `--workspace` o `B2G_WORKSPACE`).
+
+```bash
+# Setup (Background de cada feature)
+uv run b2g init mi-investigacion
+cd mi-investigacion          # a partir de acá los comandos resuelven el workspace por cwd
+
+# A — sembrar (con red; recomendá --email para el polite pool de OpenAlex)
+uv run b2g seed --equation "unequal exchange" --max-results 50 --json
+uv run b2g seed --spec equation.yaml --json
+uv run b2g seed --from-bib semillas.bib --json     # sin red
+
+# B — forrajear
+uv run b2g chain --direction both --depth 1 --max-citing 25 --json
+
+# C — curar
+uv run b2g filter --year-gte 2010 --language en --json
+uv run b2g curate --dump --json                    # escribe exports/curacion.csv (solo candidatos)
+# (editar la columna decision en exports/curacion.csv)
+uv run b2g curate --from-csv exports/curacion.csv --json
+uv run b2g accept --ids oa:abc123 --json
+
+# D — redes
+uv run b2g enrich --max-citing 25 --json           # puebla cited_by_id (habilita cocitación)
+uv run b2g build --json                            # 4 o 5 redes en networks/<kind>/
+uv run b2g networks --spec redes.yaml --json       # redes ad-hoc desde YAML
+uv run b2g export --format graphml --json
+
+# E — reproducibilidad / agente
+uv run b2g snapshot --json                          # snapshots/<...>/corpus.parquet + manifest.json
+uv run b2g status --json                            # mapa del lazo, conteos, workspace
+uv run b2g restore --from-corpus corpus.parquet --json   # rehidrata sin red
+
+# Caso real reproducible sin red (gate #33):
+uv run b2g restore --from-corpus ../examples/valoraciones/corpus.parquet --json
+uv run b2g build --json
+```
+
+Los pasos con red (`seed --equation/--spec`, `chain`, `enrich`, `monitor`) consultan OpenAlex; los
+sin red (`seed --from-bib`, `filter`, `accept`/`reject`/`curate`, `build`, `networks`, `export`,
+`snapshot`, `restore`, `status`) son deterministas y no requieren conexión.
+
+## Nota sobre futura ejecutabilidad (pytest-bdd)
+
+Cuando se cableen con `pytest-bdd`, la configuración va en `pyproject.toml`/`pytest.ini` sin mover
+estos archivos:
+
+```ini
+[pytest]
+bdd_features_base_dir = docs/features
+```
+
+Los `Then` ya están redactados contra **campos exactos del envelope** (`data.papers_added`,
+`data.steps[].excluded`, `data.loop_state`, …), **exit codes exactos** (0–5) y **artefactos**
+(`networks/<kind>/network.graphml`), de modo que los step-defs sean implementables sin reescribir
+los `.feature`. Los escenarios marcados `@pendiente` quedan como documentación honesta del gap (se
+saltarán con `@pytest.mark.skip` o un tag de skip hasta que el CLI los soporte).


### PR DESCRIPTION
## Qué
Detalla las historias de usuario del PRD §7 como **escenarios BDD/Gherkin ejecutables a mano por CLI**, anclados al CLI real post-#75. Nuevo `docs/features/`:
- Un `.feature` por épica: `A-sembrar`, `B-forrajear`, `C-curar`, `D-redes`, `E-reproducibilidad-agente`.
- `README.md`: índice historia→feature, tabla de estado, recetas CLI reproducibles, y nota de ejecutabilidad futura con `pytest-bdd` (`bdd_features_base_dir = docs/features`, sin mover archivos).

Given/When/Then en español, con campos exactos del envelope `--json`, exit codes 0–5 y artefactos — **verificados por smoke-test offline contra el CLI real** (restore del corpus de ejemplo → build/status/curate/metrics).

## Gaps honestos PRD↔CLI (marcados `@pendiente`, no inventados en verde)
- **B2** — `depth>1` no implementado; **no hay preview de crecimiento por CLI** (`Forager.preview` quedó como API de librería). El PRD §5.1 lo promete.
- **C1/C2** — `normalize`/`thesaurus`/`dedup` **no tienen subcomando `b2g`** (solo `preprocessors/`, librería). El flujo CLI no puede normalizar ni aplicar thesaurus.
- **D3** — `assortativity()`/`community_composition()` existen como funciones puras pero el camino del artefacto las ignora (`facade` fija `assortativity=None`).
- **B4** — retirada (ADR 0022).

## Extra
Corrige drift del PRD §8/§11 (R1–R5 y Hitos 1–9 ya hechos).

🤖 Generated with [Claude Code](https://claude.com/claude-code)