### PR TITLE
fix(seed): cerrar el backend clonado correcto en reseed --from-bib (#93)

### DIFF
--- a/src/bib2graph/cli/commands/seed.py
+++ b/src/bib2graph/cli/commands/seed.py
@@ -139,7 +139,10 @@ def run_seed(
         merged_deduped = normalize_and_dedup(merged, applied_at=ingest_at)
         papers_added = len(result.corpus)
         total_papers = len(merged_deduped)
-        merged_backend_close = getattr(merged_deduped._backend, "close", None)
+        # Capturá close() del backend CLONADO (merged._backend, no merged_deduped)
+        # normalize_and_dedup devuelve un corpus con InMemoryBackend;
+        # el clone DuckDB está en merged._backend (fix #93).
+        merged_backend_close = getattr(merged._backend, "close", None)
         store.persist_replace(merged_deduped)
         store.backend.set_loop_state(new_state, cycle_round=new_round)
     finally:
@@ -259,9 +262,10 @@ def run_seed_from_bib(
         merged_deduped = normalize_and_dedup(merged, applied_at=ingest_at)
         papers_added = len(corpus)
         total_papers = len(merged_deduped)
-        # Capturá close() del backend clonado antes de persistir (puede no
-        # existir si el backend es InMemoryBackend).
-        merged_backend_close = getattr(merged_deduped._backend, "close", None)
+        # Capturá close() del backend CLONADO (merged._backend, no merged_deduped)
+        # antes de persistir.  normalize_and_dedup devuelve un corpus con
+        # InMemoryBackend; el clone DuckDB está en merged._backend (fix #93).
+        merged_backend_close = getattr(merged._backend, "close", None)
         store.persist_replace(merged_deduped)
         store.backend.set_loop_state(new_state, cycle_round=new_round)
 

--- a/tests/unit/test_seed_from_bib.py
+++ b/tests/unit/test_seed_from_bib.py
@@ -403,11 +403,6 @@ def test_run_seed_from_bib_archivo_inexistente_lanza_data_error(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.skip(
-    reason="bibtex reseed crash (BibDataString/pyparsing estado global, mismo proceso) "
-    "expuesto por el auto-dedup de #88 — ver #93. No afecta el CLI real (proceso nuevo "
-    "por invocación). Reactivar al cerrar #93."
-)
 def test_run_seed_from_bib_reseed_incrementa_ronda(tmp_path: Path) -> None:
     """Segunda siembra con --from-bib es un reseed: ronda++ y reseeded=True."""
     from bib2graph.cli.commands.seed import run_seed_from_bib


### PR DESCRIPTION
Cierra **#93**. El crash `BibDataString`/pyparsing al reseed con `--from-bib` **no era de bibtexparser** — era una **fuga de conexión**:

`run_seed`/`run_seed_from_bib` capturaban `close()` de `merged_deduped._backend` (un `InMemoryBackend` → no-op) en vez de `merged._backend` (el **clone DuckDB** con la conexión de archivo abierta). El clone quedaba vivo; el 2º seed en el mismo proceso compartía el catálogo UDF stale del clone → DuckDB invocaba callables liberados/reusados por las parse-actions de pyparsing → crash.

**Fix:** capturar `merged._backend.close()` (lo que el comentario ya decía, pero el código no hacía). Quita el `@pytest.mark.skip` del test de reseed.

Gate verde **con extras** (810 passed). El mismo typo estaba en `run_seed` (OpenAlex) — corregido también. Solo `seed.py` tiene este patrón.

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)