### PR TITLE
feat(backends): tabla lateral external_ids (ADR 0036, infra opción C)

### DIFF
--- a/src/bib2graph/backends/base.py
+++ b/src/bib2graph/backends/base.py
@@ -174,3 +174,37 @@ class TabularBackend(Protocol):
             Lista de ``ref_id``.
         """
         ...
+
+    def add_external_id(self, paper_id: str, engine: str, id: str) -> None:
+        """Registra un ID externo para un paper dado un motor (ADR 0036 opción C).
+
+        Idempotente: si ya existe una entrada ``(paper_id, engine)``, el valor
+        se reemplaza (un ID por motor por paper).
+
+        Args:
+            paper_id: ID interno del paper en el corpus.
+            engine: Nombre del motor / fuente del ID (p. ej. ``'openalex'``,
+                ``'semanticscholar'``, ``'doi'``).
+            id: El ID externo correspondiente a ese motor.
+        """
+        ...
+
+    def external_ids_for(self, paper_id: str) -> dict[str, str]:
+        """Devuelve todos los IDs externos registrados para un paper.
+
+        Args:
+            paper_id: ID interno del paper en el corpus.
+
+        Returns:
+            Diccionario ``{engine: id}`` con todos los IDs registrados para
+            ese paper.  Vacío si el paper no tiene IDs externos registrados.
+        """
+        ...
+
+    def all_external_ids(self) -> list[tuple[str, str, str]]:
+        """Devuelve todas las entradas de la tabla ``external_ids``.
+
+        Returns:
+            Lista de tuplas ``(paper_id, engine, id)`` en orden no definido.
+        """
+        ...

--- a/src/bib2graph/backends/duckdb.py
+++ b/src/bib2graph/backends/duckdb.py
@@ -124,6 +124,20 @@ CREATE TABLE IF NOT EXISTS referenced_but_not_fetched (
 )
 """
 
+# ADR 0036 (opción C): tabla lateral de IDs externos por motor (openalex, doi, etc.)
+# PK lógica (paper_id, engine): un id por motor por paper.  Escritura idempotente
+# vía INSERT OR REPLACE (upsert) — re-escribir el mismo (paper_id, engine) reemplaza
+# el valor anterior sin duplicar.  Lateral al corpus: NO entra en CORPUS_SCHEMA
+# ni en corpus_hash.
+_DDL_EXTERNAL_IDS = """
+CREATE TABLE IF NOT EXISTS external_ids (
+    paper_id VARCHAR NOT NULL,
+    engine   VARCHAR NOT NULL,
+    id       VARCHAR NOT NULL,
+    PRIMARY KEY (paper_id, engine)
+)
+"""
+
 # ADR 0024: migración liviana para bases pre-existentes sin columna ``_seq``.
 # Se suprime el error si la columna ya existe (CatalogException o BinderException).
 # El backfill usa ``rowid`` como proxy de orden de inserción original; es inocuo
@@ -316,6 +330,8 @@ class DuckDBBackend:
         self._con.execute(_DDL_CORPUS_BACKFILL_SEQ)
         # #54: tabla auxiliar para IDs backward observados pero no materializados.
         self._con.execute(_DDL_REFERENCED_BUT_NOT_FETCHED)
+        # ADR 0036 (opción C): tabla lateral de IDs externos por motor.
+        self._con.execute(_DDL_EXTERNAL_IDS)
         self._register_udfs()
 
     def _register_udfs(self) -> None:
@@ -422,6 +438,16 @@ class DuckDBBackend:
                     "INSERT INTO referenced_but_not_fetched "
                     "(ref_id, cycle_round, observed_at) VALUES (?, ?, ?)",
                     [ref_id_val, cycle_round_val, observed_at_val],
+                )
+            # ADR 0036: copiar la tabla lateral external_ids
+            ext_rows = self._con.execute(
+                "SELECT paper_id, engine, id FROM external_ids"
+            ).fetchall()
+            for paper_id_val, engine_val, id_val in ext_rows:
+                new_backend._con.execute(
+                    "INSERT OR REPLACE INTO external_ids (paper_id, engine, id) "
+                    "VALUES (?, ?, ?)",
+                    [paper_id_val, engine_val, id_val],
                 )
             return new_backend
         else:
@@ -718,6 +744,58 @@ class DuckDBBackend:
             "SELECT ref_id FROM referenced_but_not_fetched ORDER BY observed_at"
         ).fetchall()
         return [r[0] for r in rows]
+
+    # ------------------------------------------------------------------
+    # Extensiones propias: external_ids (ADR 0036 opción C)
+    # ------------------------------------------------------------------
+
+    def add_external_id(self, paper_id: str, engine: str, id: str) -> None:
+        """Registra un ID externo para un paper dado un motor.
+
+        Idempotente: si ya existe una entrada ``(paper_id, engine)``, el valor
+        se reemplaza (un ID por motor por paper).  La PK lógica
+        ``(paper_id, engine)`` garantiza que no haya duplicados.
+
+        Args:
+            paper_id: ID interno del paper en el corpus.
+            engine: Nombre del motor / fuente del ID (p. ej. ``'openalex'``,
+                ``'semanticscholar'``, ``'doi'``).
+            id: El ID externo correspondiente a ese motor.
+        """
+        self._con.execute(
+            "INSERT OR REPLACE INTO external_ids (paper_id, engine, id) "
+            "VALUES (?, ?, ?)",
+            [paper_id, engine, id],
+        )
+
+    def external_ids_for(self, paper_id: str) -> dict[str, str]:
+        """Devuelve todos los IDs externos registrados para un paper.
+
+        Args:
+            paper_id: ID interno del paper en el corpus.
+
+        Returns:
+            Diccionario ``{engine: id}`` con todos los IDs registrados para
+            ese paper.  Vacío si el paper no tiene IDs externos registrados.
+        """
+        rows = self._con.execute(
+            "SELECT engine, id FROM external_ids WHERE paper_id = ?",
+            [paper_id],
+        ).fetchall()
+        return {r[0]: r[1] for r in rows}
+
+    def all_external_ids(self) -> list[tuple[str, str, str]]:
+        """Devuelve todas las entradas de la tabla ``external_ids``.
+
+        Usado internamente para ``_clone()`` y tests de paridad.
+
+        Returns:
+            Lista de tuplas ``(paper_id, engine, id)`` en orden no definido.
+        """
+        rows = self._con.execute(
+            "SELECT paper_id, engine, id FROM external_ids"
+        ).fetchall()
+        return [(r[0], r[1], r[2]) for r in rows]
 
     # ------------------------------------------------------------------
     # Extensión: query SQL libre

--- a/src/bib2graph/backends/memory.py
+++ b/src/bib2graph/backends/memory.py
@@ -364,6 +364,7 @@ class InMemoryBackend:
         table: pa.Table,
         *,
         referenced_refs: list[str] | None = None,
+        external_ids: dict[tuple[str, str], str] | None = None,
     ) -> None:
         """Constructor interno.
 
@@ -373,10 +374,15 @@ class InMemoryBackend:
             referenced_refs: Lista de IDs ya registrados en la tabla auxiliar
                 ``referenced_but_not_fetched`` (para clonar el estado en
                 operaciones que devuelven una nueva instancia).
+            external_ids: Diccionario ``{(paper_id, engine): id}`` con los IDs
+                externos registrados (ADR 0036 opción C).  Lateral al corpus:
+                no entra en CORPUS_SCHEMA ni en corpus_hash.
         """
         self._table = table
         # #54: IDs backward observados, en orden de inserción, sin duplicados.
         self._referenced_refs: list[str] = list(referenced_refs or [])
+        # ADR 0036: IDs externos por (paper_id, engine).  PK lógica (paper_id, engine).
+        self._external_ids: dict[tuple[str, str], str] = dict(external_ids or {})
 
     # ------------------------------------------------------------------
     # TabularBackend protocol
@@ -402,7 +408,9 @@ class InMemoryBackend:
         existing = self._table.to_pylist()
         existing.append(row)
         return InMemoryBackend(
-            _rows_to_table(existing), referenced_refs=self._referenced_refs
+            _rows_to_table(existing),
+            referenced_refs=self._referenced_refs,
+            external_ids=self._external_ids,
         )
 
     def merge(self, other_table: pa.Table) -> InMemoryBackend:
