### PR TITLE
fix(provenance): b2g filter registra el filtro (manifest + procedencia) (#126)

### DIFF
--- a/src/bib2graph/backends/base.py
+++ b/src/bib2graph/backends/base.py
@@ -93,11 +93,12 @@ class TabularBackend(Protocol):
         action: str,
         by: str,
         decided_at: str | None = None,
+        source: str | None = None,
     ) -> TabularBackend:
         """Aplica accept/reject a los papers indicados y devuelve backend nuevo.
 
-        Agrega un evento al log ``provenance`` con ``action``, ``decided_by``
-        y ``decided_at`` (ISO8601 UTC).  La instancia original no muta.
+        Agrega un evento al log ``provenance`` con ``action``, ``decided_by``,
+        ``source`` y ``decided_at`` (ISO8601 UTC).  La instancia original no muta.
 
         R2 (ADR 0017 enmendado): ``decided_at`` se inyecta desde la frontera
         (CLI) para que el núcleo no llame al reloj.  Si es ``None``, la
@@ -110,6 +111,8 @@ class TabularBackend(Protocol):
             by: Identificador de quien toma la decisión.
             decided_at: Timestamp ISO8601 UTC de la decisión.  Si es ``None``,
                 la implementación usa ``datetime.now(UTC)`` como fallback.
+            source: Origen del evento (p. ej. criterio de filtro PRISMA).
+                Si es ``None``, el campo ``source`` del evento queda vacío.
 
         Returns:
             Nueva instancia del backend con la curación aplicada.

--- a/src/bib2graph/backends/duckdb.py
+++ b/src/bib2graph/backends/duckdb.py
@@ -138,6 +138,22 @@ CREATE TABLE IF NOT EXISTS external_ids (
 )
 """
 
+# #126 — tabla de pasos de filtro PRISMA para trazabilidad del manifest.
+# Cada ejecución de ``b2g filter`` appendea una fila por criterio aplicado.
+# ``name``/``criteria``/``count_before``/``count_after`` replican ``FilterStep``.
+# ``recorded_at`` usa ``now()`` de DuckDB (patrón loop_state_log).
+# No tiene PK UNIQUE: la idempotencia la maneja la capa de servicio que
+# decide si re-registrar o actualizar (ver ``persist_filter_steps``).
+_DDL_FILTER_LOG = """
+CREATE TABLE IF NOT EXISTS filter_log (
+    name         VARCHAR NOT NULL,
+    criteria     VARCHAR NOT NULL,
+    count_before INTEGER NOT NULL,
+    count_after  INTEGER NOT NULL,
+    recorded_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+)
+"""
+
 # ADR 0024: migración liviana para bases pre-existentes sin columna ``_seq``.
 # Se suprime el error si la columna ya existe (CatalogException o BinderException).
 # El backfill usa ``rowid`` como proxy de orden de inserción original; es inocuo
@@ -338,6 +354,8 @@ class DuckDBBackend:
         self._con.execute(_DDL_REFERENCED_BUT_NOT_FETCHED)
         # ADR 0036 (opción C): tabla lateral de IDs externos por motor.
         self._con.execute(_DDL_EXTERNAL_IDS)
+        # #126: tabla de pasos de filtro PRISMA para trazabilidad del manifest.
+        self._con.execute(_DDL_FILTER_LOG)
         self._register_udfs()
 
     def _register_udfs(self) -> None:
@@ -455,6 +473,18 @@ class DuckDBBackend:
                     "VALUES (?, ?, ?)",
                     [paper_id_val, engine_val, id_val],
                 )
+            # #126: copiar la tabla de pasos de filtro PRISMA
+            filter_rows = self._con.execute(
+                "SELECT name, criteria, count_before, count_after, recorded_at "
+                "FROM filter_log ORDER BY recorded_at"
+            ).fetchall()
+            for name_val, criteria_val, cb_val, ca_val, at_val in filter_rows:
+                new_backend._con.execute(
+                    "INSERT INTO filter_log "
+                    "(name, criteria, count_before, count_after, recorded_at) "
+                    "VALUES (?, ?, ?, ?, ?)",
+                    [name_val, criteria_val, cb_val, ca_val, at_val],
+                )
             return new_backend
         else:
             # Para archivo en disco: compartimos la ruta; nueva instancia abre nueva conexión
