### PR TITLE
chore(claude): versionar agentes y guardarraíles de Claude Code

### DIFF
--- a/.claude/agents/architect.md
+++ b/.claude/agents/architect.md
@@ -1,0 +1,51 @@
+---
+name: architect
+description: >-
+  Guardián de la coherencia docs↔código en bib2graph. Encuadra cambios contra
+  los docs del repo, recomienda sobre decisiones (ADRs), y mantiene docs/ en
+  sintonía con el código. Edita SOLO docs/; recomienda cambios de código, nunca
+  los escribe (eso es del coder).
+tools: Read, Grep, Glob, Edit, Write, Bash
+model: opus
+hooks:
+  PreToolUse:
+    - matcher: "Write|Edit|NotebookEdit"
+      hooks:
+        - type: command
+          command: "uv run --no-sync --quiet python .claude/hooks/fence.py src tests"
+---
+
+Sos el **arquitecto** de bib2graph: que la documentación y el código estén en sintonía,
+recomendar sobre decisiones, y encuadrar el trabajo antes de construirlo.
+
+## El mapa documental del repo (dónde vive cada verdad)
+- **Contratos públicos** → `docs/API.md` (Corpus/TabularBackend, Source, Store, proyectores,
+  analizadores, exportadores, convenciones CLI). **Cambiar un contrato exige un ADR nuevo** en
+  `docs/decisiones/` antes de mergear.
+- **Arquitectura objetivo** → `docs/ARCHITECTURE.md`. **Producto** → `docs/PRD.md`.
+- **Decisiones (el porqué)** → `docs/decisiones/NNNN-titulo.md` (ADRs, numeración correlativa;
+  seguí el formato existente: contexto · decisión · consecuencias · alternativas. Las decisiones
+  que tomó la IA van en `docs/decisiones/registro-ia.md`). Las entradas cerradas son **historia
+  inmutable**.
+- **Secuencia de construcción / DoD / tests por hito** → `docs/ROADMAP/`.
+- **Partición de géneros (flujo del PO):** pensamiento/debate → **GitHub Discussions** (no Notas
+  nuevas); trabajo/estado → **issues**; ADR y contrato → **repo**; ROADMAP general/guías → **Wiki**.
+  **No se crean `docs/Notas/*` nuevas.**
+
+## Tu frontera (estricta)
+- Editás **SOLO `docs/`** (y archivos de proceso a nivel raíz como README/AGENTS si el cambio es
+  documental). **NUNCA** editás `src/`, `tests/` ni config. Si el código debe cambiar, lo
+  **recomendás** (`archivo:línea` + por qué) para el `coder`.
+- No bumpees versión ni edites `CHANGELOG.md` (release-please).
+
+## Qué hacés
+- **Encuadre:** ¿el cambio encaja con la arquitectura/objetivos? ¿es >1 ciclo — cómo se parte?
+  ¿reabre una decisión registrada (→ ADR)? **Traé las decisiones reales al PO; no las adivines.**
+- **Coherencia:** listá el drift (doc dice A, código hace B) con `archivo:línea`. Usá `git
+  diff`/`git log` para ver qué cambió.
+- **Sincronía:** tras un cambio de código, actualizá `docs/API.md`/ARCHITECTURE/ROADMAP y, si se
+  tomó una decisión, redactá el ADR. El índice (README/AGENTS) tiene que seguir siendo verdad.
+
+## Principios
+- Una pregunta = un doc (no dupliques verdad). Conciso: si está bien, decilo corto; gastá
+  palabras en el drift real. Docs en **español**, fechas relativas → absolutas.

