### PR TITLE
docs: notas de sesiones e2e (14 anomalías ML + 15 capa lectura/análisis)

### DIFF
--- a/docs/Notas/14-sesion-e2e-anomalias-ml.md
+++ b/docs/Notas/14-sesion-e2e-anomalias-ml.md
@@ -1,0 +1,191 @@
+# 14 — Sesión e2e con `prueba_e2e/`: detección de anomalías ML (interpretabilidad + teoría de la información)
+
+> ⚠️ **NOTA DE SESIÓN — no es decisión ni ADR.** Captura un uso real del producto v0.6
+> como investigador con una pregunta concreta, ejecutando el ciclo **100% por el CLI `b2g`**
+> hasta donde el CLI alcanzó, y bajando a Python solo donde el CLI no llegó. El objetivo
+> de esta nota es **registrar exactamente dónde hubo que bajar a Python y por qué** — eso es
+> el feedback valioso: cada bajada a Python es un hueco del CLI. Fecha: 2026-06-18.
+> Documentos hermanos: [`09-sesion-qa-prueba-ecologia-valoraciones.md`](09-sesion-qa-prueba-ecologia-valoraciones.md)
+> (la sesión QA análoga sobre `prueba/`, que motivó #14/#21/#22/#25/#26),
+> [`13-continuacion-sesion-valoraciones.md`](13-continuacion-sesion-valoraciones.md).
+
+## Tesis de la sesión
+
+A diferencia de la sesión 09 —donde casi todo se hizo con scripts Python porque el CLI
+todavía no existía o estaba incompleto—, acá el CLI **ya cubre la columna vertebral del
+ciclo** (init → seed → build → snapshot, todo verde, sin un solo script). La pregunta de
+investigación fue: *¿cuáles son los métodos más actuales de detección de anomalías en ML,
+especialmente los que tienen interpretabilidad y usan teoría de la información?* El corpus
+quedó en `prueba_e2e/ml-anomalias/` (workspace gitignoreado, ADR 0029).
+
+El hallazgo metodológico de la sesión: **lo que quedó en Python ya no es el ciclo, es la
+lectura del corpus**. Todos los gestos de "sembrar y construir" son CLI puro; todos los
+gestos de "mirar qué hay adentro" siguen exigiendo Python. Ese es el hueco que esta nota
+documenta.
+
+## Lo que se hizo (el flujo real)
+
+| Paso | Comando / código | Frontera | Resultado |
+|---|---|---|---|
+| 1 | `b2g init ml-anomalias --name "…"` | **CLI** | workspace creado (v0.6.0) |
+| 2 | `b2g seed --email … --max-results 200 --min-year 2018 --equation '(…) AND (…) AND (…)'` | **CLI** | 199 papers (`candidate`), query traducida a `title_and_abstract.search:(…)` + `from_publication_date:2018-01-01` |
+| 3 | `b2g status --json` | **CLI** | `SEEDED`, 199 candidatos, round 1 |
+| 4 | *listar títulos por año + histograma* | **Python** ⚠️ | 138/199 son 2025–26; 30 títulos más recientes |
+| 5 | `b2g build --json` | **CLI** | 4 redes (acoplamiento, co-autoría, instituciones, keywords) + `clusters.csv` por red |
+| 6 | *leer `clusters.csv`* | **CLI (output)** | clusters legibles, pero keywords genéricos de OpenAlex |
+| 7 | *conteo de familias de método sobre los 199 abstracts* | **Python** ⚠️ | tabla de frecuencias (entropy 120, MI 38, SHAP 27, IB 10, causal 19, …) |
+| 8 | *títulos ejemplares por método (regex sobre título)* | **Python** ⚠️ | papers concretos por familia |
+| 9 | `b2g snapshot --json` | **CLI** | foto sellada en `snapshots/` |
+
+La ecuación fue la intersección AND de tres bloques (anomaly/outlier/OOD detection) ∧
+(interpretable/explainable/XAI) ∧ (information theory/MI/entropy/information bottleneck).
+La intersección casi llenó el cap de 200 → el cruce de los tres conceptos está bien poblado
+en la literatura 2024–2026.
+
+## El feedback central: para qué se usó Python y por qué no estaba en el CLI
+
+Tres bajadas a Python (pasos 4, 7, 8), y **las tres son la misma raíz: el CLI puede
+*producir* el corpus pero no puede *leerlo* salvo un paper a la vez**.
+
+### G1. No hay forma de listar/ojear el corpus desde el CLI
+
+**Síntoma:** después de sembrar 199 papers, para ver *qué se trajo* (títulos, años) hubo que
+escribir Python que abre `DuckDBStore`, carga la tabla Arrow y la recorre.
+
+**Causa:** el inventario read-only del CLI es:
+- `b2g status` → conteos por `curation_status` y por `CycleState`, **nada de contenido**.
+- `b2g inspect` sin `--id` → manifest + conteos; con `--id` → **un** paper. No hay listado.
+
+No existe un `b2g list` / `b2g ls` que devuelva las filas (id, título, año, status) con
+límite, orden y filtro. El humano (o el agente LLM, que es el usuario primario del CLI según
+ADR 0010) está ciego sobre su propio corpus a menos que baje a Python o conozca los IDs de
+antemano.
+
+**Lo más cercano que sí existe:** `b2g curate --dump --all` escribe un CSV de todo el corpus.
+Sirve para *abrir en Excel*, pero (a) está enmarcado como "curación", no como "ojear", y
+(b) no responde preguntas rápidas ("dame los 30 más recientes") sin abrir la planilla.
+
+**Por qué importa:** el CLI es la API para agentes (ADR 0010). Un agente que siembra y no
+puede leer el resultado en el mismo lenguaje (subprocess + JSON) no puede cerrar el lazo de
+exploración: tiene que salir a Python, y ahí el CLI deja de ser la frontera.
+
+### G2. No hay facetado / distribución desde el CLI
+
+**Síntoma:** el histograma por año (paso 4) y los conteos por familia de método (paso 7) se
+calcularon a mano en Python.
+
+**Causa:** `status` cuenta por `curation_status` y nada más. No hay `--group-by year`,
+`--group-by language`, ni nada equivalente. La distribución temporal —la pregunta más
+básica de "¿qué tan actual es mi corpus?"— no tiene comando.
+
+**Por qué importa:** la pregunta del PO era explícitamente sobre **lo más actual**. "138 de
+199 son 2025–26" es la métrica que respondió eso, y salió de Python. Es exactamente el tipo
+de faceta que debería ser un flag, no un script.
+
+### G3. No hay búsqueda/filtro de texto sobre el corpus ya traído
+
+**Síntoma:** "dame los papers de Information Bottleneck / Mutual Information" (paso 8) se
+resolvió con regex sobre títulos en Python.
+
+**Causa:** una vez en la biblioteca viva, no hay forma de filtrar localmente por término
+(`b2g list --grep "information bottleneck"`). El único filtrado del CLI es **PRISMA**
+(`b2g filter`, que marca `rejected`, no consulta) y la query de OpenAlex en el `seed` (red,
+no local).
+
+**Por qué importa:** la síntesis temática —el verdadero deliverable de una investigación—
+se construye iterando "mostrame X, ahora mostrame Y". Sin filtro local, cada iteración es
+un script. Esto es la versión 2026 del P2/P4 de la nota 09: el patrón "diagnóstico/vista de
+tabla" sigue sin estar absorbido.
+
+### G4 (menor). `seed --native` es un footgun: exige el prefijo de campo
+
+**Síntoma:** el primer `seed --native '("…") AND (…)'` devolvió **400 Bad Request** de
+OpenAlex (exit 4, `NETWORK_ERROR`).
+
+**Causa:** `--native` pasa la ecuación **cruda como el `filter` entero**, sin envolverla en
+`title_and_abstract.search:(…)`. OpenAlex necesita el campo; sin él, el filtro es inválido.
+Sin `--native`, el traductor agrega el prefijo y funciona perfecto.
+
+**Por qué importa:** el error 400 se reporta como `NETWORK_ERROR` ("Verificá tu conexión a
+internet"), lo cual **despista**: no es la red, es la query. `--native` debería (a) validar
+que la query trae un campo o (b) documentar en el `--help` que el usuario es responsable del
+prefijo `title_and_abstract.search:`, y el 400 debería mapearse a error de datos (exit 2),
+no de red (exit 4).
+
+## Lo que el CLI hizo bien (contraste con la sesión 09)
+
+Vale registrarlo porque es el progreso desde la nota 09:
+
+- **El ciclo seed → build → snapshot es CLI puro.** En 09, sembrar, exportar redes con
+  labels y todo lo demás necesitaba scripts. Hoy no. Los issues #14 (`--max-results`),
+  #21 (cap de chaining), #25 (labels legibles) están cerrados y se nota: las redes salieron
+  con labels y el seed aceptó `--max-results`/`--min-year` sin tocar Python.
+- **`clusters.csv` lo escribe `b2g build`** (issue #31, P4 de la nota 09 absorbido). La
+  "vista de clusters como tabla" que en 09 era un script (`07_distribuciones_clusters.py`)
+  ahora es un artefacto del CLI. El único pero: los `top_keywords` son concepts genéricos de
+  OpenAlex (`computer-science`, `artificial-intelligence`), poco útiles para *nombrar* el
+  método del cluster.
+- **El workspace por carpeta (ADR 0029)** hizo que todos los comandos se resolvieran por
+  ambiente desde dentro de `ml-anomalias/`, sin `--store` ni paths. Limpio.
+
+## Patrones que el producto debería absorber (continuación de la nota 09)
+
+### P6. `b2g list` — el comando que falta
+
+Un read-only que devuelva filas del corpus con `--limit`, `--sort-by year|title`,
+`--status candidate|accepted|…`, `--grep <term>` y `--json`. Cubre G1 + G3 de un saque.
+Es, probablemente, el hueco más sentido del CLI hoy: sin él, el agente LLM no puede inspeccionar
+lo que sembró.
+
+### P7. Facetas en `status` (o un `b2g stats`)
+
+`--group-by year|language|type` para responder "qué tan actual / en qué idiomas / qué tipos
+de documento" sin Python. Cubre G2.
+
+### P8. Co-ocurrencia de keywords con vocabulario real, no concepts de OpenAlex
+
+El `clusters.csv` y la red de keywords usan los `concepts` de OpenAlex (jerarquía genérica).
+Para *nombrar* un cluster ("Information Bottleneck", "Shapley/SHAP") sirve más el vocabulario
+extraído del título/abstract. Esto cruza con el thesaurus (ADR 0011) — quizás la red de
+keywords debería poder construirse sobre términos del corpus, no solo concepts.
+
+## Hallazgos de investigación (el deliverable, breve)
+
+Para que la nota sea autocontenida: sobre 199 papers (138 de 2025–26), la intersección
+**interpretabilidad + teoría de la información** la dominan cuatro líneas, todas
+interpretables por construcción (no post-hoc):
+
+1. **Information Bottleneck (IB)** — comprime reteniendo solo la información relevante a la
+   anomalía → detección + representación mínima interpretable en un principio (VIB, IB
+   multimodal, 2026).
+2. **Mutual Information como score y atribución** — MI para puntuar y explicar la variable
+   responsable (MGAD, MI ~ GLRT, weighted MI para OOD).
+3. **Frameworks entropy-driven XAI** — la familia más poblada (120 mencionan entropía);
+   entropía como score y explicación a la vez; combinaciones con flujos normalizadores +
+   causalidad (CCEFiNF, 2026).
+4. **Causal / counterfactual anomaly detection** — emergente, el "por qué" es el camino
+   causal (19 papers).
+
+**SHAP/Shapley** (27) es la capa de interpretabilidad **post-hoc** más usada sobre detectores
+existentes — fundamento teórico-informacional, pero explicación añadida, no detección
+interpretable nativa.
+
+## Lo que la sesión NO hizo (limitaciones honestas)
+
+- **No se enriqueció** (`b2g enrich`): la red de co-citación quedó fuera (necesita
+  `cited_by_id`, 2º nivel de fetch). Solo 4 de las 5 redes posibles.
+- **No se curó**: los 199 quedaron `candidate`. Se observaron títulos duplicados ×3 (mismo
+  trabajo de varias fuentes) — candidato a curación + dedup `[dedup]`.
+- **No se verificó reproducibilidad** corriendo el pipeline dos veces (mismo `corpus_hash`).
+
+## Lecciones metodológicas
+
+1. **La frontera se movió, pero no desapareció.** En 09 el script ad-hoc cubría el *ciclo*;
+   en 14 cubre la *lectura*. El producto absorbió producir el corpus; falta absorber leerlo.
+2. **Cada `import` de `DuckDBStore` en un script de sesión es un issue de CLI.** La regla de
+   la nota 09 sigue valiendo: el script ad-hoc es señal, no ruido. Hoy señala G1/G2/G3 → P6/P7.
+3. **El agente LLM es el caso de prueba más duro.** Un humano puede abrir Python; un agente
+   que orquesta por subprocess no debería tener que. Que el CLI no pueda *listar* su propio
+   corpus es el hueco más visible desde la óptica ADR 0010.
+4. **Mapear bien los exit codes importa.** Un 400 de query reportado como `NETWORK_ERROR`
+   (exit 4) manda a debuggear la red cuando el problema es la query (G4).

--- a/docs/Notas/15-cli-capa-lectura-analisis.md
+++ b/docs/Notas/15-cli-capa-lectura-analisis.md
@@ -1,0 +1,126 @@
+# 15 — El hueco persistente del CLI: la capa de lectura y análisis
+
+> ⚠️ **NOTA DE SESIÓN — no es decisión ni ADR.** Consolida el feedback de uso real del CLI
+> `b2g` acumulado en tres sesiones de e2e/QA y nombra el hueco que se repite. Fecha: 2026-06-18.
+> Documentos hermanos / antecedentes directos:
+> [`09-sesion-qa-prueba-ecologia-valoraciones.md`](09-sesion-qa-prueba-ecologia-valoraciones.md)
+> (QA valoraciones → issues #14/#21/#22/#25/#26),
+> [`14-sesion-e2e-anomalias-ml.md`](14-sesion-e2e-anomalias-ml.md) (e2e anomalías ML → huecos
+> G1–G4 de lectura). Esta nota suma la 3ª sesión (corrupción ⨉ ciencia de redes, corrida única
+> sobre los 5 flujos A–E) y unifica.
+
+## Tesis: el CLI **produce** pero no deja **leer** ni **analizar**
+
+Tres sesiones de uso real, tres veces el mismo final: el ciclo se corre **entero por CLI** (sembrar
+→ forrajear → curar → redes → snapshot), pero para **responder la pregunta de investigación** hubo
+que bajar a Python y reescribir, otra vez, la misma capa de análisis (`scripts/analizar.py` +
+`scripts/figuras.py`, copiados casi idénticos entre `ml-anomalias/` y `corrupcion-redes/`).
+
+La frontera se movió, pero no desapareció — **se corrió de "producir" a "leer/analizar":**
+
+| Sesión | Lo que el CLI ya cubría | Lo que hubo que hacer en Python |
+|---|---|---|
+| **09** (valoraciones) | casi nada (CLI incompleto) | sembrar, exportar redes, dump CSV, curación |
+| **14** (anomalías ML) | sembrar → build → snapshot (CLI puro) | **leer** el corpus (listar, facetar por año, buscar) |
+| **15** (corrupción) | los 5 flujos A–E completos | **analizar**: rankear centrales, lecturas fundacionales, facetas |
+
+Lo de 09 se cerró (#14/#21/#22/#25/#26/#31 + `--exclude`). Lo de 14 sigue abierto. Lo de 15 es
+nuevo y **más profundo**: no es solo que no se pueda *ver* el corpus, es que no se puede *obtener el
+resultado* (las lecturas centrales y fundacionales) sin un tool externo.
+
+## Lo nuevo de esta sesión (corrida de los 5 flujos)
+
+La corrida e2e fue **verde end-to-end** (los 5 flujos del `docs/features/` pasaron; los gaps
+`@pendiente` se comportaron como documentados — ver `prueba_e2e/corrupcion-redes/qa/qa-log.md`). El
+CLI **operó** perfecto. Lo que faltó fue todo lo que viene *después* de operar.
+
+### H1. El ranking del forrajeo es ilegible: `{id, scent}` sin título
+
+`b2g chain` devuelve `data.ranking_preview` como lista de `{id, scent}` — **IDs crudos de OpenAlex**.
+El forrajeo existe justamente para decir *"leé esto próximo"*, pero su salida no dice **qué** es cada
+candidato. Para saber qué eran los top por scent hubo que `OpenAlexSource.fetch_works_by_ids(...)` en
+Python. El producto del comando más "information-foraging" del tool es opaco desde el CLI.
+
+### H2. No hay forma de obtener las lecturas centrales desde el CLI
+
+El gesto central del investigador —*"¿cuáles son los papers centrales? acepto ese núcleo"*— no tiene
+camino CLI. Lo que hice para aceptar los 25 centrales:
+
+```
+b2g build                              # genera GraphML con degree_centrality (capa decorate)
+→ Python: nx.read_graphml + degree_centrality + ordenar + extraer node ids
+→ b2g accept --ids <25 ids>
+```
+
+La centralidad **se calcula** (la capa `decorate` la mete en el GraphML, #25) pero **no es
+consultable**: no hay `b2g top`, `b2g rank`, ni `accept --top-central N`. El dato existe, encerrado
+en un `.graphml` que el humano no abre a mano.
+
+### H3. Las lecturas fundacionales no son una salida del CLI
+
+El output más valioso de una revisión —el **canon co-citado** (Baker & Faulkner 1993, Wasserman &
+Faust 1994, …)— se computó 100% en Python (frecuencia de `references_id` + fetch de títulos).
+`clusters.csv` (#31) existe y es útil, pero es **nivel-cluster**, no la **lista rankeada de lecturas**.
+No hay `b2g references --top` ni equivalente.
+
+### H4. Facetas seguimos sin tenerlas (confirma G2 de la nota 14)
+
+El histograma por año —la métrica que respondió *"¿qué tan actual/profundo es el campo?"*— otra vez
+salió de Python. `status` cuenta por `curation_status` y nada más.
+
+### H5 (menor, contrato). `filter.steps[].criterion` sale `None`
+
+Los pasos PRISMA traen `count_before/count_after/excluded` correctos, pero el nombre legible del
+criterio (`criterion`) viene `None`. El conteo es fiel; falta etiquetar **qué** criterio fue cada paso.
+
+### H6 (menor, descubribilidad). La 5ª red aparece sin pista
+
+`b2g build` da 4 redes en silencio si no hay `cited_by_id`; que la co-citación necesita `enrich`
+previo solo se sabe leyendo los docs. Un `warning` accionable ("corré `enrich` para la 5ª red")
+cerraría el hueco.
+
+### Buena práctica registrada (no es gap)
+
+Descarté un **falso positivo**: "status sin workspace → exit 2" era `uv run b2g` corriendo **fuera
+del proyecto uv** ("program not found"), no un fallo de b2g — dentro del proyecto da exit 1 correcto.
+Lección de QA: verificar el entorno antes de reportar un exit code anómalo.
+
+## El hueco unificado y su forma: una **superficie CLI de lectura/análisis**
+
+Las tres sesiones apuntan al mismo faltante. El `scripts/analizar.py` que se reescribe cada vez
+**es la especificación del comando que falta**. Propuesta consolidada (renumera P6–P8 de la nota 14):
+
+| ID | Comando propuesto | Cierra | Qué hace |
+|---|---|---|---|
+| **P6** | `b2g list [--limit --sort-by --status --grep --json]` | G1, G3 (n.14) | listar/filtrar/ordenar filas del corpus |
+| **P7** | `b2g stats` / facetas en `status` (`--group-by year\|lang\|type`) | G2 (n.14), H4 | distribución del corpus sin Python |
+| **P9** | `b2g top` / `b2g rank` (papers por centralidad; refs por co-citación) | H2, H3 | **la salida de investigación**: lecturas centrales + fundacionales como tabla rankeada |
+| **P10** | `ranking_preview` con título (no solo `{id, scent}`) | H1 | el forrajeo dice **qué** leer, no un ID |
+| **P11** | `accept --top-central N` / `accept --from-ranking` | H2 | aceptar el núcleo central sin pasar por GraphML+Python |
+| — | `criterion` legible en `filter.steps` | H5 | etiquetar el paso PRISMA |
+| — | warning de "5ª red requiere enrich" en `build` | H6 | descubribilidad |
+
+`b2g top`/`rank` (P9) es el de mayor palanca: es **el resultado** que el investigador busca, hoy
+encerrado en GraphML/parquet. Con él (+ P10/P11) el lazo *forrajear → leer lo central → curar* se
+cierra sin salir del CLI.
+
+## Por qué importa más allá del CLI (gancho con la GUI #34)
+
+La GUI (`docs/ROADMAP/05-gui.md`) va a necesitar **exactamente esta capa**: listar, facetar, rankear
+centrales y fundacionales, leer candidatos del forrajeo con su título. Hoy esa lógica vive
+**tres veces en scripts ad-hoc** y **cero veces en el producto**. Construir la superficie de
+lectura/análisis en el CLI (la API agente-native, ADR 0010) le da a la GUI su backend natural: la
+GUI sería una vista sobre `b2g list/top/rank --json`, no una reimplementación. El `analizar.py`
+recurrente no es ruido: es el contrato pendiente entre el núcleo y cualquier frontera (CLI o GUI).
+
+## Lecciones
+
+1. **El script que se reescribe cada sesión es un comando faltante.** Tres veces el mismo
+   `analizar.py` ⇒ `b2g list/top/rank` no es opcional.
+2. **Producir ≠ entregar.** El CLI genera artefactos (GraphML, parquet, clusters.csv); el
+   investigador quiere *lecturas rankeadas*. El último tramo —de artefacto a respuesta— sigue siendo
+   manual.
+3. **La salida del forrajeo debe ser legible.** Un ranking de IDs sin título contradice el propósito
+   del *information scent* (H1).
+4. **El dato ya existe; falta exponerlo.** Centralidad, co-citación y facetas se computan en el
+   núcleo (`decorate`, proyectores, `metrics.json`); el hueco es de **superficie CLI**, no de cálculo.


### PR DESCRIPTION
## Qué

Dos notas de sesión de uso real del CLI `b2g` (feedback del PO), docs-only:

- **Nota 14** — sesión e2e con detección de anomalías ML sobre v0.6: corre el ciclo por CLI y registra dónde hubo que bajar a Python (cada bajada = hueco del CLI).
- **Nota 15** — consolida 3 sesiones e2e/QA y nombra el hueco recurrente: el CLI **produce** pero no deja **leer** ni **analizar** (la capa de lectura/análisis).

Notas de sesión (no ADR). Persistencia del feedback acumulado antes de cerrar la sesión.

🤖 Generated with [Claude Code](https://claude.com/claude-code)