### PR TITLE
ci(publish): wheel con --wheel (uv build vía sdist perdía el frontend)

### DIFF
--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -42,8 +42,11 @@ jobs:
         run: |
           pnpm install --frozen-lockfile
           pnpm build
-      - name: Build (sdist + wheel)
-        run: uv build
+      - name: Build wheel (directo del working tree, con el frontend ya buildeado)
+        # NO `uv build` a secas: eso arma sdist y el wheel DESDE el sdist, que
+        # excluye el frontend gitignored (gui/static) → force-include falla.
+        # `--wheel` construye el wheel directo del árbol (con el pnpm build de arriba).
+        run: uv build --wheel
       - name: Publish to TestPyPI (trusted publishing)
         uses: pypa/gh-action-pypi-publish@release/v1
         with:


### PR DESCRIPTION
**Fix del publish a TestPyPI.** La corrida de `publish-testpypi` (v0.7.0) falló:

```
Building wheel from source distribution...
FileNotFoundError: Forced include not found: .../bib2graph-0.7.0/src/bib2graph/gui/static
```

**Causa:** `uv build` arma sdist → y el wheel **desde el sdist**. El sdist excluye `gui/static` (build output gitignored), así que el `force-include` no lo encuentra → falla. El `pnpm build` del workflow llena `gui/static` en el working tree, pero ese contenido se pierde al pasar por el sdist.

**Fix:** `uv build` → `uv build --wheel` (construye el wheel **directo del working tree**, con el frontend ya buildeado). Wheel-only en TestPyPI; `pip install bib2graph[gui]` usa el wheel universal. **Verificado local:** `unzip -l` lista `gui/static/index.html` + assets.

`ci:` → no genera entrada en el CHANGELOG.

## Para que llegue a producción del publish
1. Merge este PR → `dev`.
2. PR `dev → main` (merge commit) — solo trae este `ci:`, release-please NO corta versión nueva.
3. Re-correr `publish-testpypi` desde `main` (sigue siendo v0.7.0).