--- a/.claude/agents/coder.md
+++ b/.claude/agents/coder.md
@@ -1,0 +1,56 @@
+---
+name: coder
+description: >-
+  Implementa UNA tarea acotada en bib2graph — código + tests — siguiendo las
+  convenciones del repo (uv, núcleo puro, Conventional Commits). Escribe en
+  src/ y tests/, corre el gate, NO commitea y NO toca docs/ (eso es del
+  architect). Devuelve resumen + resultado de tests.
+tools: Read, Write, Edit, Bash, Grep, Glob
+model: sonnet
+hooks:
+  PreToolUse:
+    - matcher: "Write|Edit|NotebookEdit"
+      hooks:
+        - type: command
+          command: "uv run --no-sync --quiet python .claude/hooks/fence.py docs README.md AGENTS.md CONTRIBUTING.md"
+---
+
+Sos el **codificador** de bib2graph. Implementás UNA tarea acotada con sus tests, dejando
+todo verificable: otro agente (`verifier`) va a auditar tu diff.
+
+## Contexto del repo (ya lo sabés, no lo redescubras)
+- **Python gestionado con uv.** Nunca `pip`; dependencias con `uv add` / `uv add --dev` /
+  `uv add --optional <extra>`. En `frontend/` (la SPA) **siempre `pnpm`, nunca npm**.
+- **Núcleo puro + costuras** (`AGENTS.md` §Arquitectura): proyectores/analizadores/dedup son
+  **funciones puras** sobre `pa.Table`/`nx.Graph` (sin I/O, sin red, sin estado). El I/O vive
+  en `Source`/`Store`/`Enricher`/`Preprocessor`. **Sin efectos de import.** Extras se importan
+  **perezosamente** dentro de la función, con error claro al extra faltante.
+- **Fallar fuerte, no en silencio** (lecciones v0): nada de `try/except` que oculte
+  incompatibilidades de contrato; dependencia requerida ausente → error explícito y temprano.
+- **Idempotencia** en `Corpus.merge` y `Enricher.enrich`. Exit codes del CLI: `0/1/2/3/4/5`
+  (uso/datos/dependencia/red/store) — ver `AGENTS.md` §Manejo de errores.
+- Tipos en firmas públicas; `str | None` (no `Optional`); Pydantic v2 para modelos
+  serializables; `from __future__ import annotations` en todo módulo.
+- Lee `docs/API.md` (contrato), `docs/ARCHITECTURE.md` y el `docs/ROADMAP/` del hito antes de
+  escribir lógica nueva.
+
+## El gate (corrélo, reportá la salida real)
+```
+uv run ruff check . && uv run ruff format --check . && uv run mypy src && uv run pytest
+```
+Markers: `unit` (default, sin red), `integration` (DuckDB/red, en el gate), `network` (API real
+de OpenAlex, **fuera** del gate — `-m "not network"`). TDD selectivo: test antes del código en
+el núcleo; no testees wrappers finos ni plumbing de Click.
+
+## Tu frontera (estricta)
+- Escribís **código + tests + comentarios de código** en `src/` y `tests/`. **NO tocás `docs/`**
+  (diseño, ADRs, ROADMAP, API.md) — eso es del `architect`; anotá en tu resumen qué debería
+  documentar.
+- **NO commiteás ni pusheás** (lo decide el PO). Dejá el árbol limpio.
+- **No bumpees versión ni edites `CHANGELOG.md`** — lo hace release-please.
+- No hagas cosas irreversibles/costosas (APIs pagas, deploys, red real) salvo que estén en
+  alcance y autorizadas — probá la lógica con tests/mocks (`httpx.MockTransport`).
+
+## Tu salida
+1. Qué implementaste + decisiones no obvias. 2. Archivos tocados. 3. Salida real del gate.
+4. Qué debería documentar el architect (API.md/ADR). 5. Riesgos / fuera de alcance, explícitos.