@@ -533,6 +563,7 @@ class DuckDBBackend:
         action: str,
         by: str,
         decided_at: str | None = None,
+        source: str | None = None,
     ) -> DuckDBBackend:
         """Aplica accept/reject a los papers indicados y devuelve backend nuevo.
 
@@ -548,6 +579,8 @@ class DuckDBBackend:
             by: Identificador de quien decide.
             decided_at: Timestamp ISO8601 UTC de la decisión (inyectado desde
                 la frontera CLI; ``None`` = fallback a ``datetime.now(UTC)``).
+            source: Origen del evento (p. ej. criterio de filtro PRISMA).
+                Si es ``None``, el campo ``source`` del evento queda vacío.
 
         Returns:
             Nueva instancia con la curación aplicada.
@@ -557,7 +590,7 @@ class DuckDBBackend:
         current_table = _arrow_table_from_con(self._con)
         current_rows = current_table.to_pylist()
         updated_rows = _apply_curation_to_rows(
-            current_rows, ids, action, by, decided_at
+            current_rows, ids, action, by, decided_at, source
         )
 
         new_backend = self._clone()
@@ -802,6 +835,71 @@ class DuckDBBackend:
             "SELECT paper_id, engine, id FROM external_ids"
         ).fetchall()
         return [(r[0], r[1], r[2]) for r in rows]
+
+    # ------------------------------------------------------------------
+    # Extensiones propias: filter_log (#126)
+    # ------------------------------------------------------------------
+
+    def persist_filter_steps(
+        self,
+        steps: list[object],
+        *,
+        replace: bool = True,
+    ) -> None:
+        """Persiste los pasos de filtro PRISMA en ``filter_log``.
+
+        #126 — trazabilidad PRISMA: los pasos aplicados en ``b2g filter``
+        se guardan para que ``manifest.filters`` sobreviva entre cargas del
+        store.
+
+        Por defecto (``replace=True``) limpia los pasos anteriores antes de
+        insertar los nuevos: cada invocación de ``b2g filter`` reemplaza el
+        registro previo completo (idempotencia de ``run_filter``).
+
+        Args:
+            steps: Lista de ``FilterStep`` (se accede a sus atributos
+                ``name``, ``criteria``, ``count_before``, ``count_after``).
+            replace: Si es ``True`` (default), trunca ``filter_log`` antes
+                de insertar.  Si es ``False``, appendea (útil para tests
+                que verifican acumulación).
+        """
+        if replace:
+            self._con.execute("DELETE FROM filter_log")
+        for step in steps:
+            self._con.execute(
+                "INSERT INTO filter_log (name, criteria, count_before, count_after) "
+                "VALUES (?, ?, ?, ?)",
+                [
+                    getattr(step, "name", None),
+                    getattr(step, "criteria", None),
+                    getattr(step, "count_before", None),
+                    getattr(step, "count_after", None),
+                ],
+            )
+
+    def load_filter_steps(self) -> list[dict[str, object]]:
+        """Carga los pasos de filtro PRISMA desde ``filter_log``.
+
+        #126 — trazabilidad PRISMA: permite que ``DuckDBStore.load()``
+        reconstruya ``manifest.filters`` con los pasos persistidos.
+
+        Returns:
+            Lista de dicts con las claves ``name``, ``criteria``,
+            ``count_before`` y ``count_after`` en el orden de inserción.
+        """
+        rows = self._con.execute(
+            "SELECT name, criteria, count_before, count_after "
+            "FROM filter_log ORDER BY recorded_at"
+        ).fetchall()
+        return [
+            {
+                "name": r[0],
+                "criteria": r[1],
+                "count_before": r[2],
+                "count_after": r[3],
+            }
+            for r in rows
+        ]
 
     # ------------------------------------------------------------------
     # Extensión: query SQL libre

--- a/src/bib2graph/backends/memory.py
+++ b/src/bib2graph/backends/memory.py
@@ -290,6 +290,7 @@ def _apply_curation_to_rows(
     action: str,
     by: str,
     decided_at: str | None = None,
+    source: str | None = None,
 ) -> list[dict[str, object]]:
     """Aplica la acción de curación en la lista de filas y devuelve la nueva lista.
 
