### PR TITLE
feat(networks): cablear assortativity_attribute + composición (#90)

### DIFF
--- a/src/bib2graph/cli/commands/build.py
+++ b/src/bib2graph/cli/commands/build.py
@@ -87,16 +87,21 @@ def _write_artifacts(
             for k, v in art.metrics.items()
             if isinstance(v, (int, float, str, bool, type(None)))
         }
+
+        # D3 — incluir asortatividad en metrics.json cuando está disponible.
+        # community_composition es un dict anidado; se incluye dentro de
+        # assortativity para no alterar el schema de primer nivel.
+        metrics_payload: dict[str, object] = {
+            "kind": kind,
+            "nodes": art.graph.number_of_nodes(),
+            "edges": art.graph.number_of_edges(),
+            **safe_metrics,
+        }
+        if art.assortativity is not None:
+            metrics_payload["assortativity"] = art.assortativity
+
         metrics_path.write_text(
-            json.dumps(
-                {
-                    "kind": kind,
-                    "nodes": art.graph.number_of_nodes(),
-                    "edges": art.graph.number_of_edges(),
-                    **safe_metrics,
-                },
-                ensure_ascii=False,
-            ),
+            json.dumps(metrics_payload, ensure_ascii=False),
             encoding="utf-8",
         )
 
@@ -140,6 +145,8 @@ def _write_artifacts(
             "graphml": str(kind_dir / "network.graphml"),
             "metrics_json": str(metrics_path),
         }
+        if art.assortativity is not None:
+            net_entry["assortativity"] = art.assortativity
         if clusters_path is not None:
             net_entry["clusters_csv"] = clusters_path
         networks_info.append(net_entry)

--- a/src/bib2graph/networks/facade.py
+++ b/src/bib2graph/networks/facade.py
@@ -20,7 +20,12 @@ import networkx as nx
 import pyarrow as pa
 
 from bib2graph.constants import NetworkKind
-from bib2graph.networks.analyzer import detect_communities, network_metrics
+from bib2graph.networks.analyzer import (
+    assortativity,
+    community_composition,
+    detect_communities,
+    network_metrics,
+)
 from bib2graph.networks.decorate import decorate
 from bib2graph.networks.projectors import (
     AuthorCollaborationProjector,
@@ -155,6 +160,57 @@ def _apply_keyword_filter(table: pa.Table, terms: list[str]) -> pa.Table:
     return table.filter(bool_array)
 
 
+def _inject_scalar_attribute(
+    g: _Graph,
+    table: pa.Table,
+    attribute: str,
+) -> bool:
+    """Inyecta un atributo escalar del corpus como atributo de nodo en el grafo.
+
+    Útil para atributos como ``language`` o ``research_areas`` que no son
+    inyectados por ``decorate`` pero sí existen en la tabla Arrow.
+
+    Solo actúa en grafos cuyo nodo es un paper id (``Col.ID``): busca cada nodo
+    del grafo en la columna ``id`` de la tabla y extrae el valor escalar.
+    Para atributos de lista (p.ej. ``research_areas``), extrae el primer elemento.
+
+    Args:
+        g: Grafo NetworkX (modificado in-place).
+        table: Tabla Arrow canónica del Corpus.
+        attribute: Nombre del atributo/columna a inyectar.
+
+    Returns:
+        ``True`` si el atributo existía en la tabla y se inyectó en al menos
+        un nodo; ``False`` si la columna no existe en la tabla.
+    """
+    from bib2graph.constants import Col
+
+    if attribute not in table.schema.names:
+        return False
+
+    # Construir índice rápido: paper_id → valor del atributo
+    ids = table.column(Col.ID).to_pylist()
+    values = table.column(attribute).to_pylist()
+
+    attr_index: dict[str, object] = {}
+    for pid, val in zip(ids, values, strict=False):
+        if pid is None:
+            continue
+        # Para atributos de lista, extraer el primero (p.ej. research_areas)
+        if isinstance(val, list):
+            val = val[0] if val else None
+        attr_index[str(pid)] = val
+
+    injected = False
+    for node in g.nodes():
+        key = str(node)
+        if key in attr_index and attr_index[key] is not None:
+            g.nodes[node][attribute] = attr_index[key]
+            injected = True
+
+    return injected
+
+
 def _build_artifact(corpus: Corpus, spec: NetworkSpec) -> NetworkArtifact:
     """Construye un ``NetworkArtifact`` a partir de un corpus y una spec.
 
@@ -226,6 +282,41 @@ def _build_artifact(corpus: Corpus, spec: NetworkSpec) -> NetworkArtifact:
     # exportadores (GraphML, CSV) y el CLI reciban artefactos ya decorados
     # sin necesitar conocer el corpus.
     decorate(artifact, table)
+
+    # D3 — asortatividad/composición: solo cuando spec.assortativity_attribute
+    # está configurado y el grafo tiene nodos.
+    if spec.assortativity_attribute is not None and g.number_of_nodes() > 0:
+        attr = spec.assortativity_attribute
+
+        # Verificar si el atributo ya está en los nodos (p.ej. inyectado por
+        # decorate para 'curation_status', 'is_seed', etc.). Si no, intentar
+        # inyectarlo desde la tabla Arrow (p.ej. 'language', 'research_areas').
+        attr_in_nodes = any(
+            attr in g.nodes[n] for n in g.nodes() if g.nodes[n].get(attr) is not None
+        )
+        if not attr_in_nodes:
+            attr_in_nodes = _inject_scalar_attribute(g, table, attr)
+
+        if not attr_in_nodes:
+            # El atributo no existe en el grafo ni en la tabla del corpus.
+            # Warning accionable: no crashear (D3 — manejo de atributo inexistente).
+            logger.warning(
+                "assortativity_attribute='%s' no existe en los nodos del grafo "
+                "ni como columna en el corpus. Verificá el nombre del atributo. "
+                "Asortatividad no calculada para la red '%s'.",
+                attr,
+                spec.kind,
+            )
+        else:
+            assort_result = assortativity(g, attribute=attr, by_degree=True)
+
+            # Si hay comunidades, agregar composición por comunidad.
+            if communities is not None:
+                assort_result["community_composition"] = community_composition(
+                    g, communities, attr
+                )
+
+            artifact.assortativity = assort_result
 
     return artifact
 

--- a/tests/unit/test_assortativity_d3.py
+++ b/tests/unit/test_assortativity_d3.py
@@ -1,0 +1,401 @@
+"""Tests D3 — asortatividad/composición cableada en NetworkArtifact.
+
+Historia D3 (#90): ``NetworkSpec.assortativity_attribute`` cablea la llamada a
+``analyzer.assortativity`` y ``analyzer.community_composition`` dentro de
+``_build_artifact`` (facade.py), exponiendo el resultado en
+``NetworkArtifact.assortativity`` y en el ``metrics.json`` / envelope de red.
+
+Casos cubiertos:
+1. Atributo categórico en la tabla del corpus (``language``) + comunidades →
+   ``attribute_assortativity`` y ``community_composition`` poblados.
+2. ``assortativity_attribute=None`` → ``artifact.assortativity is None``
+   (comportamiento anterior intacto).
+3. Atributo inexistente → warning accionable (no crash), ``assortativity`` sigue None.
+4. Atributo de nodo ya inyectado por ``decorate`` (``curation_status``) →
+   asortatividad calculada sin pasar por ``_inject_scalar_attribute``.
+5. ``_write_artifacts`` incluye asortatividad en ``metrics.json`` y en el
+   entry del envelope.
+
+Marcador: ``unit`` (sin red, sin I/O).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import tempfile
+from pathlib import Path
+from typing import Any
+
+import networkx as nx
+import pyarrow as pa
+import pytest
+
+from bib2graph.corpus import Corpus
+from bib2graph.networks.facade import Networks, _inject_scalar_attribute
+from bib2graph.networks.spec import NetworkSpec
+from bib2graph.schemas import CORPUS_SCHEMA
+
+# ---------------------------------------------------------------------------
+# Helpers de fixtures
+# ---------------------------------------------------------------------------
+
+
+def _row(
+    pid: str,
+    *,
+    language: str | None = None,
+    curation_status: str = "candidate",
+    references_id: list[str] | None = None,
+) -> dict[str, Any]:
+    """Crea una fila de corpus mínima para los tests."""
+    return {
+        "id": pid,
+        "openalex_id": None,
+        "doi": None,
+        "title": f"Paper {pid}",
+        "year": 2020,
+        "abstract": None,
+        "source": None,
+        "language": language,
+        "publisher": None,
+        "research_areas": None,
+        "is_seed": True,
+        "curation_status": curation_status,
+        "provenance": None,
+        "authors_raw": None,
+        "authors_id": None,
+        "authors_affiliations": None,
+        "keywords_raw": None,
+        "keywords_id": None,
+        "institutions_raw": None,
+        "institutions_id": None,
+        "references_id": references_id,
+        "references_doi": None,
+        "cited_by_id": None,
+    }
+
+
+def _make_corpus_con_language() -> Corpus:
+    """Corpus de 4 papers: 2 en inglés (comparten una referencia) y 2 en español.
+
+    Construye una red de acoplamiento bibliográfico donde los pares del mismo
+    idioma comparten referencias. Esto garantiza asortatividad alta por ``language``.
+
+      P0 (en) refs: [R0, R_SHARED_EN]
+      P1 (en) refs: [R1, R_SHARED_EN]
+      P2 (es) refs: [R2, R_SHARED_ES]
+      P3 (es) refs: [R3, R_SHARED_ES]
+    """
+    rows = [
+        _row("P0", language="en", references_id=["R0", "R_SHARED_EN"]),
+        _row("P1", language="en", references_id=["R1", "R_SHARED_EN"]),
+        _row("P2", language="es", references_id=["R2", "R_SHARED_ES"]),
+        _row("P3", language="es", references_id=["R3", "R_SHARED_ES"]),
+    ]
+    table = pa.Table.from_pylist(rows, schema=CORPUS_SCHEMA)
+    return Corpus.from_arrow(table)
+
+
+def _make_corpus_sin_language() -> Corpus:
+    """Corpus de 3 papers sin atributo de lenguaje (todos None)."""
+    rows = [
+        _row("P0", references_id=["R0", "R_SHARED"]),
+        _row("P1", references_id=["R1", "R_SHARED"]),
+        _row("P2", references_id=["R2"]),
+    ]
+    table = pa.Table.from_pylist(rows, schema=CORPUS_SCHEMA)
+    return Corpus.from_arrow(table)
+
+
+def _make_corpus_con_curation_status() -> Corpus:
+    """Corpus de 4 papers con curation_status variado para usar como atributo.
+
+    ``curation_status`` es inyectado por ``decorate`` para paper networks,
+    por lo que NO requiere ``_inject_scalar_attribute``.
+    """
+    rows = [
+        _row("P0", curation_status="accepted", references_id=["R0", "R_SHARED_ACC"]),
+        _row("P1", curation_status="accepted", references_id=["R1", "R_SHARED_ACC"]),
+        _row("P2", curation_status="candidate", references_id=["R2", "R_SHARED_CAND"]),
+        _row("P3", curation_status="candidate", references_id=["R3", "R_SHARED_CAND"]),
+    ]
+    table = pa.Table.from_pylist(rows, schema=CORPUS_SCHEMA)
+    return Corpus.from_arrow(table)
+
+
+# ---------------------------------------------------------------------------
+# Test 1: atributo de corpus inyectado + comunidades → asortatividad poblada
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_assortativity_attribute_popula_artifact() -> None:
+    """Con assortativity_attribute='language', NetworkArtifact.assortativity se puebla.
+
+    La red de acoplamiento bibliográfico tiene dos pares que comparten referencias
+    por idioma: alta asortatividad esperada (> 0).
+    """
+    corpus = _make_corpus_con_language()
+    spec = NetworkSpec(
+        kind="bibliographic_coupling",
+        clustering="louvain",
+        assortativity_attribute="language",
+    )
+    artifact = Networks.build(corpus, spec)
+
+    assert artifact.assortativity is not None, (
+        "assortativity debería poblarse cuando assortativity_attribute está seteado"
+    )
+    assert "attribute_assortativity" in artifact.assortativity
+    val = artifact.assortativity["attribute_assortativity"]
+    assert isinstance(val, float)
+    # Con pares del mismo idioma bien separados, la asortatividad debería ser > 0
+    assert isinstance(artifact.assortativity["degree_assortativity"], float)
+
+
+@pytest.mark.unit
+def test_assortativity_attribute_incluye_community_composition_cuando_hay_comunidades() -> (
+    None
+):
+    """Cuando hay comunidades, assortativity incluye 'community_composition'."""
+    corpus = _make_corpus_con_language()
+    spec = NetworkSpec(
+        kind="bibliographic_coupling",
+        clustering="louvain",
+        assortativity_attribute="language",
+    )
+    artifact = Networks.build(corpus, spec)
+
+    assert artifact.assortativity is not None
+    # community_composition debe estar presente porque spec.clustering='louvain'
+    assert "community_composition" in artifact.assortativity
+    comp = artifact.assortativity["community_composition"]
+    assert isinstance(comp, dict)
+    # Cada comunidad tiene un dict de categorías → fracciones
+    for comm_id, cat_fracs in comp.items():
+        assert isinstance(comm_id, int)
+        assert isinstance(cat_fracs, dict)
+        for cat, frac in cat_fracs.items():
+            assert isinstance(cat, str)
+            assert 0.0 <= float(frac) <= 1.0
+
+
+# ---------------------------------------------------------------------------
+# Test 2: assortativity_attribute=None → artifact.assortativity is None
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_assortativity_attribute_none_deja_assortativity_en_none() -> None:
+    """assortativity_attribute=None → NetworkArtifact.assortativity es None.
+
+    Comportamiento anterior intacto (regresión).
+    """
+    corpus = _make_corpus_con_language()
+    spec = NetworkSpec(kind="bibliographic_coupling")  # assortativity_attribute=None
+
+    artifact = Networks.build(corpus, spec)
+
+    assert artifact.assortativity is None
+
+
+# ---------------------------------------------------------------------------
+# Test 3: atributo inexistente → warning accionable, sin crash
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_assortativity_attribute_inexistente_no_crashea(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Atributo desconocido en assortativity_attribute → warning + assortativity=None.
+
+    No debe levantar excepción; emite un log.warning con el nombre del atributo.
+    """
+    corpus = _make_corpus_con_language()
+    spec = NetworkSpec(
+        kind="bibliographic_coupling",
+        assortativity_attribute="campo_inexistente",
+    )
+
+    with caplog.at_level(logging.WARNING, logger="bib2graph.networks.facade"):
+        artifact = Networks.build(corpus, spec)
+
+    # No debe crashear
+    assert artifact.assortativity is None
+    # Debe haber un warning accionable mencionando el atributo
+    assert any("campo_inexistente" in record.message for record in caplog.records), (
+        f"Se esperaba warning con nombre del atributo. Records: {caplog.records}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 4: atributo ya en nodos por decorate (curation_status) → sin _inject
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_assortativity_usa_atributo_ya_en_nodos_por_decorate() -> None:
+    """'curation_status' está en los nodos tras decorate → asortatividad calculada.
+
+    Verifica que el flujo funciona cuando el atributo categórico ya fue inyectado
+    por ``decorate`` (no necesita ``_inject_scalar_attribute``).
+    """
+    corpus = _make_corpus_con_curation_status()
+    spec = NetworkSpec(
+        kind="bibliographic_coupling",
+        clustering=None,  # sin comunidades para simplicidad
+        assortativity_attribute="curation_status",
+    )
+    artifact = Networks.build(corpus, spec)
+
+    assert artifact.assortativity is not None
+    assert "attribute_assortativity" in artifact.assortativity
+    # Sin clustering=None, no hay community_composition
+    assert "community_composition" not in artifact.assortativity
+
+
+# ---------------------------------------------------------------------------
+# Test 5: _inject_scalar_attribute — unit test de la función pura
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_inject_scalar_attribute_inyecta_language_en_nodos() -> None:
+    """_inject_scalar_attribute inyecta 'language' desde la tabla Arrow a los nodos."""
+    rows = [
+        _row("P0", language="en"),
+        _row("P1", language="es"),
+        _row("P2", language="en"),
+    ]
+    table = pa.Table.from_pylist(rows, schema=CORPUS_SCHEMA)
+
+    g: nx.Graph = nx.Graph()
+    g.add_nodes_from(["P0", "P1", "P2"])
+
+    result = _inject_scalar_attribute(g, table, "language")
+
+    assert result is True
+    assert g.nodes["P0"]["language"] == "en"
+    assert g.nodes["P1"]["language"] == "es"
+    assert g.nodes["P2"]["language"] == "en"
+
+
+@pytest.mark.unit
+def test_inject_scalar_attribute_retorna_false_si_columna_no_existe() -> None:
+    """_inject_scalar_attribute retorna False si la columna no existe en la tabla."""
+    rows = [_row("P0")]
+    table = pa.Table.from_pylist(rows, schema=CORPUS_SCHEMA)
+
+    g: nx.Graph = nx.Graph()
+    g.add_node("P0")
+
+    result = _inject_scalar_attribute(g, table, "columna_que_no_existe")
+
+    assert result is False
+    assert "columna_que_no_existe" not in g.nodes["P0"]
+
+
+@pytest.mark.unit
+def test_inject_scalar_attribute_ignora_nodos_con_valor_none() -> None:
+    """_inject_scalar_attribute no inyecta el atributo en nodos con valor None."""
+    rows = [
+        _row("P0", language=None),
+        _row("P1", language="en"),
+    ]
+    table = pa.Table.from_pylist(rows, schema=CORPUS_SCHEMA)
+
+    g: nx.Graph = nx.Graph()
+    g.add_nodes_from(["P0", "P1"])
+
+    result = _inject_scalar_attribute(g, table, "language")
+
+    # Retorna True porque al menos P1 se inyectó
+    assert result is True
+    assert "language" not in g.nodes["P0"]
+    assert g.nodes["P1"]["language"] == "en"
+
+
+# ---------------------------------------------------------------------------
+# Test 6: _write_artifacts expone assortativity en metrics.json y net_entry
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_write_artifacts_incluye_assortativity_en_metrics_json() -> None:
+    """_write_artifacts escribe 'assortativity' en metrics.json cuando está poblado.
+
+    Verifica la exposición en el artefacto de disco (D3: "que aparezca en metrics.json").
+    """
+    from bib2graph.cli.commands.build import _write_artifacts
+
+    corpus = _make_corpus_con_language()
+    spec = NetworkSpec(
+        kind="bibliographic_coupling",
+        clustering="louvain",
+        assortativity_attribute="language",
+    )
+    artifact = Networks.build(corpus, spec)
+    assert artifact.assortativity is not None  # precondición
+
+    with tempfile.TemporaryDirectory() as tmp:
+        artifacts_dir = Path(tmp)
+        entries = _write_artifacts([artifact], corpus, artifacts_dir)
+
+        assert len(entries) == 1
+        entry = entries[0]
+
+        # El net_entry del envelope debe incluir 'assortativity'
+        assert "assortativity" in entry
+        assert "attribute_assortativity" in entry["assortativity"]
+
+        # El metrics.json en disco también debe tenerlo
+        metrics = json.loads(Path(entry["metrics_json"]).read_text(encoding="utf-8"))
+        assert "assortativity" in metrics
+        assert "attribute_assortativity" in metrics["assortativity"]
+
+
+@pytest.mark.unit
+def test_write_artifacts_sin_assortativity_no_incluye_clave() -> None:
+    """_write_artifacts NO incluye 'assortativity' cuando artifact.assortativity es None.
+
+    Regresión: el comportamiento anterior sin assortativity_attribute no se rompe.
+    """
+    from bib2graph.cli.commands.build import _write_artifacts
+
+    corpus = _make_corpus_con_language()
+    spec = NetworkSpec(kind="bibliographic_coupling")  # sin assortativity_attribute
+    artifact = Networks.build(corpus, spec)
+    assert artifact.assortativity is None  # precondición
+
+    with tempfile.TemporaryDirectory() as tmp:
+        artifacts_dir = Path(tmp)
+        entries = _write_artifacts([artifact], corpus, artifacts_dir)
+
+        entry = entries[0]
+        assert "assortativity" not in entry
+
+        metrics = json.loads(Path(entry["metrics_json"]).read_text(encoding="utf-8"))
+        assert "assortativity" not in metrics
+
+
+# ---------------------------------------------------------------------------
+# Test 7: sin comunidades → community_composition ausente de assortativity
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_assortativity_sin_clustering_no_incluye_community_composition() -> None:
+    """Con clustering=None, 'community_composition' no aparece en assortativity."""
+    corpus = _make_corpus_con_language()
+    spec = NetworkSpec(
+        kind="bibliographic_coupling",
+        clustering=None,
+        assortativity_attribute="language",
+    )
+    artifact = Networks.build(corpus, spec)
+
+    assert artifact.assortativity is not None
+    assert "community_composition" not in artifact.assortativity
+    assert "attribute_assortativity" in artifact.assortativity


### PR DESCRIPTION
Cierra **#90** (historia D3). `NetworkSpec.assortativity_attribute` existía pero no se usaba, y `analyzer.assortativity`/`community_composition` existían pero no se llamaban. Ahora:

- `_build_artifact`: si `assortativity_attribute` está seteado, calcula `attribute_assortativity` (+ degree) y la **composición por comunidad**, y puebla `NetworkArtifact.assortativity`.
- Se expone en `metrics.json` y en el envelope `--json` de `build`/`networks`.
- Nuevo helper `_inject_scalar_attribute` mapea atributos escalares del corpus (`language`, `research_areas[0]`…) a nodos de redes de paper.
- Atributo ausente → warning accionable, sin crash. Redes no-paper cubiertas con el mismo warning.

11 tests nuevos. Gate verde **con extras** (820 passed).

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)