### PR TITLE
feat(cli): preview del crecimiento del chaining antes del fetch (#89)

### DIFF
--- a/src/bib2graph/cli/commands/chain.py
+++ b/src/bib2graph/cli/commands/chain.py
@@ -31,8 +31,15 @@ def run_chain(
     max_citing_per_paper: int | None = 50,
     email: str | None = None,
     transport: Any = None,
+    preview: bool = False,
 ) -> dict[str, Any]:
     """Expande el corpus con candidatos rankeados por information scent.
+
+    Cuando ``preview=True``, estima el crecimiento potencial **sin fetchear**
+    ni transicionar el estado del corpus.  La estimación backward es exacta
+    (desde ``references_id``); la forward es exacta si el corpus tiene
+    ``cited_by_id`` poblado (pasó por ``b2g enrich``), o indica que se
+    requiere fetch si ``cited_by_id`` está vacío.
 
     Args:
         store_path: Ruta al archivo ``.duckdb``.
@@ -43,15 +50,28 @@ def run_chain(
             chaining (default 50; None = sin tope).
         email: Email para el polite pool de OpenAlex.
         transport: Transport inyectable para tests.
+        preview: Si ``True``, solo estima el crecimiento sin fetchear ni
+            transicionar estado (dry-run).
 
     Returns:
-        Dict con ``candidates_found``, ``total_papers``, ``ranking_preview``.
+        Dict con ``candidates_found``, ``total_papers``, ``ranking_preview``
+        (modo normal); o con ``preview``, ``estimated_candidates``,
+        ``by_direction``, ``capped_by_max``, ``forward_requires_fetch``,
+        ``forward_from_cited_by`` (modo preview).
 
     Raises:
         DependencyError: Si el source no soporta forward chaining.
         NetworkError: Si falla la conexión a OpenAlex.
         StoreError: Si el store está bloqueado.
     """
+    if preview:
+        return _run_chain_preview(
+            store_path,
+            direction=direction,
+            depth=depth,
+            max_candidates=max_candidates,
+        )
+
     from bib2graph.cycle import apply_transition
     from bib2graph.foraging import Forager
     from bib2graph.sources.openalex import OpenAlexSource
@@ -142,6 +162,76 @@ def run_chain(
     }
 
 
+def _run_chain_preview(
+    store_path: str | Path,
+    *,
+    direction: Literal["backward", "forward", "both"],
+    depth: int,
+    max_candidates: int | None,
+) -> dict[str, Any]:
+    """Implementación del modo preview (dry-run) de ``run_chain``.
+
+    Estima el crecimiento potencial del corpus **sin hacer fetch ni transicionar
+    estado**.  Abre el store, lee el corpus y llama a ``Forager.preview()``.
+
+    Args:
+        store_path: Ruta al archivo ``.duckdb``.
+        direction: Dirección pedida.
+        depth: Profundidad (solo 1 implementado; >1 → DependencyError).
+        max_candidates: Tope de candidatos.
+
+    Returns:
+        Dict con las claves del envelope de preview (``preview=True``,
+        ``estimated_candidates``, ``by_direction``, ``direction``,
+        ``capped_by_max``, ``forward_requires_fetch``, ``forward_from_cited_by``).
+    """
+    from bib2graph.foraging import Forager
+
+    # Para preview backward/both, el source nunca se usa (cero red).
+    # Para preview forward con cited_by_id, tampoco.
+    # Usamos None como source (el Forager solo llama al source en chain(), no en preview()).
+    store = open_store(store_path)
+    try:
+        corpus = store.load()
+
+        try:
+            forager = Forager(
+                None,  # source no se usa en preview()
+                depth=depth,
+                max_candidates=max_candidates,
+            )
+        except NotImplementedError as exc:
+            raise DependencyError(
+                f"Profundidad {depth} no soportada aún: {exc}. "
+                "Usá depth=1 (por defecto)."
+            ) from exc
+
+        growth = forager.preview(corpus, direction=direction)
+    finally:
+        store.close()
+
+    # Mensaje accionable cuando el forward no es estimable localmente.
+    warnings: list[str] = []
+    if growth.forward_requires_fetch:
+        warnings.append(
+            "El crecimiento forward no puede estimarse sin red: el corpus no tiene "
+            "``cited_by_id`` poblado.  Ejecutá ``b2g enrich`` primero para obtener "
+            "una estimación local, o ejecutá ``b2g chain`` sin ``--preview`` para "
+            "traer los citantes directamente."
+        )
+
+    return {
+        "preview": True,
+        "direction": direction,
+        "estimated_candidates": growth.estimated_new,
+        "by_direction": growth.by_direction,
+        "capped_by_max": growth.capped_by_max,
+        "forward_requires_fetch": growth.forward_requires_fetch,
+        "forward_from_cited_by": growth.forward_from_cited_by,
+        "warnings": warnings,
+    }
+
+
 # ---------------------------------------------------------------------------
 # Comando Click
 # ---------------------------------------------------------------------------
@@ -182,6 +272,18 @@ def run_chain(
     help="Email para el polite pool de OpenAlex.",
 )
 @click.option(
+    "--preview",
+    "preview",
+    is_flag=True,
+    default=False,
+    help=(
+        "Estima el crecimiento potencial SIN fetchear ni modificar el corpus "
+        "(dry-run).  Backward: exacto desde references_id.  Forward: exacto "
+        "si el corpus tiene cited_by_id (requiere enrich previo), si no, "
+        "indica que se necesita fetch."
+    ),
+)
+@click.option(
     "--json",
     "json_output",
     is_flag=True,
@@ -197,11 +299,13 @@ def chain_cmd(
     max_candidates: int | None,
     max_citing_per_paper: int,
     email: str | None,
+    preview: bool,
     json_output: bool,
 ) -> None:
     """Expande el corpus con candidatos rankeados por information scent.
 
-    Tras el chain, el estado del lazo transiciona a FORAGED.
+    Con --preview (dry-run), solo muestra la estimación de crecimiento sin
+    tocar la red ni el corpus.  Sin --preview, transiciona el estado a FORAGED.
     """
     store_path = resolve_library_path(ctx.obj)
     data = run_chain(
@@ -211,6 +315,7 @@ def chain_cmd(
         max_candidates=max_candidates,
         max_citing_per_paper=max_citing_per_paper,
         email=email,
+        preview=preview,
     )
 
     if json_output:
@@ -219,8 +324,18 @@ def chain_cmd(
             ok=True,
             data=data,
             exit_code=0,
+            warnings=data.get("warnings", []),
         )
         emit(envelope)
+    elif preview:
+        emit_human(f"[preview] Dirección: {data['direction']}")
+        emit_human(f"[preview] Candidatos potenciales: {data['estimated_candidates']}")
+        for dir_name, count in data["by_direction"].items():
+            emit_human(f"  {dir_name}: {count}")
+        if data["capped_by_max"]:
+            emit_human(f"  (acotado por --max-candidates={max_candidates})")
+        for warning in data.get("warnings", []):
+            emit_human(f"Aviso: {warning}")
     else:
         emit_human(f"Candidatos encontrados: {data['candidates_found']}")
         emit_human(f"Total en corpus: {data['total_papers']}")

--- a/src/bib2graph/foraging/base.py
+++ b/src/bib2graph/foraging/base.py
@@ -27,10 +27,19 @@ class GrowthPreview(BaseModel):
     fetch (ADR 0008: control de crecimiento).
 
     ``preview()`` opera **solo localmente**, sin red.  El crecimiento
-    backward se estima exactamente desde ``references_id``.  El crecimiento
-    forward no puede estimarse sin fetch, por lo que ``by_direction["forward"]``
-    vale ``0`` cuando ``forward_requires_fetch`` es ``True``; el conteo real
-    solo se conoce al llamar ``chain(direction="forward"/"both")``.
+    backward se estima exactamente desde ``references_id``.
+
+    Para el crecimiento forward hay dos casos:
+
+    - Si el corpus fue enriquecido (``b2g enrich``), los papers tienen
+      ``cited_by_id`` poblado: se calcula el número de IDs únicos aún no
+      presentes en el corpus — estimación local exacta.  En este caso
+      ``forward_requires_fetch`` es ``False`` y ``forward_from_cited_by``
+      es ``True``.
+    - Si ``cited_by_id`` está vacío (corpus recién sembrado, sin enrich),
+      el crecimiento forward no es estimable sin red.  En este caso
+      ``forward_requires_fetch`` es ``True``, ``forward_from_cited_by``
+      es ``False`` y ``by_direction["forward"]`` vale ``0``.
 
     Attributes:
         estimated_new: Estimación total de candidatos nuevos (solo lo que
@@ -40,16 +49,25 @@ class GrowthPreview(BaseModel):
             La entrada ``"forward"`` vale ``0`` cuando el crecimiento forward
             no es estimable sin red.
         direction: Dirección pedida (``backward``/``forward``/``both``).
-        forward_requires_fetch: ``True`` cuando se pidió forward o both —
-            indica que el crecimiento forward es desconocido hasta llamar a
-            ``chain()``.  ``False`` cuando la dirección es solo backward
-            (estimación exacta local).
+        forward_requires_fetch: ``True`` cuando el crecimiento forward no puede
+            estimarse localmente (corpus sin ``cited_by_id`` poblado) y es
+            necesario llamar a ``chain()`` para obtener el conteo real.
+            ``False`` cuando la dirección es solo backward, o cuando
+            ``cited_by_id`` está disponible (estimación local exacta).
+        forward_from_cited_by: ``True`` cuando el crecimiento forward se estimó
+            localmente desde ``cited_by_id`` (corpus enriquecido con
+            ``b2g enrich``).  ``False`` en los demás casos.
+        capped_by_max: ``True`` cuando el resultado está acotado por
+            ``max_candidates``; ``False`` si no se aplicó límite o si el
+            número de candidatos es menor al límite.
     """
 
     estimated_new: int
     by_direction: dict[str, int]
     direction: Direction
     forward_requires_fetch: bool = False
+    forward_from_cited_by: bool = False
+    capped_by_max: bool = False
 
 
 class RankedCandidates(BaseModel):

--- a/src/bib2graph/foraging/forager.py
+++ b/src/bib2graph/foraging/forager.py
@@ -93,6 +93,48 @@ def _extract_seed_ids(corpus_rows: list[dict[str, Any]]) -> list[str]:
     return result
 
 
+def _estimate_forward_from_cited_by_detail(
+    corpus_rows: list[dict[str, Any]],
+) -> tuple[int, bool, int]:
+    """Versión de diagnóstico que devuelve también el total sin cap.
+
+    Args:
+        corpus_rows: Filas del corpus como dicts (``to_pylist()``).
+
+    Returns:
+        Tupla ``(count_capped_placeholder, available, total_uncapped)``
+        donde ``total_uncapped`` es el conteo antes de aplicar cualquier cap.
+        (El cap lo aplica el llamador; aquí siempre devuelve el total completo.)
+    """
+    # ids ya presentes en el corpus
+    corpus_ids: set[str] = set()
+    for row in corpus_rows:
+        id_val = row.get(Col.ID)
+        source_id_val = row.get(Col.SOURCE_ID)
+        if id_val:
+            corpus_ids.add(str(id_val))
+        if source_id_val:
+            corpus_ids.add(str(source_id_val))
+
+    # Recolectar IDs únicos de cited_by_id que no estén ya en el corpus
+    candidate_ids: set[str] = set()
+    has_cited_by_data = False
+    for row in corpus_rows:
+        cited_by = row.get(Col.CITED_BY_ID)
+        if not cited_by or not isinstance(cited_by, list):
+            continue
+        has_cited_by_data = True
+        for cid in cited_by:
+            if cid and isinstance(cid, str) and cid not in corpus_ids:
+                candidate_ids.add(cid)
+
+    if not has_cited_by_data:
+        return 0, False, 0
+
+    total = len(candidate_ids)
+    return total, True, total
+
+
 class Forager:
     """Orquesta el chaining sobre un Source, rankeando candidatos por scent.
 
@@ -165,15 +207,13 @@ class Forager:
         API en ninguna dirección.
 
         - **Backward**: estimación exacta desde ``references_id`` local.
-        - **Forward**: el conteo de citantes no es estimable sin red
-          (``cited_by_id`` está vacío tras el seed inicial).  Sin embargo,
-          se reporta el número de semillas (``is_seed=True``) que se forejarían
-          como estimación del costo de red (~1 request por lote de 50 semillas).
-          Cuando se pide forward o
-          both, ``by_direction["forward"]`` vale ``0`` y
-          ``GrowthPreview.forward_requires_fetch`` es ``True``.  El conteo
-          real de candidatos forward solo se conoce al llamar
-          ``chain(direction="forward"/"both")``, que sí fetchea.
+        - **Forward** (dos casos):
+          - Si el corpus tiene ``cited_by_id`` poblado (pasó por ``b2g enrich``),
+            se cuentan los IDs únicos en ``cited_by_id`` que aún no están en el
+            corpus — estimación local exacta sin red.
+          - Si ``cited_by_id`` está vacío (corpus recién sembrado), el conteo
+            forward no es estimable sin red; ``forward_requires_fetch=True``
+            y ``by_direction["forward"]`` vale ``0``.
 
         NO muta el corpus de entrada.
 
@@ -189,23 +229,35 @@ class Forager:
         rows = corpus.to_arrow().to_pylist()
         by_direction: dict[str, int] = {}
         forward_requires_fetch = False
+        forward_from_cited_by = False
+        capped_by_max = False
 
         if direction in ("backward", "both"):
-            bwd = compute_backward_scent(rows)
-            if self._max_candidates is not None:
-                bwd_ranked = rank_candidates(bwd, max_candidates=self._max_candidates)
-                by_direction["backward"] = len(bwd_ranked)
+            bwd_uncapped = compute_backward_scent(rows)
+            bwd_total = len(bwd_uncapped)
+            if self._max_candidates is not None and bwd_total > self._max_candidates:
+                by_direction["backward"] = self._max_candidates
+                capped_by_max = True
             else:
-                by_direction["backward"] = len(bwd)
+                by_direction["backward"] = bwd_total
 
         if direction in ("forward", "both"):
-            # El crecimiento forward no puede estimarse localmente: cited_by_id
-            # está vacío tras el seed y traerlo requeriría fetch a la red.
-            # Marcamos el campo para que el llamador sepa que debe chain() para
-            # obtener el conteo real.  El número de semillas (is_seed=True)
-            # es la única estimación disponible sin red.
-            by_direction["forward"] = 0
-            forward_requires_fetch = True
+            fwd_total, fwd_local, _ = _estimate_forward_from_cited_by_detail(rows)
+            if fwd_local:
+                # cited_by_id disponible localmente: estimación sin red.
+                if (
+                    self._max_candidates is not None
+                    and fwd_total > self._max_candidates
+                ):
+                    by_direction["forward"] = self._max_candidates
+                    capped_by_max = True
+                else:
+                    by_direction["forward"] = fwd_total
+                forward_from_cited_by = True
+            else:
+                # cited_by_id vacío: el forward requiere fetch.
+                by_direction["forward"] = 0
+                forward_requires_fetch = True
 
         estimated_new = sum(by_direction.values())
         return GrowthPreview(
@@ -213,6 +265,8 @@ class Forager:
             by_direction=by_direction,
             direction=direction,
             forward_requires_fetch=forward_requires_fetch,
+            forward_from_cited_by=forward_from_cited_by,
+            capped_by_max=capped_by_max,
         )
 
     def chain(

--- a/tests/unit/test_chain_preview.py
+++ b/tests/unit/test_chain_preview.py
@@ -1,0 +1,533 @@
+"""Tests TDD — issue #89: preview del crecimiento del chaining (B2).
+
+Verifica que ``b2g chain --preview`` (``run_chain(..., preview=True)``) estima
+el crecimiento potencial del corpus **sin fetchear ni modificar estado**:
+
+- Backward: exacto desde ``references_id`` (refs únicas no presentes en corpus,
+  acotado por max-candidates).
+- Forward: exacto desde ``cited_by_id`` si el corpus fue enriquecido (``b2g
+  enrich``); mensaje accionable si ``cited_by_id`` está vacío.
+- ``--preview`` nunca agrega papers ni transiciona el CycleState.
+
+Los tests del núcleo puro (``Forager.preview``) prueban la estimación desde
+``cited_by_id``; los tests de integración usan un store DuckDB temporal.
+
+Marcador: ``unit`` (DuckDB en tmp_path, sin red real).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pyarrow as pa
+import pytest
+
+from bib2graph.corpus import Corpus
+from bib2graph.foraging.base import GrowthPreview
+from bib2graph.foraging.forager import Forager
+from bib2graph.schemas import CORPUS_SCHEMA
+
+pytestmark = pytest.mark.unit
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _row(
+    id: str,
+    *,
+    source_id: str | None = None,
+    is_seed: bool = True,
+    references_id: list[str] | None = None,
+    cited_by_id: list[str] | None = None,
+    curation_status: str = "candidate",
+) -> dict[str, Any]:
+    """Fila mínima con schema canónico completo."""
+    return {
+        "id": id,
+        "source_id": source_id,
+        "doi": None,
+        "title": f"Paper {id}",
+        "year": 2020,
+        "abstract": None,
+        "source": None,
+        "language": None,
+        "publisher": None,
+        "research_areas": None,
+        "is_seed": is_seed,
+        "curation_status": curation_status,
+        "provenance": None,
+        "authors_raw": None,
+        "authors_id": None,
+        "authors_affiliations": None,
+        "keywords_raw": None,
+        "keywords_id": None,
+        "institutions_raw": None,
+        "institutions_id": None,
+        "references_id": references_id,
+        "references_doi": None,
+        "cited_by_id": cited_by_id,
+    }
+
+
+def _make_corpus(*rows: dict[str, Any]) -> Corpus:
+    table = pa.Table.from_pylist(list(rows), schema=CORPUS_SCHEMA)
+    return Corpus.from_arrow(table)
+
+
+def _seed_store_with_rows(store_path: Path, rows: list[dict[str, Any]]) -> None:
+    """Puebla un store DuckDB con las filas dadas."""
+    from bib2graph.stores.duckdb import DuckDBStore
+
+    table = pa.Table.from_pylist(rows, schema=CORPUS_SCHEMA)
+    corpus = Corpus.from_arrow(table)
+    store = DuckDBStore(store_path)
+    store.persist(corpus)
+    store.close()
+
+
+# ---------------------------------------------------------------------------
+# Tests del núcleo puro: Forager.preview() con cited_by_id
+# ---------------------------------------------------------------------------
+
+
+class TestForagerPreviewForwardDesdeCitedByID:
+    """Forager.preview() estima forward localmente desde cited_by_id (post-enrich)."""
+
+    def test_forward_estima_desde_cited_by_id(self) -> None:
+        """Con cited_by_id poblado, forward preview estima sin red.
+
+        P1 tiene cited_by_id=[CIT_A, CIT_B, CIT_C].
+        Los 3 citantes no están en el corpus → forward = 3.
+        """
+        rows = [
+            _row("P1", source_id="W1", cited_by_id=["CIT_A", "CIT_B", "CIT_C"]),
+        ]
+        corpus = _make_corpus(*rows)
+
+        source = MagicMock()
+        forager = Forager(source, depth=1)
+        preview = forager.preview(corpus, direction="forward")
+
+        assert isinstance(preview, GrowthPreview)
+        assert preview.by_direction["forward"] == 3
+        assert preview.estimated_new == 3
+        assert preview.forward_from_cited_by is True
+        assert preview.forward_requires_fetch is False
+
+    def test_forward_excluye_ids_ya_en_corpus(self) -> None:
+        """cited_by_id que ya están en el corpus no cuentan como candidatos nuevos.
+
+        P1.cited_by_id = [P2, CIT_X].
+        P2 ya está en el corpus → solo CIT_X es nuevo → forward = 1.
+        """
+        rows = [
+            _row("P1", source_id="W1", cited_by_id=["P2", "CIT_X"]),
+            _row("P2", source_id="W2"),
+        ]
+        corpus = _make_corpus(*rows)
+
+        source = MagicMock()
+        forager = Forager(source, depth=1)
+        preview = forager.preview(corpus, direction="forward")
+
+        assert preview.by_direction["forward"] == 1
+        assert preview.forward_from_cited_by is True
+
+    def test_forward_excluye_source_ids_ya_en_corpus(self) -> None:
+        """cited_by_id que coinciden con source_id del corpus se excluyen."""
+        rows = [
+            # P1 tiene source_id=W1; su cited_by_id incluye W1 (ya en corpus)
+            _row("P1", source_id="W1", cited_by_id=["W1", "CIT_Y"]),
+        ]
+        corpus = _make_corpus(*rows)
+
+        source = MagicMock()
+        forager = Forager(source, depth=1)
+        preview = forager.preview(corpus, direction="forward")
+
+        # W1 ya está (source_id de P1); solo CIT_Y es nuevo
+        assert preview.by_direction["forward"] == 1
+
+    def test_forward_sin_cited_by_id_requiere_fetch(self) -> None:
+        """Sin cited_by_id, forward preview marca forward_requires_fetch=True."""
+        rows = [
+            _row("P1", source_id="W1", cited_by_id=None),
+        ]
+        corpus = _make_corpus(*rows)
+
+        source = MagicMock()
+        forager = Forager(source, depth=1)
+        preview = forager.preview(corpus, direction="forward")
+
+        assert preview.forward_requires_fetch is True
+        assert preview.forward_from_cited_by is False
+        assert preview.by_direction["forward"] == 0
+        assert preview.estimated_new == 0
+
+    def test_both_backward_y_forward_desde_datos_locales(self) -> None:
+        """direction='both' combina backward (references_id) y forward (cited_by_id).
+
+        P1: references_id=[REF_A, REF_B], cited_by_id=[CIT_X].
+        backward = 2 (REF_A, REF_B), forward = 1 (CIT_X) → total = 3.
+        """
+        rows = [
+            _row(
+                "P1",
+                source_id="W1",
+                references_id=["REF_A", "REF_B"],
+                cited_by_id=["CIT_X"],
+            ),
+        ]
+        corpus = _make_corpus(*rows)
+
+        source = MagicMock()
+        forager = Forager(source, depth=1)
+        preview = forager.preview(corpus, direction="both")
+
+        assert preview.by_direction["backward"] == 2
+        assert preview.by_direction["forward"] == 1
+        assert preview.estimated_new == 3
+        assert preview.forward_from_cited_by is True
+        assert preview.forward_requires_fetch is False
+
+    def test_max_candidates_acota_backward(self) -> None:
+        """max_candidates acota el conteo backward en el preview."""
+        rows = [
+            _row("P1", references_id=["REF_A", "REF_B", "REF_C"]),
+        ]
+        corpus = _make_corpus(*rows)
+
+        source = MagicMock()
+        forager = Forager(source, depth=1, max_candidates=2)
+        preview = forager.preview(corpus, direction="backward")
+
+        assert preview.by_direction["backward"] == 2
+        assert preview.capped_by_max is True
+
+    def test_max_candidates_acota_forward_desde_cited_by_id(self) -> None:
+        """max_candidates acota el conteo forward cuando viene de cited_by_id."""
+        rows = [
+            _row(
+                "P1",
+                source_id="W1",
+                cited_by_id=["CIT_A", "CIT_B", "CIT_C", "CIT_D"],
+            ),
+        ]
+        corpus = _make_corpus(*rows)
+
+        source = MagicMock()
+        forager = Forager(source, depth=1, max_candidates=2)
+        preview = forager.preview(corpus, direction="forward")
+
+        assert preview.by_direction["forward"] == 2
+        assert preview.capped_by_max is True
+
+    def test_max_candidates_no_acota_si_hay_menos_candidatos(self) -> None:
+        """capped_by_max=False cuando hay menos candidatos que el límite."""
+        rows = [
+            _row("P1", source_id="W1", cited_by_id=["CIT_A"]),
+        ]
+        corpus = _make_corpus(*rows)
+
+        source = MagicMock()
+        forager = Forager(source, depth=1, max_candidates=10)
+        preview = forager.preview(corpus, direction="forward")
+
+        assert preview.by_direction["forward"] == 1
+        assert preview.capped_by_max is False
+
+    def test_preview_no_llama_al_source(self) -> None:
+        """preview() no debe llamar a ningún método del source."""
+        calls: list[str] = []
+
+        class SpySource:
+            def fetch_citing_batch(
+                self, ids: list[str], *, max_per_paper: int | None = None
+            ) -> dict[str, list[str]]:
+                calls.append("fetch_citing_batch")
+                raise AssertionError("preview() no debe llamar al source")
+
+            def fetch_citing(self, oa_id: str) -> list[dict[str, Any]]:
+                calls.append("fetch_citing")
+                raise AssertionError("preview() no debe llamar al source")
+
+        rows = [
+            _row("P1", source_id="W1", cited_by_id=["CIT_X"], references_id=["REF_A"]),
+        ]
+        corpus = _make_corpus(*rows)
+        forager = Forager(SpySource(), depth=1)  # type: ignore[arg-type]
+        forager.preview(corpus, direction="both")
+
+        assert calls == [], f"El source fue llamado: {calls}"
+
+    def test_preview_no_muta_corpus(self) -> None:
+        """preview() no modifica el corpus de entrada."""
+        rows = [
+            _row("P1", source_id="W1", cited_by_id=["CIT_X"], references_id=["REF_A"]),
+        ]
+        corpus = _make_corpus(*rows)
+        n_original = len(corpus)
+
+        source = MagicMock()
+        forager = Forager(source, depth=1)
+        forager.preview(corpus, direction="both")
+
+        assert len(corpus) == n_original, "preview() no debe agregar filas al corpus"
+
+    def test_unique_ids_de_multiples_papers(self) -> None:
+        """IDs repetidos en cited_by_id de varios papers se cuentan una sola vez."""
+        rows = [
+            _row("P1", source_id="W1", cited_by_id=["CIT_A", "CIT_B"]),
+            _row("P2", source_id="W2", cited_by_id=["CIT_B", "CIT_C"]),
+        ]
+        corpus = _make_corpus(*rows)
+
+        source = MagicMock()
+        forager = Forager(source, depth=1)
+        preview = forager.preview(corpus, direction="forward")
+
+        # CIT_B aparece en los dos; solo se cuenta una vez → total 3 únicos
+        assert preview.by_direction["forward"] == 3
+        assert preview.forward_from_cited_by is True
+
+
+# ---------------------------------------------------------------------------
+# Tests de run_chain con preview=True (integración con DuckDB)
+# ---------------------------------------------------------------------------
+
+
+class TestRunChainPreview:
+    """``run_chain(..., preview=True)`` estimación sin fetch ni transición de estado."""
+
+    def test_backward_preview_estima_correctamente(self, tmp_path: Path) -> None:
+        """run_chain(preview=True, direction='backward') estima desde references_id.
+
+        2 refs únicas no presentes en corpus → estimated_candidates=2.
+        No agrega papers, no transiciona estado.
+        """
+        from bib2graph.cli.commands.chain import run_chain
+        from bib2graph.stores.duckdb import DuckDBStore
+
+        store_path = tmp_path / "lib.duckdb"
+        _seed_store_with_rows(
+            store_path,
+            [
+                _row("P1", references_id=["REF_A", "REF_B"]),
+                _row("P2", references_id=["REF_A"]),
+            ],
+        )
+
+        # Registrar estado inicial (puede ser None si se creó con persist raw)
+        store = DuckDBStore(store_path)
+        state_before = store.backend.loop_state()
+        store.close()
+
+        result = run_chain(
+            store_path,
+            direction="backward",
+            preview=True,
+        )
+
+        assert result["preview"] is True
+        assert result["estimated_candidates"] == 2
+        assert result["by_direction"]["backward"] == 2
+        assert result["forward_requires_fetch"] is False  # backward only
+
+        # El estado no debe haber cambiado
+        store = DuckDBStore(store_path)
+        state_after = store.backend.loop_state()
+        n_papers_after = len(store.load())
+        store.close()
+
+        assert state_after == state_before, (
+            f"preview no debe cambiar el estado; antes={state_before!r}, "
+            f"después={state_after!r}"
+        )
+        assert n_papers_after == 2, "preview no debe agregar papers"
+
+    def test_forward_preview_desde_cited_by_id(self, tmp_path: Path) -> None:
+        """run_chain(preview=True, direction='forward') usa cited_by_id local.
+
+        P1.cited_by_id=[CIT_X] → estimated_candidates=1, sin red.
+        """
+        from bib2graph.cli.commands.chain import run_chain
+        from bib2graph.stores.duckdb import DuckDBStore
+
+        store_path = tmp_path / "lib.duckdb"
+        _seed_store_with_rows(
+            store_path,
+            [_row("P1", source_id="W1", cited_by_id=["CIT_X"])],
+        )
+
+        # Estado inicial
+        store = DuckDBStore(store_path)
+        state_before = store.backend.loop_state()
+        store.close()
+
+        result = run_chain(
+            store_path,
+            direction="forward",
+            preview=True,
+        )
+
+        assert result["preview"] is True
+        assert result["forward_from_cited_by"] is True
+        assert result["forward_requires_fetch"] is False
+        assert result["by_direction"]["forward"] == 1
+        assert result["estimated_candidates"] == 1
+
+        # Estado inalterado
+        store = DuckDBStore(store_path)
+        state_after = store.backend.loop_state()
+        store.close()
+        assert state_after == state_before, (
+            f"preview no debe cambiar el estado; antes={state_before!r}, "
+            f"después={state_after!r}"
+        )
+
+    def test_forward_sin_cited_by_id_da_aviso_accionable(self, tmp_path: Path) -> None:
+        """run_chain(preview=True, direction='forward') sin cited_by_id → aviso.
+
+        Si el corpus no tiene cited_by_id (no pasó por enrich), el preview
+        debe indicar que se requiere fetch e incluir un mensaje accionable.
+        """
+        from bib2graph.cli.commands.chain import run_chain
+
+        store_path = tmp_path / "lib.duckdb"
+        _seed_store_with_rows(
+            store_path,
+            [_row("P1", source_id="W1", cited_by_id=None)],
+        )
+
+        result = run_chain(
+            store_path,
+            direction="forward",
+            preview=True,
+        )
+
+        assert result["preview"] is True
+        assert result["forward_requires_fetch"] is True
+        assert result["by_direction"]["forward"] == 0
+        assert result["estimated_candidates"] == 0
+        # Debe haber un aviso accionable
+        warnings = result.get("warnings", [])
+        assert len(warnings) >= 1
+        # El aviso debe mencionar enrich o cited_by_id
+        combined = " ".join(warnings).lower()
+        assert "enrich" in combined or "cited_by_id" in combined
+
+    def test_preview_no_transiciona_estado(self, tmp_path: Path) -> None:
+        """preview nunca transiciona el CycleState aunque se llame varias veces."""
+        from bib2graph.cli.commands.chain import run_chain
+        from bib2graph.stores.duckdb import DuckDBStore
+
+        store_path = tmp_path / "lib.duckdb"
+        _seed_store_with_rows(
+            store_path,
+            [
+                _row(
+                    "P1",
+                    references_id=["REF_A"],
+                    cited_by_id=["CIT_X"],
+                )
+            ],
+        )
+
+        # Registrar estado inicial
+        store = DuckDBStore(store_path)
+        state_before = store.backend.loop_state()
+        store.close()
+
+        # Llamar preview varias veces
+        for _ in range(3):
+            run_chain(store_path, direction="both", preview=True)
+
+        store = DuckDBStore(store_path)
+        state_after = store.backend.loop_state()
+        n_papers = len(store.load())
+        store.close()
+
+        assert state_after == state_before, (
+            f"preview no debe cambiar el estado; antes={state_before!r}, "
+            f"después={state_after!r}"
+        )
+        assert n_papers == 1, "preview no debe agregar papers al corpus"
+
+    def test_preview_max_candidates_acota_estimado(self, tmp_path: Path) -> None:
+        """max_candidates acota la estimación del preview.
+
+        3 referencias nuevas, max_candidates=2 → estimated=2, capped_by_max=True.
+        """
+        from bib2graph.cli.commands.chain import run_chain
+
+        store_path = tmp_path / "lib.duckdb"
+        _seed_store_with_rows(
+            store_path,
+            [_row("P1", references_id=["REF_A", "REF_B", "REF_C"])],
+        )
+
+        result = run_chain(
+            store_path,
+            direction="backward",
+            max_candidates=2,
+            preview=True,
+        )
+
+        assert result["estimated_candidates"] == 2
+        assert result["capped_by_max"] is True
+
+    def test_envelope_preview_tiene_claves_estables(self, tmp_path: Path) -> None:
+        """El dict de preview tiene todas las claves del contrato."""
+        from bib2graph.cli.commands.chain import run_chain
+
+        store_path = tmp_path / "lib.duckdb"
+        _seed_store_with_rows(
+            store_path,
+            [_row("P1", references_id=["REF_A"])],
+        )
+
+        result = run_chain(store_path, direction="backward", preview=True)
+
+        expected_keys = {
+            "preview",
+            "direction",
+            "estimated_candidates",
+            "by_direction",
+            "capped_by_max",
+            "forward_requires_fetch",
+            "forward_from_cited_by",
+            "warnings",
+        }
+        assert expected_keys.issubset(result.keys()), (
+            f"Faltan claves en el resultado: {expected_keys - result.keys()}"
+        )
+
+    def test_both_con_references_y_cited_by(self, tmp_path: Path) -> None:
+        """direction='both' combina backward (references_id) + forward (cited_by_id)."""
+        from bib2graph.cli.commands.chain import run_chain
+
+        store_path = tmp_path / "lib.duckdb"
+        _seed_store_with_rows(
+            store_path,
+            [
+                _row(
+                    "P1",
+                    source_id="W1",
+                    references_id=["REF_A", "REF_B"],
+                    cited_by_id=["CIT_X"],
+                )
+            ],
+        )
+
+        result = run_chain(store_path, direction="both", preview=True)
+
+        assert result["preview"] is True
+        assert result["by_direction"]["backward"] == 2
+        assert result["by_direction"]["forward"] == 1
+        assert result["estimated_candidates"] == 3
+        assert result["forward_from_cited_by"] is True
+        assert result["forward_requires_fetch"] is False


### PR DESCRIPTION
Cierra **#89** (historia B2). Nuevo flag `b2g chain --preview` (dry-run): estima cuánto crecería el corpus **sin pegarle a la red**, para decidir antes del fetch caro.

- **backward:** refs únicas (`references_id`) aún no en el corpus.
- **forward:** citantes únicos (`cited_by_id`) post-`enrich`; si no hay `cited_by`, avisa accionable (correr `enrich` primero), `forward_requires_fetch=true`.
- Acota por `--max-candidates` (`capped_by_max`); **NO** agrega papers ni transiciona estado.

`GrowthPreview` gana `forward_from_cited_by` + `capped_by_max`. Envelope `--json` con `estimated_candidates`/`by_direction`. 18 tests (núcleo puro + integración duckdb). Gate verde **con extras** (827 passed).

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)