### PR TITLE
feat(networks): keyword_filter en NetworkSpec para sub-redes temáticas (#113)

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1843,6 +1843,11 @@ class NetworkSpec(BaseModel):
                              # siendo función pura del corpus_hash, R2).
     assortativity_attribute: str | None = None     # p. ej. "region"
     layout: Literal["spring", "kamada_kawai", "circular"] | None = None
+    keyword_filter: list[str] | None = None  # Issue #113: sub-red temática. Filtra el corpus ANTES
+                                             # de proyectar a los papers cuyo keywords_raw matchee
+                                             # (ANY, substring, case-insensitive) algún término.
+                                             # None/[] = sin filtro. Param de spec, FUERA del
+                                             # corpus_hash (como min_weight/scope).
 
 
 def load_specs(path: str | Path) -> list[NetworkSpec]:
@@ -1875,6 +1880,19 @@ class Networks:
 **Modo quick** (v1) cubre baja fricción; **modo spec** (Hito 9, YAML) cubre el pipeline declarativo
 versionable, vía `load_specs(redes.yaml)` + `Networks.build` por red (y el subcomando `b2g
 networks --spec`, §convenciones CLI).
+
+**Sub-redes temáticas (`keyword_filter`, issue #113):** cada red declarada puede acotar el corpus a
+un tema antes de proyectar — útil para comparar sub-redes (p. ej. T4 vs T7) sin pre-filtrar el corpus
+entero ni escribir scripts. El match es **ANY** (un paper entra si algún término matchea), por
+**substring case-insensitive** sobre `keywords_raw` (display names). `None`/`[]` = sin filtro.
+
+```yaml
+networks:
+  - kind: keyword_cooccurrence
+    keyword_filter: ["complex", "ecolog"]   # papers con keywords tipo "Complexity"/"Ecological..."
+  - kind: bibliographic_coupling
+    keyword_filter: ["assessment"]
+```
 
 **Notas de contrato** (Hito 2, ADR [0014](decisiones/0014-proyeccion-redes-pesos-asortatividad.md)):
 

--- a/src/bib2graph/networks/facade.py
+++ b/src/bib2graph/networks/facade.py
@@ -17,6 +17,7 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 import networkx as nx
+import pyarrow as pa
 
 from bib2graph.constants import NetworkKind
 from bib2graph.networks.analyzer import detect_communities, network_metrics
@@ -119,6 +120,41 @@ def _projector_for_kind(spec: NetworkSpec) -> Projector:
         raise ValueError(f"Kind de red no reconocido: '{kind}'")
 
 
+def _apply_keyword_filter(table: pa.Table, terms: list[str]) -> pa.Table:
+    """Filtra la tabla a filas cuyo ``keywords_raw`` matchee algún término.
+
+    Semántica ANY + substring case-insensitive: un paper entra si CUALQUIER
+    término del filtro matchea como substring (case-insensitive) contra
+    CUALQUIERA de sus keywords en ``keywords_raw``.
+
+    Implementación puramente Python/pyarrow: sin I/O, sin estado global,
+    determinista (cumple la regla de pureza del núcleo, AGENTS.md).
+
+    Args:
+        table: Tabla Arrow canónica del Corpus.
+        terms: Lista de términos a buscar (no vacía; el llamador garantiza esto).
+
+    Returns:
+        Tabla Arrow filtrada (puede estar vacía si ningún paper matchea).
+    """
+    terms_lower = [t.lower() for t in terms]
+    keywords_col = table.column("keywords_raw").to_pylist()
+
+    mask: list[bool] = []
+    for kws in keywords_col:
+        if not kws:  # None o lista vacía → no matchea
+            mask.append(False)
+            continue
+        # ANY: un término matchea cualquier keyword del paper
+        matched = any(
+            term in kw.lower() for kw in kws if kw is not None for term in terms_lower
+        )
+        mask.append(matched)
+
+    bool_array = pa.array(mask, type=pa.bool_())
+    return table.filter(bool_array)
+
+
 def _build_artifact(corpus: Corpus, spec: NetworkSpec) -> NetworkArtifact:
     """Construye un ``NetworkArtifact`` a partir de un corpus y una spec.
 
@@ -127,6 +163,12 @@ def _build_artifact(corpus: Corpus, spec: NetworkSpec) -> NetworkArtifact:
 
     R2: Louvain se siembra con un ``random_state`` derivado del
     ``corpus_hash`` de contenido (excluyendo provenance) para reproducibilidad.
+
+    Si ``spec.keyword_filter`` es una lista no vacía, la tabla Arrow del corpus
+    se subsettea antes de proyectar: solo entran los papers cuyas
+    ``keywords_raw`` matcheen (ANY, substring, case-insensitive) algún término
+    del filtro. Proyección y decoración operan sobre el subcorpus, garantizando
+    consistencia entre nodos, aristas y labels.
 
     Args:
         corpus: Corpus de origen.
@@ -137,6 +179,9 @@ def _build_artifact(corpus: Corpus, spec: NetworkSpec) -> NetworkArtifact:
     """
     projector = _projector_for_kind(spec)
     table = corpus.to_arrow()
+
+    if spec.keyword_filter:
+        table = _apply_keyword_filter(table, spec.keyword_filter)
 
     g: _Graph = projector.project(
         table,

--- a/src/bib2graph/networks/spec.py
+++ b/src/bib2graph/networks/spec.py
@@ -54,6 +54,12 @@ class NetworkSpec(BaseModel):
             ``label_prop`` y ``greedy_modularity`` (sin error).
         assortativity_attribute: Atributo categórico para asortatividad.
         layout: Algoritmo de layout para visualización (futuro).
+        keyword_filter: Lista de términos temáticos. Si se provee (lista no
+            vacía), solo entran al build los papers cuyo ``keywords_raw``
+            contenga al menos un término que matchee (ANY) por substring
+            case-insensitive. Ej: ``["complex", "ecolog"]`` incluye papers con
+            keywords "Complexity" o "Ecological economics". ``None`` o lista
+            vacía = sin filtro (comportamiento por defecto).
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -67,6 +73,7 @@ class NetworkSpec(BaseModel):
     resolution: float = 1.0
     assortativity_attribute: str | None = None
     layout: Literal["spring", "kamada_kawai", "circular"] | None = None
+    keyword_filter: list[str] | None = None
 
 
 def load_specs(path: str | Path) -> list[NetworkSpec]:

--- a/tests/unit/test_keyword_filter.py
+++ b/tests/unit/test_keyword_filter.py
@@ -1,0 +1,404 @@
+"""Tests TDD del issue #113 — keyword_filter en NetworkSpec.
+
+Casos cubiertos:
+
+(a) corpus con keywords mixtas → keyword_filter produce sub-red solo con
+    los papers que matchean.
+(b) keyword_filter=None (default) → comportamiento idéntico al actual
+    (sin filtrar).
+(c) filtro sin matches → grafo vacío (0 nodos), sin error.
+(d) case-insensitivity y substring: term "complex" matchea "Complexity".
+
+Marcador: ``unit`` (sin red ni I/O externo).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pyarrow as pa
+import pytest
+
+from bib2graph.corpus import Corpus
+from bib2graph.networks.facade import Networks, _apply_keyword_filter
+from bib2graph.networks.spec import NetworkSpec, load_specs
+from bib2graph.schemas import CORPUS_SCHEMA
+
+# ---------------------------------------------------------------------------
+# Helpers de fixture
+# ---------------------------------------------------------------------------
+
+
+def _paper(
+    pid: str,
+    keywords_raw: list[str] | None,
+    references_id: list[str] | None = None,
+) -> dict[str, Any]:
+    """Construye una fila de paper mínima para los tests de keyword_filter."""
+    return {
+        "id": pid,
+        "openalex_id": None,
+        "doi": None,
+        "title": f"Paper {pid}",
+        "year": 2020,
+        "abstract": None,
+        "source": None,
+        "language": None,
+        "publisher": None,
+        "research_areas": None,
+        "is_seed": True,
+        "curation_status": "candidate",
+        "provenance": None,
+        "authors_raw": None,
+        "authors_id": [f"AUTH_{pid}"],
+        "authors_affiliations": None,
+        "keywords_raw": keywords_raw,
+        "keywords_id": None,
+        "institutions_raw": None,
+        "institutions_id": None,
+        "references_id": references_id,
+        "references_doi": None,
+        "cited_by_id": None,
+    }
+
+
+def _make_corpus_con_keywords() -> Corpus:
+    """Corpus con 4 papers de distintas temáticas para los tests de filtro.
+
+    - P1: keywords de complejidad ("Complexity", "Systems thinking")
+    - P2: keywords de ecología ("Ecological economics", "Biodiversity")
+    - P3: keywords mixtas ("Complexity", "Ecology")
+    - P4: sin keywords relevantes ("Mathematics", "Algebra")
+
+    P1 y P3 comparten REF_SHARED (para que haya aristas de coupling entre ellos).
+    P2 y P3 comparten REF_ECO.
+    """
+    rows = [
+        _paper(
+            "P1",
+            keywords_raw=["Complexity", "Systems thinking"],
+            references_id=["REF_SHARED", "REF_A"],
+        ),
+        _paper(
+            "P2",
+            keywords_raw=["Ecological economics", "Biodiversity"],
+            references_id=["REF_ECO", "REF_B"],
+        ),
+        _paper(
+            "P3",
+            keywords_raw=["Complexity", "Ecology"],
+            references_id=["REF_SHARED", "REF_ECO"],
+        ),
+        _paper(
+            "P4",
+            keywords_raw=["Mathematics", "Algebra"],
+            references_id=["REF_C"],
+        ),
+    ]
+    table = pa.Table.from_pylist(rows, schema=CORPUS_SCHEMA)
+    return Corpus.from_arrow(table)
+
+
+# ---------------------------------------------------------------------------
+# Tests de _apply_keyword_filter (función pura interna)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_apply_keyword_filter_retorna_solo_papers_con_match() -> None:
+    """_apply_keyword_filter retiene solo filas con keywords que matchean."""
+    corpus = _make_corpus_con_keywords()
+    table = corpus.to_arrow()
+
+    filtrada = _apply_keyword_filter(table, ["complex"])
+
+    ids = filtrada.column("id").to_pylist()
+    # P1 ("Complexity") y P3 ("Complexity") deben matchear; P2 y P4, no.
+    assert set(ids) == {"P1", "P3"}
+
+
+@pytest.mark.unit
+def test_apply_keyword_filter_case_insensitive() -> None:
+    """El filtro es case-insensitive: 'complex' matchea 'Complexity'."""
+    corpus = _make_corpus_con_keywords()
+    table = corpus.to_arrow()
+
+    # Término en mayúsculas: debe igualmente matchear "Complexity"
+    filtrada_upper = _apply_keyword_filter(table, ["COMPLEX"])
+    filtrada_lower = _apply_keyword_filter(table, ["complex"])
+
+    assert (
+        filtrada_upper.column("id").to_pylist()
+        == filtrada_lower.column("id").to_pylist()
+    )
+
+
+@pytest.mark.unit
+def test_apply_keyword_filter_substring() -> None:
+    """El filtro es por substring: 'ecolog' matchea 'Ecological economics' y 'Ecology'."""
+    corpus = _make_corpus_con_keywords()
+    table = corpus.to_arrow()
+
+    filtrada = _apply_keyword_filter(table, ["ecolog"])
+
+    ids = set(filtrada.column("id").to_pylist())
+    # P2 ("Ecological economics"), P3 ("Ecology")
+    assert ids == {"P2", "P3"}
+
+
+@pytest.mark.unit
+def test_apply_keyword_filter_any_semantics() -> None:
+    """ANY: un paper entra si CUALQUIER término del filtro matchea alguna keyword."""
+    corpus = _make_corpus_con_keywords()
+    table = corpus.to_arrow()
+
+    # "complex" matchea P1 y P3; "biodiversity" matchea P2
+    filtrada = _apply_keyword_filter(table, ["complex", "biodiversity"])
+
+    ids = set(filtrada.column("id").to_pylist())
+    assert ids == {"P1", "P2", "P3"}
+
+
+@pytest.mark.unit
+def test_apply_keyword_filter_sin_matches_devuelve_tabla_vacia() -> None:
+    """Sin matches → tabla vacía (0 filas), sin error."""
+    corpus = _make_corpus_con_keywords()
+    table = corpus.to_arrow()
+
+    filtrada = _apply_keyword_filter(table, ["termino_que_no_existe_xyz"])
+
+    assert filtrada.num_rows == 0
+
+
+@pytest.mark.unit
+def test_apply_keyword_filter_paper_sin_keywords_no_matchea() -> None:
+    """Un paper con keywords_raw=None no matchea ningún filtro."""
+    rows = [
+        _paper("P_sin_kw", keywords_raw=None, references_id=["REF_X"]),
+        _paper("P_con_kw", keywords_raw=["Complexity"], references_id=["REF_X"]),
+    ]
+    table = pa.Table.from_pylist(rows, schema=CORPUS_SCHEMA)
+
+    filtrada = _apply_keyword_filter(table, ["complex"])
+
+    ids = filtrada.column("id").to_pylist()
+    assert ids == ["P_con_kw"]
+
+
+# ---------------------------------------------------------------------------
+# (a) Networks.build con keyword_filter produce sub-red con papers que matchean
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_keyword_filter_produce_sub_red_con_papers_matching() -> None:
+    """(a) keyword_filter=['complex'] limita la red a P1 y P3 (acoplamiento).
+
+    P1 y P3 comparten REF_SHARED, así que la red de coupling debe tener
+    exactamente esa arista. P2 y P4 quedan fuera.
+    """
+    corpus = _make_corpus_con_keywords()
+    spec = NetworkSpec(
+        kind="bibliographic_coupling",
+        keyword_filter=["complex"],
+        clustering=None,
+    )
+
+    artifact = Networks.build(corpus, spec)
+
+    nodes = set(artifact.graph.nodes())
+    # Solo P1 y P3 pasan el filtro; la arista P1-P3 (REF_SHARED) debe existir.
+    assert nodes == {"P1", "P3"}
+    assert artifact.graph.has_edge("P1", "P3")
+
+
+@pytest.mark.unit
+def test_keyword_filter_excluye_papers_sin_match() -> None:
+    """(a) Papers sin keyword matching no aparecen en el grafo resultante."""
+    corpus = _make_corpus_con_keywords()
+    spec = NetworkSpec(
+        kind="bibliographic_coupling",
+        keyword_filter=["complex"],
+        clustering=None,
+    )
+
+    artifact = Networks.build(corpus, spec)
+
+    nodes = set(artifact.graph.nodes())
+    assert "P2" not in nodes
+    assert "P4" not in nodes
+
+
+# ---------------------------------------------------------------------------
+# (b) keyword_filter=None → comportamiento idéntico al actual (sin filtrar)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_keyword_filter_none_no_filtra() -> None:
+    """(b) keyword_filter=None (default) → mismo resultado que sin keyword_filter."""
+    corpus = _make_corpus_con_keywords()
+
+    spec_con_none = NetworkSpec(
+        kind="bibliographic_coupling",
+        keyword_filter=None,
+        clustering=None,
+    )
+    spec_sin_campo = NetworkSpec(
+        kind="bibliographic_coupling",
+        clustering=None,
+    )
+
+    art_con_none = Networks.build(corpus, spec_con_none)
+    art_sin_campo = Networks.build(corpus, spec_sin_campo)
+
+    assert set(art_con_none.graph.nodes()) == set(art_sin_campo.graph.nodes())
+    assert set(art_con_none.graph.edges()) == set(art_sin_campo.graph.edges())
+
+
+@pytest.mark.unit
+def test_keyword_filter_lista_vacia_no_filtra() -> None:
+    """Lista vacía keyword_filter=[] → sin filtro (mismo resultado que None)."""
+    corpus = _make_corpus_con_keywords()
+
+    spec_vacia = NetworkSpec(
+        kind="bibliographic_coupling",
+        keyword_filter=[],
+        clustering=None,
+    )
+    spec_none = NetworkSpec(
+        kind="bibliographic_coupling",
+        keyword_filter=None,
+        clustering=None,
+    )
+
+    art_vacia = Networks.build(corpus, spec_vacia)
+    art_none = Networks.build(corpus, spec_none)
+
+    assert set(art_vacia.graph.nodes()) == set(art_none.graph.nodes())
+    assert set(art_vacia.graph.edges()) == set(art_none.graph.edges())
+
+
+# ---------------------------------------------------------------------------
+# (c) filtro sin matches → grafo vacío (0 nodos), sin error
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_keyword_filter_sin_matches_grafo_vacio() -> None:
+    """(c) Ningún paper matchea → grafo con 0 nodos, sin error."""
+    corpus = _make_corpus_con_keywords()
+    spec = NetworkSpec(
+        kind="bibliographic_coupling",
+        keyword_filter=["termino_que_no_existe_xyz"],
+        clustering=None,
+    )
+
+    artifact = Networks.build(corpus, spec)
+
+    assert artifact.graph.number_of_nodes() == 0
+    assert artifact.graph.number_of_edges() == 0
+
+
+@pytest.mark.unit
+def test_keyword_filter_sin_matches_no_lanza_error() -> None:
+    """(c) El filtro que no matchea nada no debe lanzar excepción."""
+    corpus = _make_corpus_con_keywords()
+    spec = NetworkSpec(
+        kind="keyword_cooccurrence",
+        keyword_filter=["zzz_nada_zzz"],
+        clustering=None,
+    )
+
+    # No debe lanzar ninguna excepción
+    artifact = Networks.build(corpus, spec)
+    assert artifact is not None
+
+
+# ---------------------------------------------------------------------------
+# (d) case-insensitivity y substring en Networks.build
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_keyword_filter_case_insensitive_en_build() -> None:
+    """(d) 'complex' (minúscula) matchea keyword 'Complexity' (capitalizada)."""
+    corpus = _make_corpus_con_keywords()
+
+    spec_lower = NetworkSpec(
+        kind="bibliographic_coupling",
+        keyword_filter=["complex"],
+        clustering=None,
+    )
+    spec_upper = NetworkSpec(
+        kind="bibliographic_coupling",
+        keyword_filter=["COMPLEX"],
+        clustering=None,
+    )
+
+    art_lower = Networks.build(corpus, spec_lower)
+    art_upper = Networks.build(corpus, spec_upper)
+
+    assert set(art_lower.graph.nodes()) == set(art_upper.graph.nodes())
+
+
+@pytest.mark.unit
+def test_keyword_filter_substring_en_build() -> None:
+    """(d) Término parcial 'ecolog' matchea 'Ecological economics' y 'Ecology'."""
+    corpus = _make_corpus_con_keywords()
+    spec = NetworkSpec(
+        kind="bibliographic_coupling",
+        keyword_filter=["ecolog"],
+        clustering=None,
+    )
+
+    artifact = Networks.build(corpus, spec)
+
+    nodes = set(artifact.graph.nodes())
+    # P2 ("Ecological economics") y P3 ("Ecology") deben estar
+    assert "P2" in nodes
+    assert "P3" in nodes
+    # P1 y P4 no tienen keywords con 'ecolog'
+    assert "P1" not in nodes
+    assert "P4" not in nodes
+
+
+# ---------------------------------------------------------------------------
+# NetworkSpec — validación del campo keyword_filter
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_networkspec_keyword_filter_default_es_none() -> None:
+    """El campo keyword_filter tiene None como valor por defecto."""
+    spec = NetworkSpec(kind="bibliographic_coupling")
+    assert spec.keyword_filter is None
+
+
+@pytest.mark.unit
+def test_networkspec_keyword_filter_acepta_lista_de_strings() -> None:
+    """keyword_filter acepta una lista de strings correctamente."""
+    spec = NetworkSpec(
+        kind="bibliographic_coupling", keyword_filter=["complex", "ecolog"]
+    )
+    assert spec.keyword_filter == ["complex", "ecolog"]
+
+
+@pytest.mark.unit
+def test_networkspec_keyword_filter_en_yaml(tmp_path: Path) -> None:
+    """El campo keyword_filter se carga correctamente desde YAML."""
+    yaml_content = """\
+networks:
+  - kind: bibliographic_coupling
+    keyword_filter:
+      - complex
+      - ecolog
+"""
+    spec_file = tmp_path / "redes.yaml"
+    spec_file.write_text(yaml_content, encoding="utf-8")
+
+    specs = load_specs(spec_file)
+
+    assert len(specs) == 1
+    assert specs[0].keyword_filter == ["complex", "ecolog"]


### PR DESCRIPTION
## Qué

Cierra **#113**. `NetworkSpec` gana `keyword_filter: list[str] | None`. Si se provee (lista no vacía), `_build_artifact` **subsetea el corpus antes de proyectar** a los papers cuyo `keywords_raw` matchee algún término — **ANY**, **substring**, **case-insensitive**. Proyección y decoración operan sobre el subcorpus (nodos/aristas/labels consistentes). `None`/`[]` = sin filtro (comportamiento actual intacto).

## Por qué

Permite armar **sub-redes temáticas** (p. ej. T4/T7) vía `b2g networks --spec` sin escribir scripts externos — el dolor documentado en el informe de uso real (§6.4: el usuario tuvo que invocar los projectors a mano con LIKE).

## Alcance
- `src/bib2graph/networks/spec.py` — campo nuevo + docstring.
- `src/bib2graph/networks/facade.py` — `_apply_keyword_filter` (función pura) + aplicación en `_build_artifact`.
- `tests/unit/test_keyword_filter.py` — 17 tests.
- `docs/API.md` §10 — campo + ejemplo YAML.

Gate local verde (765 passed, 1 skip preexistente). Función pura, determinista. `min_year`/`max_year` siguen placeholders (fuera de alcance).

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)