@@ -439,7 +447,9 @@ class InMemoryBackend:
                 result_rows.append(row)
 
         return InMemoryBackend(
-            _rows_to_table(result_rows), referenced_refs=self._referenced_refs
+            _rows_to_table(result_rows),
+            referenced_refs=self._referenced_refs,
+            external_ids=self._external_ids,
         )
 
     def apply_curation(
@@ -469,7 +479,9 @@ class InMemoryBackend:
             self._table.to_pylist(), ids, action, by, decided_at
         )
         return InMemoryBackend(
-            _rows_to_table(updated), referenced_refs=self._referenced_refs
+            _rows_to_table(updated),
+            referenced_refs=self._referenced_refs,
+            external_ids=self._external_ids,
         )
 
     def filter_view(self, view: Literal["seeds", "candidates", "accepted"]) -> pa.Table:
@@ -556,3 +568,50 @@ class InMemoryBackend:
             Lista de ``ref_id``.
         """
         return list(self._referenced_refs)
+
+    # ------------------------------------------------------------------
+    # Extensiones: external_ids (ADR 0036 opción C)
+    # ------------------------------------------------------------------
+
+    def add_external_id(self, paper_id: str, engine: str, id: str) -> None:
+        """Registra un ID externo para un paper dado un motor.
+
+        Idempotente: si ya existe una entrada ``(paper_id, engine)``, el valor
+        se reemplaza (un ID por motor por paper).
+
+        Args:
+            paper_id: ID interno del paper en el corpus.
+            engine: Nombre del motor / fuente del ID (p. ej. ``'openalex'``,
+                ``'semanticscholar'``, ``'doi'``).
+            id: El ID externo correspondiente a ese motor.
+        """
+        self._external_ids[(paper_id, engine)] = id
+
+    def external_ids_for(self, paper_id: str) -> dict[str, str]:
+        """Devuelve todos los IDs externos registrados para un paper.
+
+        Args:
+            paper_id: ID interno del paper en el corpus.
+
+        Returns:
+            Diccionario ``{engine: id}`` con todos los IDs registrados para
+            ese paper.  Vacío si el paper no tiene IDs externos registrados.
+        """
+        return {
+            engine: ext_id
+            for (pid, engine), ext_id in self._external_ids.items()
+            if pid == paper_id
+        }
+
+    def all_external_ids(self) -> list[tuple[str, str, str]]:
+        """Devuelve todas las entradas de la tabla ``external_ids``.
+
+        Usado internamente para tests de paridad con DuckDBBackend.
+
+        Returns:
+            Lista de tuplas ``(paper_id, engine, id)`` en orden no definido.
+        """
+        return [
+            (pid, engine, ext_id)
+            for (pid, engine), ext_id in self._external_ids.items()
+        ]

--- a/tests/unit/test_external_ids.py
+++ b/tests/unit/test_external_ids.py
@@ -1,0 +1,379 @@
+"""Tests TDD — ADR 0036 opción C: tabla lateral ``external_ids``.
+
+Verifica que:
+- La tabla ``external_ids`` existe en DuckDBBackend y en InMemoryBackend.
+- Paridad de contrato observable entre ambos backends.
+- Idempotencia: escribir ``(paper_id, engine, id)`` dos veces → una sola entrada.
+- Reemplazo: escribir ``(paper_id, engine, id2)`` sobre un ``(paper_id, engine)``
+  existente reemplaza el valor anterior (un ID por motor por paper).
+- Multi-motor: ``(p1, 'openalex', 'W1')`` y ``(p1, 'semanticscholar', 'S1')``
+  coexisten (N motores por paper).
+- ``external_ids`` NO afecta ``corpus_hash`` (agregar entradas no cambia el hash).
+- La tabla sobrevive al ``_clone()`` del DuckDBBackend.
+- Migración liviana: una DB sin la tabla no falla al abrirla.
+
+Marcadores:
+- ``unit`` (InMemoryBackend, DuckDB en tmp_path — sin red real).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pyarrow as pa
+import pytest
+
+from bib2graph.backends.duckdb import DuckDBBackend
+from bib2graph.backends.memory import InMemoryBackend
+from bib2graph.schemas import CORPUS_SCHEMA
+
+pytestmark = pytest.mark.unit
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _empty_table() -> pa.Table:
+    """Tabla Arrow canónica vacía (para backends sin papers)."""
+    return pa.table(
+        {f.name: pa.array([], type=f.type) for f in CORPUS_SCHEMA},
+        schema=CORPUS_SCHEMA,
+    )
+
+
+def _memory_backend() -> InMemoryBackend:
+    return InMemoryBackend(_empty_table())
+
+
+# ---------------------------------------------------------------------------
+# InMemoryBackend — tabla external_ids
+# ---------------------------------------------------------------------------
+
+
+class TestInMemoryBackendExternalIds:
+    """InMemoryBackend.add_external_id / external_ids_for / all_external_ids."""
+
+    def test_initial_empty(self) -> None:
+        """Backend nuevo no tiene IDs externos registrados."""
+        backend = _memory_backend()
+        assert backend.external_ids_for("P1") == {}
+        assert backend.all_external_ids() == []
+
+    def test_add_and_retrieve(self) -> None:
+        """add_external_id registra el id y external_ids_for lo devuelve."""
+        backend = _memory_backend()
+        backend.add_external_id("P1", "openalex", "W123")
+
+        result = backend.external_ids_for("P1")
+        assert result == {"openalex": "W123"}
+
+    def test_idempotente_mismo_valor(self) -> None:
+        """Re-escribir el mismo (paper_id, engine, id) no crea duplicado."""
+        backend = _memory_backend()
+        backend.add_external_id("P1", "openalex", "W123")
+        backend.add_external_id("P1", "openalex", "W123")
+
+        result = backend.external_ids_for("P1")
+        assert result == {"openalex": "W123"}
+        assert len(backend.all_external_ids()) == 1
+
+    def test_reemplaza_valor_distinto(self) -> None:
+        """Re-escribir (paper_id, engine) con id distinto reemplaza el anterior."""
+        backend = _memory_backend()
+        backend.add_external_id("P1", "openalex", "W1")
+        backend.add_external_id("P1", "openalex", "W2")
+
+        result = backend.external_ids_for("P1")
+        assert result == {"openalex": "W2"}
+        # Solo una entrada por (paper_id, engine)
+        assert len(backend.all_external_ids()) == 1
+
+    def test_multi_motor(self) -> None:
+        """Motores distintos para el mismo paper coexisten."""
+        backend = _memory_backend()
+        backend.add_external_id("P1", "openalex", "W1")
+        backend.add_external_id("P1", "semanticscholar", "S1")
+
+        result = backend.external_ids_for("P1")
+        assert result == {"openalex": "W1", "semanticscholar": "S1"}
+        assert len(backend.all_external_ids()) == 2
+
+    def test_multi_paper(self) -> None:
+        """Papers distintos no interfieren entre sí."""
+        backend = _memory_backend()
+        backend.add_external_id("P1", "openalex", "W1")
+        backend.add_external_id("P2", "openalex", "W2")
+
+        assert backend.external_ids_for("P1") == {"openalex": "W1"}
+        assert backend.external_ids_for("P2") == {"openalex": "W2"}
+        assert backend.external_ids_for("P3") == {}
+
+    def test_corpus_hash_no_cambia(self) -> None:
+        """corpus_hash no cambia al agregar external_ids."""
+        backend = _memory_backend()
+        hash_antes = backend.corpus_hash()
+
+        backend.add_external_id("P1", "openalex", "W1")
+        backend.add_external_id("P1", "semanticscholar", "S1")
+
+        hash_despues = backend.corpus_hash()
+        assert hash_antes == hash_despues, (
+            "corpus_hash no debe cambiar al agregar external_ids"
+        )
+
+    def test_external_ids_sobreviven_a_add_paper(self) -> None:
+        """external_ids se propagan a la nueva instancia tras add_paper."""
+        backend = _memory_backend()
+        backend.add_external_id("P1", "openalex", "W1")
+
+        row: dict[str, Any] = {
+            "id": "P2",
+            "openalex_id": None,
+            "doi": None,
+            "title": "Paper 2",
+            "year": 2021,
+            "abstract": None,
+            "source": None,
+            "language": None,
+            "publisher": None,
+            "research_areas": None,
+            "is_seed": True,
+            "curation_status": "candidate",
+            "provenance": None,
+            "authors_raw": None,
+            "authors_id": None,
+            "authors_affiliations": None,
+            "keywords_raw": None,
+            "keywords_id": None,
+            "institutions_raw": None,
+            "institutions_id": None,
+            "references_id": None,
+            "references_doi": None,
+            "cited_by_id": None,
+        }
+        backend2 = backend.add_paper(row)
+
+        # El external_id de P1 sobrevive en la nueva instancia
+        assert backend2.external_ids_for("P1") == {"openalex": "W1"}
+
+
+# ---------------------------------------------------------------------------
+# DuckDBBackend — tabla external_ids
+# ---------------------------------------------------------------------------
+
+
+class TestDuckDBBackendExternalIds:
+    """DuckDBBackend: tabla external_ids (DDL, métodos, migración)."""
+
+    def test_tabla_creada_en_setup(self, tmp_path: Path) -> None:
+        """La tabla external_ids se crea en _setup."""
+        db_path = tmp_path / "test.duckdb"
+        backend = DuckDBBackend(path=db_path)
+        # Debe poder hacer la query sin error
+        result = backend.external_ids_for("P1")
+        assert result == {}
+        backend.close()
+
+    def test_add_and_retrieve(self, tmp_path: Path) -> None:
+        """add_external_id registra el id y external_ids_for lo devuelve."""
+        db_path = tmp_path / "test.duckdb"
+        backend = DuckDBBackend(path=db_path)
+
+        backend.add_external_id("P1", "openalex", "W123")
+        result = backend.external_ids_for("P1")
+        assert result == {"openalex": "W123"}
+        backend.close()
+
+    def test_idempotente_mismo_valor(self, tmp_path: Path) -> None:
+        """Re-escribir el mismo (paper_id, engine, id) no crea duplicado."""
+        db_path = tmp_path / "test.duckdb"
+        backend = DuckDBBackend(path=db_path)
+
+        backend.add_external_id("P1", "openalex", "W123")
+        backend.add_external_id("P1", "openalex", "W123")
+
+        result = backend.external_ids_for("P1")
+        assert result == {"openalex": "W123"}
+        assert len(backend.all_external_ids()) == 1
+        backend.close()
+
+    def test_reemplaza_valor_distinto(self, tmp_path: Path) -> None:
+        """Re-escribir (paper_id, engine) con id distinto reemplaza el anterior."""
+        db_path = tmp_path / "test.duckdb"
+        backend = DuckDBBackend(path=db_path)
+
+        backend.add_external_id("P1", "openalex", "W1")
+        backend.add_external_id("P1", "openalex", "W2")
+
+        result = backend.external_ids_for("P1")
+        assert result == {"openalex": "W2"}
+        assert len(backend.all_external_ids()) == 1
+        backend.close()
+
+    def test_multi_motor(self, tmp_path: Path) -> None:
+        """Motores distintos para el mismo paper coexisten."""
+        db_path = tmp_path / "test.duckdb"
+        backend = DuckDBBackend(path=db_path)
+
+        backend.add_external_id("P1", "openalex", "W1")
+        backend.add_external_id("P1", "semanticscholar", "S1")
+
+        result = backend.external_ids_for("P1")
+        assert result == {"openalex": "W1", "semanticscholar": "S1"}
+        assert len(backend.all_external_ids()) == 2
+        backend.close()
+
+    def test_multi_paper(self, tmp_path: Path) -> None:
+        """Papers distintos no interfieren entre sí."""
+        db_path = tmp_path / "test.duckdb"
+        backend = DuckDBBackend(path=db_path)
+
+        backend.add_external_id("P1", "openalex", "W1")
+        backend.add_external_id("P2", "openalex", "W2")
+
+        assert backend.external_ids_for("P1") == {"openalex": "W1"}
+        assert backend.external_ids_for("P2") == {"openalex": "W2"}
+        assert backend.external_ids_for("P3") == {}
+        backend.close()
+
+    def test_corpus_hash_no_cambia(self, tmp_path: Path) -> None:
+        """corpus_hash no cambia al agregar external_ids al DuckDBBackend."""
+        db_path = tmp_path / "test.duckdb"
+        backend = DuckDBBackend(path=db_path)
+        hash_antes = backend.corpus_hash()
+
+        backend.add_external_id("P1", "openalex", "W1")
+        hash_despues = backend.corpus_hash()
+
+        assert hash_antes == hash_despues, (
+            "corpus_hash no debe cambiar al agregar external_ids"
+        )
+        backend.close()
+
+    def test_snapshot_round_trip_memory(self, tmp_path: Path) -> None:
+        """La tabla external_ids sobrevive al _clone en modo :memory:."""
+        backend = DuckDBBackend()  # :memory:
+        backend.add_external_id("P1", "openalex", "W1")
+        backend.add_external_id("P1", "semanticscholar", "S1")
+
+        cloned = backend._clone()
+        assert cloned.external_ids_for("P1") == {
+            "openalex": "W1",
+            "semanticscholar": "S1",
+        }
+
+    def test_snapshot_round_trip_file(self, tmp_path: Path) -> None:
+        """La tabla external_ids persiste en archivo y una nueva instancia la lee."""
+        db_path = tmp_path / "test.duckdb"
+        backend = DuckDBBackend(path=db_path)
+        backend.add_external_id("P1", "openalex", "W1")
+        backend.close()
+
+        backend2 = DuckDBBackend(path=db_path)
+        assert backend2.external_ids_for("P1") == {"openalex": "W1"}
+        backend2.close()
+
+    def test_migracion_liviana_db_sin_tabla(self, tmp_path: Path) -> None:
+        """Una DB sin external_ids no falla al abrirla (CREATE TABLE IF NOT EXISTS).
+
+        Simula una base pre-ADR 0036: creamos las tablas viejas manualmente
+        sin external_ids, luego abrimos DuckDBBackend que debe crearla.
+        """
+        import duckdb
+
+        db_path = tmp_path / "legacy.duckdb"
+        con = duckdb.connect(str(db_path))
+        con.execute(
+            "CREATE TABLE IF NOT EXISTS corpus (id VARCHAR PRIMARY KEY, "
+            "openalex_id VARCHAR, doi VARCHAR, title VARCHAR NOT NULL, "
+            "year INTEGER, abstract VARCHAR, source VARCHAR, language VARCHAR, "
+            "publisher VARCHAR, research_areas VARCHAR[], is_seed BOOLEAN NOT NULL, "
+            "curation_status VARCHAR NOT NULL, provenance VARCHAR, "
+            "authors_raw VARCHAR[], authors_id VARCHAR[], authors_affiliations VARCHAR[], "
+            "keywords_raw VARCHAR[], keywords_id VARCHAR[], institutions_raw VARCHAR[], "
+            "institutions_id VARCHAR[], references_id VARCHAR[], references_doi VARCHAR[], "
+            "cited_by_id VARCHAR[], _seq BIGINT)"
+        )
+        con.execute(
+            "CREATE TABLE IF NOT EXISTS loop_state_log "
+            "(state VARCHAR NOT NULL, round INTEGER DEFAULT 0, "
+            "recorded_at TIMESTAMPTZ NOT NULL DEFAULT now())"
+        )
+        con.execute(
+            "CREATE TABLE IF NOT EXISTS referenced_but_not_fetched "
+            "(ref_id VARCHAR NOT NULL, cycle_round INTEGER NOT NULL DEFAULT 0, "
+            "observed_at TIMESTAMPTZ NOT NULL DEFAULT now())"
+        )
+        con.close()
+
+        # Abrir con DuckDBBackend — no debe fallar
+        backend = DuckDBBackend(path=db_path)
+        assert backend.external_ids_for("P1") == {}
+        backend.close()
+
+
+# ---------------------------------------------------------------------------
+# Paridad de contrato InMemoryBackend ↔ DuckDBBackend
+# ---------------------------------------------------------------------------
+
+
+class TestExternalIdsParidad:
+    """Verifica que InMemoryBackend y DuckDBBackend exponen el mismo contrato observable."""
+
+    def test_add_and_retrieve_paridad(self, tmp_path: Path) -> None:
+        """add_external_id + external_ids_for dan el mismo resultado en ambos backends."""
+        mem = _memory_backend()
+        db = DuckDBBackend(path=tmp_path / "par.duckdb")
+
+        for backend in (mem, db):
+            backend.add_external_id("P1", "openalex", "W1")
+            backend.add_external_id("P1", "semanticscholar", "S1")
+            backend.add_external_id("P2", "doi", "10.1234/test")
+
+        assert mem.external_ids_for("P1") == db.external_ids_for("P1")
+        assert mem.external_ids_for("P2") == db.external_ids_for("P2")
+        assert mem.external_ids_for("P99") == db.external_ids_for("P99")
+        db.close()
+
+    def test_idempotencia_paridad(self, tmp_path: Path) -> None:
+        """Idempotencia (mismo valor) da el mismo resultado en ambos backends."""
+        mem = _memory_backend()
+        db = DuckDBBackend(path=tmp_path / "par.duckdb")
+
+        for backend in (mem, db):
+            backend.add_external_id("P1", "openalex", "W1")
+            backend.add_external_id("P1", "openalex", "W1")  # duplicado
+
+        assert mem.external_ids_for("P1") == db.external_ids_for("P1")
+        assert len(mem.all_external_ids()) == len(db.all_external_ids()) == 1
+        db.close()
+
+    def test_reemplazo_paridad(self, tmp_path: Path) -> None:
+        """Reemplazo de valor da el mismo resultado en ambos backends."""
+        mem = _memory_backend()
+        db = DuckDBBackend(path=tmp_path / "par.duckdb")
+
+        for backend in (mem, db):
+            backend.add_external_id("P1", "openalex", "W1")
+            backend.add_external_id("P1", "openalex", "W2")  # reemplaza
+
+        assert mem.external_ids_for("P1") == db.external_ids_for("P1")
+        assert len(mem.all_external_ids()) == len(db.all_external_ids()) == 1
+        db.close()
+
+    def test_corpus_hash_no_cambia_paridad(self, tmp_path: Path) -> None:
+        """corpus_hash no cambia tras add_external_id en ninguno de los dos backends."""
+        mem = _memory_backend()
+        db = DuckDBBackend(path=tmp_path / "par.duckdb")
+
+        hash_mem_antes = mem.corpus_hash()
+        hash_db_antes = db.corpus_hash()
+
+        mem.add_external_id("P1", "openalex", "W1")
+        db.add_external_id("P1", "openalex", "W1")
+
+        assert mem.corpus_hash() == hash_mem_antes
+        assert db.corpus_hash() == hash_db_antes
+        db.close()


