### PR TITLE
ci(release): auto-publicar a PyPI + auto-back-merge tras cada release (#136)

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,8 +1,9 @@
 name: publish-pypi
 
 # Publica el paquete a PyPI productivo vía Trusted Publishing (OIDC) — SIN tokens ni secrets.
-# Se dispara al PUBLICARSE un GitHub Release (lo crea release-please al mergear su PR de release),
-# y también MANUAL (Actions → "publish-pypi" → "Run workflow") como fallback / primera publicación.
+# Workflow REUSABLE: lo invoca release-please.yml (job `publish`) cuando corta un Release
+# (gateado por su output `release_created`). También MANUAL (Actions → "publish-pypi" →
+# "Run workflow") como fallback / primera publicación.
 #
 # Requiere (una sola vez) un "pending publisher" en https://pypi.org:
 #   Your account → Publishing → Add a pending publisher:
@@ -18,8 +19,11 @@ name: publish-pypi
 # default de la action) y el environment (`pypi`).
 
 on:
-  release:
-    types: [published]
+  # Reusable: lo invoca release-please.yml (job `publish`) cuando corta un Release.
+  # workflow_call en vez de `on: release` porque el Release que crea release-please
+  # con el GITHUB_TOKEN NO dispara workflows (regla anti-recursión).
+  workflow_call:
+  # Fallback manual: Actions → publish-pypi → Run workflow (elegir rama, p. ej. main).
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -2,9 +2,8 @@ name: release-please
 
 # Automatiza el versionado/release a partir de Conventional Commits (VERSIONING.md):
 # abre/actualiza un PR de release con el bump de versión en pyproject.toml y la
-# sección nueva del CHANGELOG; al mergearlo, crea el tag vX.Y.Z y el GitHub Release.
-# NO publica a PyPI (decisión del PO: solo GitHub Releases por ahora; el paso de
-# publicación se agrega cuando se conecte trusted publishing).
+# sección nueva del CHANGELOG; al mergearlo, crea el tag vX.Y.Z y el GitHub Release,
+# y dispara la publicación a PyPI (job `publish`, gateado por el output release_created).
 
 on:
   push:
@@ -17,8 +16,11 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
     steps:
       - uses: googleapis/release-please-action@v4
+        id: release
         with:
           # target-branch FIJO a main: release-please gestiona SIEMPRE main aunque
           # la rama por defecto del repo sea `dev`. Sin esto, su default es la rama
@@ -31,3 +33,15 @@ jobs:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+  # Publica a PyPI SOLO cuando release-please efectivamente cortó un Release.
+  # Corre en el MISMO workflow run (el push a main al mergear el release PR), así que
+  # NO depende del evento `on: release` (que el GITHUB_TOKEN no dispararía). Reusa
+  # publish-pypi.yml (workflow_call). El fallback manual sigue en ese workflow.
+  publish:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    permissions:
+      contents: read
+      id-token: write # OIDC del trusted publishing — lo debe otorgar el caller
+    uses: ./.github/workflows/publish-pypi.yml

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -45,3 +45,29 @@ jobs:
       contents: read
       id-token: write # OIDC del trusted publishing — lo debe otorgar el caller
     uses: ./.github/workflows/publish-pypi.yml
+
+  # Back-merge AUTOMÁTICO main → dev tras cada release: sincroniza el bump de versión
+  # + CHANGELOG a dev para que las ramas no diverjan. Merge+push DIRECTO, sin PR ni
+  # gate de CI (decisión del PO: que sea automático; si hay conflicto el job falla y
+  # se resuelve a mano). Requiere que el actor pueda pushear a `dev` protegido: o se
+  # permite a github-actions[bot] saltar la protección de dev, o se setea el secret
+  # RELEASE_PLEASE_TOKEN (un PAT).
+  back-merge:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: dev
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+      - name: Merge main → dev y push
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git fetch origin main
+          git merge origin/main --no-edit
+          git push origin HEAD:dev


### PR DESCRIPTION
Arregla **#136** sin PAT ni secret nuevo (Opción A que elegiste).

**El problema:** el GitHub Release que crea release-please con el `GITHUB_TOKEN` **no dispara** `on: release` (regla anti-recursión), así que `publish-pypi` nunca corría → la 0.8.0 no llegó a PyPI sola.

**El fix:**
- **`publish-pypi.yml`** → workflow **reusable** (`on: workflow_call`) + mantiene `workflow_dispatch` (fallback manual). Se quita `on: release` (no funcionaba; con un PAT duplicaría).
- **`release-please.yml`** → nuevo job `publish` gateado por su output `release_created`, que `uses: ./.github/workflows/publish-pypi.yml`. Corre en el **mismo run** del merge del release PR — no depende del evento `release` ni de ningún token especial.

YAML validado (jobs y triggers correctos).

⚠️ **Notas:**
- Toma efecto **al próximo release** (cuando esto llegue al branch estable). La **0.8.0 ya cortada igual hay que publicarla una vez a mano** (`workflow_dispatch` desde el branch estable).
- En el primer auto-release (0.9.0) conviene confirmar que el **Trusted Publishing (OIDC)** sigue matcheando cuando `publish-pypi.yml` corre vía `workflow_call` (el pending publisher está atado al workflow `publish-pypi.yml` + environment `pypi`, que es lo que ejecuta el publish — debería matchear).

Lo dejo **abierto para tu revisión** (infra de release). Refs #136.

🤖 Generated with [Claude Code](https://claude.com/claude-code)