### PR TITLE
ci(release): deshabilitar attestations en publish-pypi (camino reusable)

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -59,3 +59,14 @@ jobs:
       - name: Publish to PyPI (trusted publishing)
         # Sin repository-url → la action publica a PyPI productivo (https://upload.pypi.org/legacy/).
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          # attestations OFF: cuando este workflow se invoca como REUSABLE desde
+          # release-please.yml, el certificado de la attestation (PEP 740) registra el
+          # workflow top-level (release-please.yml), no este archivo. El Trusted Publisher
+          # de PyPI espera publish-pypi.yml → PyPI rechaza el upload con 400 ("Build Config
+          # URI does not match expected Trusted Publisher"). PyPA no soporta reusable
+          # workflows con Trusted Publishing. El OIDC del token sí matchea (job_workflow_ref
+          # = publish-pypi.yml), así que deshabilitar la attestation desbloquea el publish
+          # sin perder el trusted publishing. El disparo MANUAL (workflow_dispatch) no sufre
+          # esto (corre directo, no reusable), pero mantenemos el flag por consistencia.
+          attestations: false


### PR DESCRIPTION
## Qué

Agrega `attestations: false` al step `Publish to PyPI` en `.github/workflows/publish-pypi.yml`.

## Por qué

El **publish automático de v0.9.0 falló**. El job `publish` corre como **reusable workflow** invocado desde `release-please.yml`. La attestation (PEP 740) registra en su certificado el workflow *top-level* (`release-please.yml`), pero el Trusted Publisher de PyPI espera `publish-pypi.yml`, así que PyPI rechaza el upload:

```
400 Bad Request — Invalid attestations supplied during upload:
Certificate's Build Config URI (...release-please.yml@refs/heads/main)
does not match expected Trusted Publisher (publish-pypi.yml @ complexluise/bib2graph)
```

PyPA [no soporta reusable workflows con Trusted Publishing](https://docs.pypi.org/trusted-publishers/troubleshooting/#reusable-workflows-on-github). El **OIDC del token sí matchea** (`job_workflow_ref = publish-pypi.yml`); lo único que falla es la verificación de la attestation. Con `attestations: false` el publish automático post-release funciona **sin perder el trusted publishing por OIDC**.

> v0.9.0 se publicó a mano vía `workflow_dispatch` (que corre directo, no reusable, y por eso no sufre el problema). Este PR arregla el camino **automático** para los próximos releases.

## Alcance

- Solo `.github/workflows/publish-pypi.yml`. Sin cambios de código ni de dependencias.
- No aborda el fallo de **back-merge main→dev** (`GH006`, push a `dev` protegido) — eso necesita el secret `RELEASE_PLEASE_TOKEN` y va aparte.

## DoD

- [ ] El próximo release auto-publica a PyPI sin el 400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)