### PR DESCRIPTION
## Qué

Primer chunk del refactor source-agnóstico (ADR 0036). **Aditivo, no rompe nada.** Agrega la tabla hermana `external_ids(paper_id, engine, id)` 1↔N a ambos backends (DuckDB + InMemory), espejando `referenced_but_not_fetched`.

- PK lógica `(paper_id, engine)` = un id por motor por paper; escritura **idempotente**.
- **Lateral:** NO entra en `CORPUS_SCHEMA` ni en `corpus_hash`.
- Métodos: `add_external_id`, `external_ids_for` (engine→id), `all_external_ids`; declarados en el Protocol `TabularBackend`. `_clone` + propagación in-memory copian la tabla.

## Por qué

Habilita el cruce/dedup **cross-motor** (OpenAlex ↔ Semantic Scholar por DOI) que el ADR 0036 decidió (opción C). **Nada la puebla todavía** — la población va en el PR del breaking core (rename + identidad). Este chunk es la infraestructura, aislada y verde.

## Alcance
- `src/bib2graph/backends/{base,duckdb,memory}.py`
- `tests/unit/test_external_ids.py` — 22 tests (paridad in-memory↔duckdb, idempotencia, multi-motor, `corpus_hash` invariante).

Gate local verde (787 passed, 1 skip preexistente). Refs ADR 0036.

🤖 Generated with [Claude Code](https://claude.com/claude-code)