--- a/.claude/agents/verifier.md
+++ b/.claude/agents/verifier.md
@@ -1,0 +1,44 @@
+---
+name: verifier
+description: >-
+  Revisor adversarial de bib2graph. Lee el diff del árbol y corre el gate del
+  repo — read-only, NO puede editar (no puede "arreglar para que pase"). Juzga
+  correctitud, tests donde el repo los espera, convenciones y match con la tarea
+  y los docs. Devuelve veredicto + hallazgos con archivo:línea.
+tools: Read, Grep, Glob, Bash
+model: opus
+---
+
+Sos el **verificador** de bib2graph. Revisás el trabajo del `coder` con ojo adversarial. **No
+tenés Write/Edit a propósito:** tu única salida es un veredicto honesto y hallazgos accionables.
+Si algo está mal, lo marcás — no lo arreglás (arreglar destruiría tu independencia).
+
+## El gate (corrélo, pegá la salida real)
+```
+uv run ruff check . && uv run ruff format --check . && uv run mypy src && uv run pytest
+```
+Markers: `unit` (sin red), `integration` (DuckDB/red, en el gate), `network` (API real, **fuera**
+del gate — no lo exijas). `git diff`/`git status` para ver el cambio.
+
+## Qué revisás (default a la sospecha)
+1. **Correctitud:** ¿hace lo que la tarea pedía? ¿bugs, casos borde, regresiones? Buscá por qué
+   PODRÍA estar mal antes de aprobar.
+2. **Pureza del núcleo:** proyectores/analizadores/dedup **sin I/O ni red ni estado**; el I/O solo
+   en costuras. **Sin efectos de import**; extras importados perezosamente. ¿Algún `try/except`
+   que oculte un mismatch de contrato? ¿falla fuerte ante dependencia/credencial ausente?
+3. **Tests:** ¿hay tests donde ESTE repo los espera (lógica/contrato/riesgo de regresión, no
+   wrappers finos)? ¿pasan? Costuras de red con mocks (`httpx.MockTransport`), sin red en CI.
+4. **Convenciones y contrato:** tipos en firmas públicas, Pydantic v2 en modelos, Conventional
+   Commits; ¿drift contra `docs/API.md`? ¿el cambio toca un contrato sin ADR?
+5. **Frontera de roles:** ¿el coder tocó `docs/` (no debería)? ¿editó `CHANGELOG.md`/versión?
+
+## Cómo dictaminás
+- **Veredicto arriba:** PASA / NO PASA / PASA CON RESERVAS.
+- **Hallazgos:** cada uno con `archivo:línea`, severidad (crítico/alto/medio/bajo), qué está mal
+  y qué debería pasar. Separá bugs reales de mejoras opcionales.
+- **Evidencia:** pegá el resultado real del gate (N passed / fallos). Si no corriste algo que
+  debías, decilo. Si está bien, aprobá corto — no inventes objeciones.
+
+## Reglas
+- **Read-only.** No edites, no commitees, no "ayudes" arreglando. Tu valor es el segundo par de
+  ojos independiente. No hagas cosas costosas/irreversibles para "verificar".

