### PR TITLE
ci(release): publish-pypi.yml — PyPI productivo vía Trusted Publishing (#104)

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,0 +1,57 @@
+name: publish-pypi
+
+# Publica el paquete a PyPI productivo vía Trusted Publishing (OIDC) — SIN tokens ni secrets.
+# Se dispara al PUBLICARSE un GitHub Release (lo crea release-please al mergear su PR de release),
+# y también MANUAL (Actions → "publish-pypi" → "Run workflow") como fallback / primera publicación.
+#
+# Requiere (una sola vez) un "pending publisher" en https://pypi.org:
+#   Your account → Publishing → Add a pending publisher:
+#     - PyPI Project Name: bib2graph
+#     - Owner:             complexluise
+#     - Repository name:   bib2graph
+#     - Workflow name:     publish-pypi.yml
+#     - Environment name:  pypi
+#
+# Mismo empaquetado que publish-testpypi.yml: se buildea el frontend ANTES del wheel y se usa
+# `uv build --wheel` (no `uv build` a secas, que arma el wheel desde el sdist y pierde el frontend
+# gitignored vía force-include). La única diferencia con TestPyPI es el índice destino (productivo,
+# default de la action) y el environment (`pypi`).
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write # requerido para el OIDC del trusted publishing
+
+jobs:
+  publish-pypi:
+    runs-on: ubuntu-latest
+    environment: pypi
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          python-version: "3.12"
+      - name: Setup Node 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Enable corepack (pnpm pinneado en package.json)
+        run: corepack enable
+      - name: Build frontend (llena src/bib2graph/gui/static/ antes del wheel)
+        working-directory: frontend
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm build
+      - name: Build wheel (directo del working tree, con el frontend ya buildeado)
+        # NO `uv build` a secas: eso arma sdist y el wheel DESDE el sdist, que
+        # excluye el frontend gitignored (gui/static) → force-include falla.
+        # `--wheel` construye el wheel directo del árbol (con el pnpm build de arriba).
+        run: uv build --wheel
+      - name: Publish to PyPI (trusted publishing)
+        # Sin repository-url → la action publica a PyPI productivo (https://upload.pypi.org/legacy/).
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Qué

Agrega `.github/workflows/publish-pypi.yml` (#104): publica a **PyPI productivo** vía **Trusted Publishing (OIDC)**, sin tokens ni secrets. Clona el empaquetado validado de `publish-testpypi.yml` (build del frontend → `uv build --wheel`), cambiando solo el **destino** (PyPI productivo, default de la action) y el **environment** (`pypi`).

Disparo: al **publicarse un GitHub Release** (release-please) + `workflow_dispatch` manual de fallback.

## Por qué

Cierra el hueco de distribución: hoy solo existe el flujo a TestPyPI, donde **instalar falla** porque TestPyPI no aloja las deps (`httpx`, `pydantic`, …). Con PyPI productivo, `pip install bib2graph` resuelve deps desde pypi.org → instalación limpia.

## ⚠️ Requiere acción del PO (una sola vez)

Antes de la primera publicación, registrar el **pending publisher** en https://pypi.org (Your account → Publishing → Add a pending publisher):

| Campo | Valor |
|---|---|
| PyPI Project Name | `bib2graph` |
| Owner | `complexluise` |
| Repository name | `bib2graph` |
| Workflow name | `publish-pypi.yml` |
| Environment name | `pypi` |

(Mismo trámite que ya hiciste para TestPyPI, pero en pypi.org y con environment `pypi`.)

Refs #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)