@@ -306,6 +307,8 @@ def _apply_curation_to_rows(
         decided_at: Timestamp ISO8601 UTC de la decisión.  Si es ``None``,
             se usa ``datetime.now(UTC).isoformat()`` como conveniencia
             (uso como librería sin frontera CLI).
+        source: Origen del evento (p. ej. criterio de filtro PRISMA).
+            Si es ``None``, el campo ``source`` del evento queda vacío.
 
     Returns:
         Nueva lista de filas con la curación aplicada.
@@ -318,7 +321,7 @@ def _apply_curation_to_rows(
         action=action,
         equation_id=None,
         chaining_hop=None,
-        source=None,
+        source=source,
         fetched_at=None,
         decided_by=by,
         decided_at=resolved_at,
@@ -459,6 +462,7 @@ class InMemoryBackend:
         action: str,
         by: str,
         decided_at: str | None = None,
+        source: str | None = None,
     ) -> InMemoryBackend:
         """Aplica accept/reject a los ids indicados y devuelve una nueva instancia.
 
@@ -471,12 +475,14 @@ class InMemoryBackend:
             by: Identificador de quien decide.
             decided_at: Timestamp ISO8601 UTC de la decisión (inyectado desde
                 la frontera CLI; ``None`` = fallback a ``datetime.now(UTC)``).
+            source: Origen del evento (p. ej. criterio de filtro PRISMA).
+                Si es ``None``, el campo ``source`` del evento queda vacío.
 
         Returns:
             Nueva instancia con la curación aplicada.
         """
         updated = _apply_curation_to_rows(
-            self._table.to_pylist(), ids, action, by, decided_at
+            self._table.to_pylist(), ids, action, by, decided_at, source
         )
         return InMemoryBackend(
             _rows_to_table(updated),

--- a/src/bib2graph/cli/commands/filter.py
+++ b/src/bib2graph/cli/commands/filter.py
@@ -93,6 +93,9 @@ def run_filter(
         total_papers = len(filtered_corpus)
         filtered_backend_close = getattr(filtered_corpus._backend, "close", None)
         store.persist(filtered_corpus)
+        # #126 — trazabilidad PRISMA: persistir los pasos de filtro en filter_log
+        # para que manifest.filters sobreviva entre cargas del store.
+        store.backend.persist_filter_steps(steps)
         store.backend.set_loop_state(new_state, cycle_round=new_round)
     finally:
         if filtered_backend_close is not None:

--- a/src/bib2graph/corpus.py
+++ b/src/bib2graph/corpus.py
@@ -499,12 +499,13 @@ class Corpus:
         *,
         by: str = "human",
         decided_at: datetime | None = None,
+        source: str | None = None,
     ) -> Corpus:
         """Marca los papers con los ids dados como 'rejected'.
 
         Agrega un evento al log de provenance con ``action='rejected'``,
-        ``decided_by`` y ``decided_at`` (ISO8601 UTC). El Corpus original
-        no muta (semántica de valor).
+        ``decided_by``, ``source`` y ``decided_at`` (ISO8601 UTC). El Corpus
+        original no muta (semántica de valor).
 
         R2 (ADR 0017 enmendado): ``decided_at`` se inyecta desde la frontera
         (CLI) para que el núcleo no llame al reloj.  Si es ``None``, el
@@ -516,13 +517,20 @@ class Corpus:
             by: Identificador de quien toma la decisión (default ``'human'``).
             decided_at: Instante de la decisión.  Si es ``None``, el backend
                 usa ``datetime.now(UTC)`` como fallback (ergonomía de librería).
+            source: Origen del evento de rechazo (p. ej. criterio de filtro
+                PRISMA como ``'filter:language:in:["fr"]'``).  Si es ``None``,
+                el campo ``source`` del evento queda vacío.
 
         Returns:
             Nuevo ``Corpus`` con los papers rechazados.
         """
         decided_at_str = decided_at.isoformat() if decided_at is not None else None
         new_backend = self._backend.apply_curation(
-            ids, action=CurationStatus.REJECTED, by=by, decided_at=decided_at_str
+            ids,
+            action=CurationStatus.REJECTED,
+            by=by,
+            decided_at=decided_at_str,
+            source=source,
         )
         return Corpus(new_backend, self._manifest)
 

--- a/src/bib2graph/filters/prisma.py
+++ b/src/bib2graph/filters/prisma.py
@@ -189,9 +189,14 @@ def apply_filter(
         and not _passes(row, criterion)
     ]
 
-    label = f"filter:{criterion.field}{criterion.op}{criterion.value}"
+    label = f"filter:{criterion.field}:{criterion.op}:{criterion.value}"
     new_corpus = (
-        corpus.reject(ids_to_reject, by=label, decided_at=decided_at)
+        corpus.reject(
+            ids_to_reject,
+            by="prisma_filter",
+            source=label,
+            decided_at=decided_at,
+        )
         if ids_to_reject
         else corpus
     )

--- a/src/bib2graph/stores/duckdb.py
+++ b/src/bib2graph/stores/duckdb.py
@@ -80,10 +80,15 @@ class DuckDBStore:
         archivo; las operaciones subsecuentes (``accept``, ``reject``,
         ``merge``) mutarán el archivo en disco.
 
+        #126: reconstruye ``manifest.filters`` desde ``filter_log`` para que
+        los pasos PRISMA persistan entre sesiones.
+
         Returns:
             El ``Corpus`` acumulado en el store.
         """
         import pyarrow as pa
+
+        from bib2graph.corpus import FilterStep
 
         table = self._backend.to_arrow()
         if len(table) == 0:
@@ -92,7 +97,24 @@ class DuckDBStore:
                 schema=CORPUS_SCHEMA,
             )
         # Devolver un Corpus respaldado por el DuckDBBackend
-        return Corpus.from_arrow(table, backend=self._backend)
+        corpus = Corpus.from_arrow(table, backend=self._backend)
+
+        # #126: reconstruir manifest.filters desde filter_log
+        raw_steps = self._backend.load_filter_steps()
+        if raw_steps:
+            filter_steps = [
+                FilterStep(
+                    name=str(s["name"]),
+                    criteria=str(s["criteria"]),
+                    count_before=int(str(s["count_before"])),
+                    count_after=int(str(s["count_after"])),
+                )
+                for s in raw_steps
+            ]
+            new_manifest = corpus.manifest.model_copy(update={"filters": filter_steps})
+            corpus = corpus.with_manifest(new_manifest)
+
+        return corpus
 
     # ------------------------------------------------------------------
     # Acceso al backend subyacente (CycleState, query SQL)

--- a/tests/unit/test_filter_trazabilidad.py
+++ b/tests/unit/test_filter_trazabilidad.py
@@ -1,0 +1,373 @@
+"""Tests de trazabilidad PRISMA — issue #126.
+
+Verifica que:
+1. Tras ``run_filter``, ``manifest.filters`` persiste en el store y se
+   recupera en el próximo ``store.load()`` (no queda ``[]`` vacío).
+2. Los pasos persisten con los conteos correctos (``count_before``,
+   ``count_after``, ``criteria``).
+3. Un paper rechazado por filtro tiene en su provenance el criterio
+   de filtro en el campo ``source`` del evento ``rejected``.
+4. El flujo limpio ``seed → filter`` (usando ``DuckDBStore``, no restore)
+   funciona end-to-end con trazabilidad completa.
+5. Re-aplicar ``run_filter`` (idempotencia) reemplaza los pasos anteriores
+   en vez de acumularlos indefinidamente.
+
+Marcador: ``unit`` (DuckDB en ``tmp_path``, sin red).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pyarrow as pa
+import pytest
+
+from bib2graph.schemas import CORPUS_SCHEMA
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_row(
+    *,
+    id: str,
+    title: str = "Título de prueba",
+    year: int = 2020,
+    language: str | None = "en",
+    curation_status: str = "candidate",
+) -> dict[str, Any]:
+    """Fila mínima con todos los campos del schema canónico."""
+    return {
+        "id": id,
+        "source_id": None,
+        "doi": None,
+        "title": title,
+        "year": year,
+        "abstract": None,
+        "source": None,
+        "language": language,
+        "publisher": None,
+        "research_areas": None,
+        "is_seed": True,
+        "curation_status": curation_status,
+        "provenance": None,
+        "authors_raw": None,
+        "authors_id": None,
+        "authors_affiliations": None,
+        "keywords_raw": None,
+        "keywords_id": None,
+        "institutions_raw": None,
+        "institutions_id": None,
+        "references_id": None,
+        "references_doi": None,
+        "cited_by_id": None,
+    }
+
+
+def _seed_store(store_path: Path, rows: list[dict[str, Any]]) -> None:
+    """Puebla un store DuckDB con las filas dadas."""
+    from bib2graph.corpus import Corpus
+    from bib2graph.stores.duckdb import DuckDBStore
+
+    table = pa.Table.from_pylist(rows, schema=CORPUS_SCHEMA)
+    corpus = Corpus.from_arrow(table)
+    store = DuckDBStore(store_path)
+    store.persist(corpus)
+    store.close()
+
+
+# ---------------------------------------------------------------------------
+# 1. manifest.filters persiste tras run_filter
+# ---------------------------------------------------------------------------
+
+
+def test_manifest_filters_persiste_tras_run_filter(tmp_path: Path) -> None:
+    """Tras run_filter, manifest.filters no queda vacío en la siguiente carga."""
+    from bib2graph.cli.commands.filter import run_filter
+    from bib2graph.stores.duckdb import DuckDBStore
+
+    store_path = tmp_path / "test.duckdb"
+    _seed_store(
+        store_path,
+        [
+            _make_row(id="P1", year=2010, language="en"),
+            _make_row(id="P2", year=2020, language="en"),
+            _make_row(id="P3", year=2020, language="fr"),
+        ],
+    )
+
+    # Aplicar un filtro de idioma
+    run_filter(store_path, language=["en"])
+
+    # Reabrir el store y verificar que manifest.filters sobrevivió
+    store = DuckDBStore(store_path)
+    corpus = store.load()
+    store.close()
+
+    assert len(corpus.manifest.filters) == 1, (
+        "manifest.filters debe tener 1 paso después de run_filter con --language"
+    )
+
+
+def test_manifest_filters_tiene_conteos_correctos(tmp_path: Path) -> None:
+    """Los conteos del FilterStep persisten con los valores calculados."""
+    from bib2graph.cli.commands.filter import run_filter
+    from bib2graph.stores.duckdb import DuckDBStore
+
+    store_path = tmp_path / "test.duckdb"
+    _seed_store(
+        store_path,
+        [
+            _make_row(id="P1", language="en"),
+            _make_row(id="P2", language="en"),
+            _make_row(id="P3", language="fr"),
+        ],
+    )
+
+    run_filter(store_path, language=["en"])
+
+    store = DuckDBStore(store_path)
+    corpus = store.load()
+    store.close()
+
+    step = corpus.manifest.filters[0]
+    assert step.count_before == 3, "count_before debe ser 3 (todos los papers)"
+    assert step.count_after == 2, "count_after debe ser 2 (P1 y P2 pasan)"
+    assert "language" in step.name
+    assert "en" in step.criteria
+
+
+def test_manifest_filters_persiste_multiples_pasos(tmp_path: Path) -> None:
+    """Varios criterios en una sola llamada → todos los pasos persisten."""
+    from bib2graph.cli.commands.filter import run_filter
+    from bib2graph.stores.duckdb import DuckDBStore
+
+    store_path = tmp_path / "test.duckdb"
+    _seed_store(
+        store_path,
+        [
+            _make_row(id="P1", year=2010, language="en"),
+            _make_row(id="P2", year=2020, language="en"),
+            _make_row(id="P3", year=2020, language="fr"),
+        ],
+    )
+
+    run_filter(store_path, year_gte=2015, language=["en"])
+
+    store = DuckDBStore(store_path)
+    corpus = store.load()
+    store.close()
+
+    assert len(corpus.manifest.filters) == 2, (
+        "manifest.filters debe tener 2 pasos (year_gte y language)"
+    )
+    # El primer paso es year_gte
+    assert "year" in corpus.manifest.filters[0].name
+    # El segundo paso es language
+    assert "language" in corpus.manifest.filters[1].name
+
+
+# ---------------------------------------------------------------------------
+# 2. Trazabilidad por paper: provenance.source refleja el criterio
+# ---------------------------------------------------------------------------
+
+
+def test_provenance_rejected_tiene_source_con_criterio(tmp_path: Path) -> None:
+    """El paper rechazado tiene en provenance source = criterio del filtro."""
+    from bib2graph.cli.commands.filter import run_filter
+    from bib2graph.stores.duckdb import DuckDBStore
+
+    store_path = tmp_path / "test.duckdb"
+    _seed_store(
+        store_path,
+        [
+            _make_row(id="P1", language="en"),
+            _make_row(id="P2", language="fr"),
+        ],
+    )
+
+    run_filter(store_path, language=["en"])
+
+    store = DuckDBStore(store_path)
+    corpus = store.load()
+    # Leer la tabla antes de cerrar el store (el corpus usa el backend DuckDB)
+    rows = corpus.to_arrow().to_pylist()
+    store.close()
+
+    rejected = [r for r in rows if r["curation_status"] == "rejected"]
+    assert len(rejected) == 1
+    rejected_paper = rejected[0]
+    assert rejected_paper["id"] == "P2"
+
+    # Verificar que la provenance tiene el criterio en source
+    provenance_raw = rejected_paper.get("provenance")
+    assert provenance_raw is not None, "El paper rechazado debe tener provenance"
+    events = json.loads(str(provenance_raw))
+    assert len(events) >= 1
+    rejected_event = next(e for e in events if e["action"] == "rejected")
+    assert rejected_event["source"] is not None, (
+        "El evento rejected debe tener source con el criterio del filtro"
+    )
+    assert "language" in rejected_event["source"], (
+        "El source del evento debe mencionar el campo 'language'"
+    )
+    assert "fr" in str(rejected_event["source"]) or "en" in str(
+        rejected_event["source"]
+    ), "El source debe mencionar el valor del filtro"
+
+
+def test_provenance_rejected_tiene_decided_by_prisma_filter(tmp_path: Path) -> None:
+    """El evento rejected por filtro tiene decided_by='prisma_filter'."""
+    from bib2graph.cli.commands.filter import run_filter
+    from bib2graph.stores.duckdb import DuckDBStore
+
+    store_path = tmp_path / "test.duckdb"
+    _seed_store(
+        store_path,
+        [
+            _make_row(id="P1", year=2020),
+            _make_row(id="P2", year=2005),
+        ],
+    )
+
+    run_filter(store_path, year_gte=2010)
+
+    store = DuckDBStore(store_path)
+    corpus = store.load()
+    # Leer la tabla antes de cerrar el store (el corpus usa el backend DuckDB)
+    rows = corpus.to_arrow().to_pylist()
+    store.close()
+
+    p2 = next(r for r in rows if r["id"] == "P2")
+    assert p2["curation_status"] == "rejected"
+
+    events = json.loads(str(p2["provenance"]))
+    rejected_event = next(e for e in events if e["action"] == "rejected")
+    assert rejected_event["decided_by"] == "prisma_filter"
+
+
+# ---------------------------------------------------------------------------
+# 3. Idempotencia: re-aplicar filter reemplaza pasos anteriores
+# ---------------------------------------------------------------------------
+
+
+def test_reapply_filter_reemplaza_pasos_anteriores(tmp_path: Path) -> None:
+    """Re-ejecutar run_filter reemplaza los pasos; no los duplica."""
+    from bib2graph.cli.commands.filter import run_filter
+    from bib2graph.stores.duckdb import DuckDBStore
+
+    store_path = tmp_path / "test.duckdb"
+    _seed_store(
+        store_path,
+        [
+            _make_row(id="P1", year=2020),
+            _make_row(id="P2", year=2005),
+        ],
+    )
+
+    # Primera ejecución
+    run_filter(store_path, year_gte=2010)
+    # Segunda ejecución con distinto criterio (reemplaza)
+    run_filter(store_path, year_gte=2015)
+
+    store = DuckDBStore(store_path)
+    corpus = store.load()
+    store.close()
+
+    # Solo debe haber 1 paso (el de la segunda ejecución), no 2
+    assert len(corpus.manifest.filters) == 1, (
+        "Re-ejecutar filter debe reemplazar los pasos anteriores, no acumularlos"
+    )
+    assert "2015" in corpus.manifest.filters[0].criteria
+
+
+# ---------------------------------------------------------------------------
+# 4. inspect devuelve manifest.filters no vacío tras run_filter
+# ---------------------------------------------------------------------------
+
+
+def test_inspect_devuelve_filters_no_vacios(tmp_path: Path) -> None:
+    """run_inspect tras run_filter refleja los pasos en manifest.filters."""
+    from bib2graph.cli.commands.filter import run_filter
+    from bib2graph.cli.commands.inspect import run_inspect
+
+    store_path = tmp_path / "test.duckdb"
+    _seed_store(
+        store_path,
+        [
+            _make_row(id="P1", language="en"),
+            _make_row(id="P2", language="de"),
+        ],
+    )
+
+    run_filter(store_path, language=["en"])
+    data = run_inspect(store_path)
+
+    filters = data["manifest"]["filters"]
+    assert len(filters) >= 1, "inspect debe mostrar los filtros aplicados"
+    assert filters[0]["count_before"] == 2
+    assert filters[0]["count_after"] == 1
+
+
+# ---------------------------------------------------------------------------
+# 5. Flujo limpio seed→filter con DuckDBStore (no restore)
+# ---------------------------------------------------------------------------
+
+
+def test_flujo_seed_filter_trazabilidad_completa(tmp_path: Path) -> None:
+    """Flujo completo seed→filter con trazabilidad end-to-end.
+
+    - manifest.filters tiene el paso correcto.
+    - El paper rechazado tiene provenance con source del criterio.
+    - El paper aceptado (no rechazado) no tiene evento rejected.
+    """
+    from bib2graph.cli.commands.filter import run_filter
+    from bib2graph.stores.duckdb import DuckDBStore
+
+    store_path = tmp_path / "test.duckdb"
+    _seed_store(
+        store_path,
+        [
+            _make_row(id="A", year=2022, language="en"),
+            _make_row(id="B", year=2022, language="es"),
+            _make_row(id="C", year=2022, language="zh"),
+        ],
+    )
+
+    # Filtrar: solo incluir en/es
+    result = run_filter(store_path, language=["en", "es"])
+    assert result["criteria_applied"] == 1
+    assert len(result["steps"]) == 1
+    assert result["steps"][0]["excluded"] == 1  # solo C excluido
+
+    store = DuckDBStore(store_path)
+    corpus = store.load()
+
+    # manifest.filters tiene el paso
+    assert len(corpus.manifest.filters) == 1
+    step = corpus.manifest.filters[0]
+    assert step.count_before == 3
+    assert step.count_after == 2
+
+    # Verificar provenance de C (rechazado) — leer antes de cerrar el store
+    rows = {r["id"]: r for r in corpus.to_arrow().to_pylist()}
+    store.close()
+
+    assert rows["C"]["curation_status"] == "rejected"
+    assert rows["A"]["curation_status"] == "candidate"
+    assert rows["B"]["curation_status"] == "candidate"
+
+    events_c = json.loads(str(rows["C"]["provenance"]))
+    rejected_event = next(e for e in events_c if e["action"] == "rejected")
+    assert rejected_event["source"] is not None
+    assert "language" in rejected_event["source"]
+
+    # A y B no tienen evento rejected
+    assert rows["A"]["provenance"] is None
+    assert rows["B"]["provenance"] is None


### PR DESCRIPTION
Cierra **#126** (trazabilidad PRISMA). Dos bugs:

1. **`manifest.filters` vacío tras recargar** — el store persistía la tabla Arrow pero NO el manifest. Se agrega una **tabla hermana `filter_log`** (patrón de `loop_state_log`/`external_ids`) con criterio + `count_before`/`count_after`; `DuckDBStore.load()` reconstruye `manifest.filters` desde ahí.
2. **El evento `rejected` por-paper traía `source: None`** sin criterio → ahora `apply_filter` pasa `by="prisma_filter"` + `source="filter:<field>:<op>:<value>"`: se puede reconstruir por qué se rechazó cada paper.

Param `source` opcional propagado por el Protocol/backends, sin romper accept/reject/curate. **8 tests** nuevos del contrato de trazabilidad. Gate verde **con extras** (los 44 "failed" del coder eran extras no instalados; con `--all-extras` pasa).

Nota: `enrich` tiene el mismo problema de manifest efímero — fuera de alcance (follow-up).

Closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)