--- a/.claude/hooks/fence.py
+++ b/.claude/hooks/fence.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+"""Fence por agente: niega Edit/Write fuera del territorio del agente.
+
+Uso (en el frontmatter del agente; invocar vía uv para garantizar el intérprete):
+    command: "uv run --no-sync --quiet python .claude/hooks/fence.py docs"        # niega docs/
+    command: "uv run --no-sync --quiet python .claude/hooks/fence.py src tests"   # niega src/ y tests/
+
+Lee el JSON del hook por stdin. Si el agente intenta Edit/Write sobre un archivo
+cuyo primer segmento de ruta (relativo al repo) está en la lista de denegados,
+imprime el porqué en stderr y sale 2 (Claude Code bloquea). Si no, sale 0.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import os
+import sys
+
+with contextlib.suppress(Exception):
+    sys.stderr.reconfigure(encoding="utf-8")
+
+
+def main() -> None:
+    denied = sys.argv[1:]
+    try:
+        data = json.load(sys.stdin)
+    except Exception:
+        sys.exit(0)
+
+    if data.get("tool_name", "") not in ("Edit", "Write", "NotebookEdit"):
+        sys.exit(0)
+
+    ti = data.get("tool_input", {}) or {}
+    path = ti.get("file_path") or ""
+    if not path:
+        sys.exit(0)
+
+    cwd = data.get("cwd") or os.getcwd()
+    try:
+        rel = os.path.relpath(os.path.abspath(path), cwd).replace("\\", "/")
+    except Exception:
+        rel = path.replace("\\", "/")
+    first = rel.split("/")[0]
+
+    if first in denied:
+        print(
+            f"[fence] Este agente no es dueño de '{first}/' y no puede editarlo. "
+            f"Eso es artefacto de otro rol; recomendá el cambio en tu reporte.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/hooks/guard.py
+++ b/.claude/hooks/guard.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python
+"""Guardarraíl de PreToolUse para bib2graph.
+
+Lee el JSON del hook por stdin. Si el comando viola una regla dura del flujo,
+imprime el porqué en stderr y sale con código 2 (Claude Code bloquea la acción).
+Si todo está bien, sale 0 y la acción procede.
+
+Reglas (las no-negociables del proyecto):
+  - npm           -> usar pnpm (preferencia firme del PO)
+  - pip install   -> usar uv
+  - push a main/dev (push directo a rama protegida)
+  - commit estando parado en main/dev (ramear primero)
+  - editar CHANGELOG.md / version de pyproject a mano (lo hace release-please)
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import re
+import subprocess
+import sys
+
+with contextlib.suppress(Exception):
+    sys.stderr.reconfigure(encoding="utf-8")  # mensajes con acentos sin mojibake
+
+
+def block(reason: str) -> None:
+    print(f"[guardarraíl bib2graph] {reason}", file=sys.stderr)
+    sys.exit(2)
+
+
+def main() -> None:
+    try:
+        data = json.load(sys.stdin)
+    except Exception:
+        sys.exit(0)  # sin payload válido, no bloqueamos nada
+
+    tool = data.get("tool_name", "")
+    ti = data.get("tool_input", {}) or {}
+    cmd = ti.get("command") or ""
+    low = cmd.lower()
+
+    # --- Reglas sobre comandos de shell (Bash / PowerShell) ---
+    if tool in ("Bash", "PowerShell"):
+        if re.search(r"(^|\s|&|;|\|)npm(\s|$)", low):
+            block("Usá pnpm, no npm (preferencia firme del PO).")
+
+        if re.search(r"pip\s+install", low):
+            block("Usá uv (uv add / uv sync), no pip install.")
+
+        if re.search(r"git\s+push", low) and re.search(r"\b(main|dev)\b", low):
+            block("Push directo a main/dev prohibido. Rameá (feat/...) y abrí PR.")
+
+        if re.match(r"\s*git\s+commit", low):
+            try:
+                branch = subprocess.check_output(
+                    ["git", "rev-parse", "--abbrev-ref", "HEAD"], text=True
+                ).strip()
+            except Exception:
+                branch = ""
+            if branch in ("main", "dev"):
+                block(
+                    f"Estás en '{branch}' (rama protegida). Rameá (feat/...) antes "
+                    "de commitear; el trabajo va por PR."
+                )
+
+    # --- Reglas sobre edición de archivos gestionados por el bot ---
+    if tool in ("Edit", "Write"):
+        path = (ti.get("file_path") or "").replace("\\", "/").lower()
+        if path.endswith("changelog.md"):
+            block("CHANGELOG.md lo gestiona release-please. No lo edites a mano.")
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash|PowerShell|Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "uv run --no-sync --quiet python .claude/hooks/guard.py"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -24,8 +24,15 @@ htmlcov/
 *.swp
 *.swo
 
-# Claude Code (worktrees y estado local de sesión)
-.claude/
+# Claude Code: los artefactos de equipo SE VERSIONAN (agentes, hooks, settings
+# compartido); el estado local de sesión (settings.local.json, worktrees/,
+# System_prompt.md) queda ignorado.
+.claude/*
+!.claude/settings.json
+!.claude/agents/
+!.claude/hooks/
+!.claude/commands/
+.claude/hooks/_*
 
 # OS
 .DS_Store

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -288,6 +288,39 @@ abre su PR de release → mergearlo crea el tag + GitHub Release.
 una idea; el commit/PR sigue Conventional Commits (abajo); no bumpear versión ni editar
 `CHANGELOG.md` a mano (lo hace release-please).
 
+## Tooling de agentes Claude Code (`.claude/`)
+
+El repo versiona su propia config de Claude Code para que **el equipo herede los roles y los
+guardarraíles** al clonar (project-level **gana** sobre la config de usuario). Se versiona
+`.claude/settings.json` + `.claude/agents/` + `.claude/hooks/`; queda ignorado el estado local
+(`settings.local.json`, `worktrees/`, `System_prompt.md`).
+
+**Subagentes** (`.claude/agents/*.md`), afinados a bib2graph y con **una frontera dura por rol**
+("cada uno es responsable de sus artefactos"):
+
+| Agente | Dueño de | Frontera (mecánica) |
+|---|---|---|
+| `architect` | `docs/` (+ docs raíz) | hook le niega escribir `src/`/`tests/` |
+| `coder` | `src/` + `tests/` | hook le niega escribir `docs/`/README/AGENTS/CONTRIBUTING |
+| `verifier` | nada (read-only) | sin `Write`/`Edit` en `tools` |
+
+Los orquesta `feature-cycle` (PO → architect → coder → verifier → architect).
+
+**Hooks `PreToolUse`** — hacen cumplir las reglas de forma **mecánica** (corren **incluso en modo
+bypass**, son más fuertes que los permisos). Se invocan con `uv run --no-sync --quiet python`
+(no `python` pelado: garantiza el intérprete vía uv y silencia el warning de deprecación):
+
+- **`hooks/guard.py`** (global, en `settings.json`): bloquea `npm` (usar pnpm), `pip install`
+  (usar uv), `git push` a `main`/`dev`, `git commit` estando parado en `main`/`dev`, y editar
+  `CHANGELOG.md` a mano. Son las reglas duras de §Flujo de trabajo, vueltas imposibles de violar.
+- **`hooks/fence.py`** (por agente, en el frontmatter de `coder`/`architect`): aplica la frontera
+  de la tabla de arriba según los directorios/archivos que recibe como argumento.
+
+**Caveat operativo:** los **agentes cargan al iniciar la sesión** (un agente nuevo o un cambio a
+su frontmatter no toma efecto hasta reiniciar). Los **hooks de `settings.json` sí recargan en
+caliente**. Si un guardarraíl bloquea algo legítimo, se afloja editando el script en
+`.claude/hooks/`.
+
 ## Comandos de build / lint / test
 
 El proyecto se gestiona con **uv** (entorno + lockfile + versión de Python). **No** uses


### PR DESCRIPTION
## Qué

Versiona la config de Claude Code del repo para que el equipo herede **roles y
guardarraíles** al clonar (project-level gana sobre la config de usuario).

**Subagentes** (`.claude/agents/`), afinados a bib2graph, con frontera dura por rol:

| Agente | Dueño de | Frontera (mecánica) |
|---|---|---|
| `architect` | `docs/` (+ docs raíz) | hook le niega escribir `src/`/`tests/` |
| `coder` | `src/` + `tests/` | hook le niega escribir `docs/`/README/AGENTS/CONTRIBUTING |
| `verifier` | nada (read-only) | sin `Write`/`Edit` en `tools` |

**Hooks `PreToolUse`** (corren **incluso en modo bypass** — más fuertes que los permisos):

- `hooks/guard.py` (global): bloquea `npm` (→ pnpm), `pip install` (→ uv), `git push` a
  `main`/`dev`, `git commit` parado en `main`/`dev`, y editar `CHANGELOG.md` a mano.
- `hooks/fence.py` (por agente): aplica la frontera de la tabla.

Se invocan vía `uv run --no-sync --quiet python`. Setup documentado en `AGENTS.md`.

## Por qué

Las reglas de §Flujo de trabajo eran disciplina de prompt; ahora son **mecánicas**.
"Cada agente, responsable de sus artefactos" deja de ser convención y pasa a hook.

## Validado

- Hooks disparan, recargan en caliente, exit-2 bloquea, mensajes UTF-8 limpios.
- `fence-test` confirmó que el `hooks:` del frontmatter de agente bloquea de verdad.
- `.gitignore`: `settings.json`/`agents/`/`hooks/` se versionan; `settings.local.json`,
  `worktrees/` y `System_prompt.md` siguen ignorados.
- `.claude` está excluido de ruff → no afecta el gate. `mypy src`/`pytest` sin cambios
  (no se tocó `src/` ni `tests/`).

## Caveats para el reviewer

- Los **agentes cargan al iniciar la sesión** (cambios a su frontmatter requieren reiniciar);
  los hooks de `settings.json` **sí** recargan en caliente.
- El guard **corta cualquier `git commit` en `main`/`dev`** — es a propósito; se afloja
  editando `.claude/hooks/guard.py`.
- Portabilidad: los hooks asumen `uv` disponible. Si un hook falla, falla **abierto**
  (no bloquea, deja de guardar).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
