### PR TITLE
feat(cli): status como mapa — next_best_action + readiness + preview por-red (ADR 0037 §e, Fase 1A)

### DIFF
--- a/src/bib2graph/cli/commands/status.py
+++ b/src/bib2graph/cli/commands/status.py
@@ -27,7 +27,8 @@ import click
 from bib2graph.cli._envelope import build_envelope, emit, emit_human
 from bib2graph.cli._errors import handle_errors
 from bib2graph.cli._store import open_store_readonly, resolve_workspace
-from bib2graph.cycle import CURATION_ACTIONS, available_transitions
+from bib2graph.cycle import CURATION_ACTIONS, available_transitions, next_best_action
+from bib2graph.networks.facade import predict_build_preview
 
 # ---------------------------------------------------------------------------
 # Función núcleo (testeable, sin Click)
@@ -48,12 +49,20 @@ def run_status(store_path: str | Path) -> dict[str, Any]:
       campo no existía y ``transitions_available`` nunca los listaba (bug).
     - ``round``: contador de ronda (0 = sin estado; 1 = primera ronda; 2+ = re-sembrados).
 
+    ADR 0037 §(e) — campos aditivos (schema="1" intacto):
+    - ``next_best_action``: único próximo comando recomendado (derivado del FSM).
+    - ``readiness``: si el próximo paso va a dar fruto (preparación, no solo
+      alcanzabilidad FSM).
+    - ``build_preview``: por cada red proyectable, predice vacío/no-vacío ANTES
+      de correr build (diagnóstico de red-vacía en status-time).
+
     Args:
         store_path: Ruta al archivo ``.duckdb``.
 
     Returns:
         Dict con ``loop_state``, ``transitions_available``, ``curation_available``,
-        ``round``, ``counts_by_status``, ``total_papers``.
+        ``round``, ``counts_by_status``, ``total_papers``, ``next_best_action``,
+        ``readiness``, ``build_preview``.
 
     Raises:
         StoreError: Si el store está bloqueado.
@@ -91,6 +100,59 @@ def run_status(store_path: str | Path) -> dict[str, Any]:
     # El campo es aditivo (schema="1" intacto; campos nuevos no rompen agentes).
     referenced_not_fetched = store.backend.referenced_refs_count()
 
+    # ADR 0037 §(e) — campos aditivos: next_best_action, readiness, build_preview.
+    # Cargar el corpus para los conteos de columnas (predicados compartidos con
+    # los proyectores → fuente única preview ↔ build).
+    corpus = store.load()
+
+    # next_best_action: derivado puramente del FSM (cycle.py).
+    action = next_best_action(loop_state)
+
+    # build_preview: predice vacío/no-vacío por red sin proyectar el grafo.
+    build_prev = predict_build_preview(corpus)
+
+    # readiness: si el próximo paso va a DAR FRUTO (no solo si está permitido).
+    # Caso crítico "build": ready si al menos 1 red no sería vacía.
+    # Caso "chain": ready si al menos 1 seed tiene source_id (necesario para
+    #   el forrajeo en OpenAlex).  BibTeX sin --resolve → source_id=None en
+    #   todos los seeds → chaining produce 0 papers nuevos (Nota 20, ADR 0037).
+    if action == "build":
+        all_empty = all(bool(item["would_be_empty"]) for item in build_prev)
+        if all_empty:
+            readiness: dict[str, Any] = {
+                "ready": False,
+                "reason": (
+                    "Todas las redes proyectables saldrían vacías. "
+                    "Revisá build_preview.fix_command para cada red."
+                ),
+            }
+        else:
+            readiness = {"ready": True, "reason": None}
+    elif action == "chain":
+        from bib2graph.constants import Col
+
+        table_for_chain = corpus.to_arrow()
+        rows_for_chain = table_for_chain.to_pylist()
+        total_seeds_count = sum(1 for r in rows_for_chain if r.get(Col.IS_SEED))
+        n_seeds_with_source = sum(
+            1
+            for r in rows_for_chain
+            if r.get(Col.IS_SEED) and r.get(Col.SOURCE_ID) is not None
+        )
+        if total_seeds_count > 0 and n_seeds_with_source == 0:
+            readiness = {
+                "ready": False,
+                "reason": (
+                    f"0/{total_seeds_count} seeds tienen source_id: "
+                    "ejecutá 'b2g seed --resolve' para obtener IDs de OpenAlex "
+                    "necesarios para el forrajeo."
+                ),
+            }
+        else:
+            readiness = {"ready": True, "reason": None}
+    else:
+        readiness = {"ready": True, "reason": None}
+
     return {
         "loop_state": state_str,
         "transitions_available": transitions,
@@ -99,6 +161,9 @@ def run_status(store_path: str | Path) -> dict[str, Any]:
         "counts_by_status": counts,
         "total_papers": total,
         "referenced_not_fetched": referenced_not_fetched,
+        "next_best_action": action,
+        "readiness": readiness,
+        "build_preview": build_prev,
     }
 
 
@@ -194,5 +259,21 @@ def status_cmd(
         ref_count = data.get("referenced_not_fetched", 0)
         if ref_count > 0:
             emit_human(f"Referenciados sin materializar: {ref_count}")
+        # ADR 0037 §(e) — campos aditivos
+        emit_human(f"Próximo mejor paso: b2g {data['next_best_action']}")
+        readiness = data["readiness"]
+        ready_str = (
+            "listo" if readiness["ready"] else f"NO listo — {readiness['reason']}"
+        )
+        emit_human(f"Preparación: {ready_str}")
+        build_preview = data.get("build_preview", [])
+        if build_preview:
+            emit_human("Preview de redes (si corrieras build ahora):")
+            for entry in build_preview:
+                status_icon = "vacía" if entry["would_be_empty"] else "ok"
+                line = f"  [{status_icon}] {entry['kind']}"
+                if entry["would_be_empty"] and entry["reason"]:
+                    line += f" — {entry['reason']} → {entry['fix_command']}"
+                emit_human(line)
         for w in warnings:
             print(f"AVISO: {w}", file=sys.stderr)

--- a/src/bib2graph/cycle.py
+++ b/src/bib2graph/cycle.py
@@ -221,3 +221,43 @@ def available_transitions(state: CycleState | None) -> list[str]:
         Lista de nombres de acciones disponibles desde el estado dado.
     """
     return list(_AVAILABLE_TRANSITIONS.get(state, ["seed"]))
+
+
+# ---------------------------------------------------------------------------
+# next_best_action — ADR 0037 §(e)
+# ---------------------------------------------------------------------------
+
+# Mapa determinista estado → único próximo comando recomendado.
+# Refleja el camino canónico del ciclo de investigación (Nota 05 §3):
+# init → seed → chain → build → read → (monitorear → chain).
+_NEXT_BEST_ACTION: dict[CycleState | None, str] = {
+    None: "seed",
+    CycleState.SEEDED: "chain",
+    CycleState.FORAGED: "build",
+    CycleState.FILTERED: "build",
+    CycleState.BUILT: "read",
+    CycleState.MONITORED: "chain",
+}
+
+
+def next_best_action(state: CycleState | None) -> str:
+    """Devuelve el único próximo comando recomendado desde el estado del FSM.
+
+    Derivado de forma determinista del FSM (ADR 0037 §(e)).  El agente lee
+    este campo para saber qué hacer sin adivinar ni recorrer
+    ``transitions_available``.
+
+    Mapeo canónico:
+    - ``None`` (sin estado) → ``"seed"``
+    - ``SEEDED`` → ``"chain"``
+    - ``FORAGED`` / ``FILTERED`` → ``"build"``
+    - ``BUILT`` → ``"read"``
+    - ``MONITORED`` → ``"chain"`` (ciclo de monitoreo)
+
+    Args:
+        state: Estado actual del lazo (``None`` = sin estado previo).
+
+    Returns:
+        Nombre del próximo comando recomendado (string simple, sin ``b2g``).
+    """
+    return _NEXT_BEST_ACTION.get(state, "seed")

--- a/src/bib2graph/networks/__init__.py
+++ b/src/bib2graph/networks/__init__.py
@@ -23,7 +23,7 @@ from bib2graph.networks.analyzer import (
 )
 from bib2graph.networks.clusters import cluster_table
 from bib2graph.networks.decorate import decorate, decorate_graph
-from bib2graph.networks.facade import Networks
+from bib2graph.networks.facade import Networks, predict_build_preview
 from bib2graph.networks.projectors import (
     MIN_WEIGHT_DEFAULT,
     AuthorCollaborationProjector,
@@ -57,4 +57,5 @@ __all__ = [
     "detect_communities",
     "load_specs",
     "network_metrics",
+    "predict_build_preview",
 ]

--- a/src/bib2graph/networks/facade.py
+++ b/src/bib2graph/networks/facade.py
@@ -19,7 +19,7 @@ from typing import TYPE_CHECKING, Any
 import networkx as nx
 import pyarrow as pa
 
-from bib2graph.constants import NetworkKind
+from bib2graph.constants import Col, NetworkKind
 from bib2graph.networks.analyzer import (
     assortativity,
     community_composition,
@@ -319,6 +319,285 @@ def _build_artifact(corpus: Corpus, spec: NetworkSpec) -> NetworkArtifact:
             artifact.assortativity = assort_result
 
     return artifact
+
+
+# ---------------------------------------------------------------------------
+# Helpers de predicados para predict_build_preview (misma lógica que los
+# proyectores — fuente única preview ↔ build, ADR 0037 §(e))
+# ---------------------------------------------------------------------------
+
+
+def _count_rows_with_col(
+    rows: list[dict[str, object]],
+    col: str,
+    *,
+    seeds_only: bool = False,
+) -> int:
+    """Cuenta filas donde la columna lista tiene al menos 1 elemento no-None.
+
+    Usado SOLO para texto de reason ("N/M papers con col"), no para el
+    predicado de vaciedad.  Ver ``_has_shared_item`` y
+    ``_has_paper_with_multi_distinct`` para los predicados correctos.
+
+    Args:
+        rows: Filas del corpus como dicts (salida de ``table.to_pylist()``).
+        col: Nombre de la columna de tipo lista.
+        seeds_only: Si ``True``, solo cuenta filas donde ``is_seed == True``.
+
+    Returns:
+        Número de filas con al menos 1 elemento no-None en la columna dada.
+    """
+    count = 0
+    for row in rows:
+        if seeds_only and not row.get(Col.IS_SEED):
+            continue
+        val = row.get(col)
+        if isinstance(val, list) and any(e is not None for e in val):
+            count += 1
+    return count
+
+
+def _has_shared_item(
+    rows: list[dict[str, object]],
+    col: str,
+    *,
+    seeds_only: bool = False,
+) -> bool:
+    """True sii algún item en ``col`` aparece en ≥2 papers distintos.
+
+    Espeja ``collect_item_to_papers`` + ``_build_shared_refs_graph``
+    (projectors.py): una arista entre P1 y P2 existe sii comparten algún
+    ítem.  El mínimo para ≥1 arista es que algún ítem sea compartido por ≥2
+    papers distintos.
+
+    Necesario y suficiente para grafos de tipo shared-refs: dos papers con
+    referencias disjuntas producen 0 aristas, aunque cada uno tenga muchas
+    referencias (caso trampa de la Nota 20).
+
+    Args:
+        rows: Filas del corpus como dicts (salida de ``table.to_pylist()``).
+        col: Columna de tipo lista (``references_id``, ``cited_by_id``).
+        seeds_only: Si ``True``, solo considera filas ``is_seed == True``
+            (para co-citación con scope ``seeds_only``).
+
+    Returns:
+        ``True`` si algún ítem aparece en ≥2 papers distintos.
+    """
+    # item → conjunto de paper_ids que lo contienen (dedup por paper)
+    item_papers: dict[str, set[str]] = {}
+    for row in rows:
+        if seeds_only and not row.get(Col.IS_SEED):
+            continue
+        val = row.get(col)
+        if not isinstance(val, list):
+            continue
+        paper_id = str(row.get(Col.ID) or "")
+        for item in val:
+            if item is not None:
+                key = str(item)
+                if key not in item_papers:
+                    item_papers[key] = set()
+                item_papers[key].add(paper_id)
+    return any(len(papers) >= 2 for papers in item_papers.values())
+
+
+def _has_paper_with_multi_distinct(
+    rows: list[dict[str, object]],
+    col: str,
+) -> bool:
+    """True sii algún paper tiene ≥2 entidades DISTINTAS no-None en ``col``.
+
+    Espeja exactamente ``_build_cooccurrence_graph`` (projectors.py): el
+    criterio es ``sorted(set(str(e) for e in entities if e is not None))``,
+    luego ``combinations(unique_entities, 2)`` → ≥1 par sii ≥2 distintas.
+
+    Corrige el bug de la Nota 20 P1: ``[A1, A1]`` (autor duplicado) tiene
+    2 elementos pero tras dedup solo 1 distinto → la red sale vacía aunque
+    ``len(val) >= 2``.  Esta función usa ``set`` para el dedup, igual que el
+    proyector.
+
+    Args:
+        rows: Filas del corpus como dicts (salida de ``table.to_pylist()``).
+        col: Columna de tipo lista (``authors_id``, ``institutions_id``,
+            ``keywords_id``).
+
+    Returns:
+        ``True`` si algún paper tiene ≥2 entidades distintas no-None.
+    """
+    for row in rows:
+        val = row.get(col)
+        if not isinstance(val, list):
+            continue
+        distinct = {str(e) for e in val if e is not None}
+        if len(distinct) >= 2:
+            return True
+    return False
+
+
+def predict_build_preview(corpus: Corpus) -> list[dict[str, object]]:
+    """Predice vacío/no-vacío para cada red posible sin proyectarlas.
+
+    Fuente única con ``Networks.quick``: reusa los mismos predicados de columna
+    que los proyectores para decidir la inclusión de papers.  El conteo es
+    barato (no proyecta ningún grafo).
+
+    Incluye siempre las 5 redes posibles (incluida co-citación incluso si
+    ``cited_by_id`` está vacío), para que el diagnóstico sea completo:
+    el agente/humano ve qué falta para activar cada tipo de red ANTES del
+    ``build`` (ADR 0037 §(e), cura de la trampa de la Nota 20).
+
+    Args:
+        corpus: Corpus a inspeccionar.
+
+    Returns:
+        Lista de dicts, uno por tipo de red, con:
+
+        - ``kind``: tipo de red (string de ``NetworkKind``).
+        - ``would_be_empty``: ``True`` si la red saldría vacía.
+        - ``reason``: causa determinista si saldría vacía, ``None`` si no.
+        - ``fix_command``: comando exacto para arreglarlo, ``None`` si no vacía.
+    """
+    table = corpus.to_arrow()
+    rows: list[dict[str, object]] = table.to_pylist()
+    total = len(rows)
+    total_seeds = sum(1 for r in rows if r.get(Col.IS_SEED))
+
+    preview: list[dict[str, object]] = []
+
+    # --- bibliographic_coupling: references_id, scope=full ---
+    # No-vacía sii algún references_id aparece en ≥2 papers distintos.
+    # (dos papers con refs disjuntas producen 0 aristas → caso trampa Nota 20)
+    n_refs_any = _count_rows_with_col(rows, Col.REFERENCES_ID)
+    bc_empty = not _has_shared_item(rows, Col.REFERENCES_ID)
+    if bc_empty:
+        if n_refs_any == 0:
+            bc_reason: str | None = f"0/{total} papers con {Col.REFERENCES_ID}"
+        else:
+            bc_reason = (
+                f"{n_refs_any}/{total} papers con {Col.REFERENCES_ID} "
+                f"pero ninguna referencia aparece en ≥2 papers"
+            )
+    else:
+        bc_reason = None
+    preview.append(
+        {
+            "kind": str(NetworkKind.BIBLIOGRAPHIC_COUPLING),
+            "would_be_empty": bc_empty,
+            "reason": bc_reason,
+            # TODO(0037 1B): reapuntar fix_command al consolidar verbos
+            "fix_command": "b2g seed --resolve" if bc_empty else None,
+        }
+    )
+
+    # --- author_collab: authors_id, scope=full ---
+    # No-vacía sii algún paper tiene ≥2 autores DISTINTOS no-None.
+    # ([A1, A1] → tras dedup 1 único → 0 aristas, aunque len=2)
+    n_authors_any = _count_rows_with_col(rows, Col.AUTHORS_ID)
+    ac_empty = not _has_paper_with_multi_distinct(rows, Col.AUTHORS_ID)
+    if ac_empty:
+        if n_authors_any == 0:
+            ac_reason: str | None = f"0/{total} papers con {Col.AUTHORS_ID}"
+        else:
+            ac_reason = (
+                f"{n_authors_any}/{total} papers con {Col.AUTHORS_ID} "
+                f"pero ninguno con ≥2 autores distintos"
+            )
+    else:
+        ac_reason = None
+    preview.append(
+        {
+            "kind": str(NetworkKind.AUTHOR_COLLAB),
+            "would_be_empty": ac_empty,
+            "reason": ac_reason,
+            # TODO(0037 1B): reapuntar fix_command al consolidar verbos
+            "fix_command": "b2g seed --resolve" if ac_empty else None,
+        }
+    )
+
+    # --- institution_collab: institutions_id, scope=full ---
+    # No-vacía sii algún paper tiene ≥2 instituciones DISTINTAS no-None.
+    n_inst_any = _count_rows_with_col(rows, Col.INSTITUTIONS_ID)
+    ic_empty = not _has_paper_with_multi_distinct(rows, Col.INSTITUTIONS_ID)
+    if ic_empty:
+        if n_inst_any == 0:
+            ic_reason: str | None = f"0/{total} papers con {Col.INSTITUTIONS_ID}"
+        else:
+            ic_reason = (
+                f"{n_inst_any}/{total} papers con {Col.INSTITUTIONS_ID} "
+                f"pero ninguno con ≥2 instituciones distintas"
+            )
+    else:
+        ic_reason = None
+    preview.append(
+        {
+            "kind": str(NetworkKind.INSTITUTION_COLLAB),
+            "would_be_empty": ic_empty,
+            "reason": ic_reason,
+            # TODO(0037 1B): reapuntar fix_command al consolidar verbos
+            "fix_command": "b2g seed --resolve" if ic_empty else None,
+        }
+    )
+
+    # --- keyword_cooccurrence: keywords_id, scope=full ---
+    # No-vacía sii algún paper tiene ≥2 keywords DISTINTAS no-None.
+    # Fix preferencial: si hay keywords_raw pero no keywords_id, thesaurus puede
+    # generar keywords_id sin red; si no hay keywords_raw, se necesita seed --resolve.
+    n_kw_any = _count_rows_with_col(rows, Col.KEYWORDS_ID)
+    n_kw_raw = _count_rows_with_col(rows, Col.KEYWORDS_RAW)
+    kw_empty = not _has_paper_with_multi_distinct(rows, Col.KEYWORDS_ID)
+    if kw_empty:
+        if n_kw_any == 0:
+            kw_reason: str | None = f"0/{total} papers con {Col.KEYWORDS_ID}"
+        else:
+            kw_reason = (
+                f"{n_kw_any}/{total} papers con {Col.KEYWORDS_ID} "
+                f"pero ninguno con ≥2 keywords distintas"
+            )
+        # Si hay keywords_raw pero no keywords_id, el thesaurus puede generarlos
+        # TODO(0037 1B): reapuntar fix_command al consolidar verbos
+        kw_fix: str | None = (
+            "b2g thesaurus" if n_kw_raw > 0 and n_kw_any == 0 else "b2g seed --resolve"
+        )
+    else:
+        kw_reason = None
+        kw_fix = None
+    preview.append(
+        {
+            "kind": str(NetworkKind.KEYWORD_COOCCURRENCE),
+            "would_be_empty": kw_empty,
+            "reason": kw_reason,
+            "fix_command": kw_fix,
+        }
+    )
+
+    # --- cocitation: cited_by_id, scope=seeds_only ---
+    # No-vacía sii algún cited_by_id aparece en ≥2 seeds distintas.
+    # (dos seeds con citantes disjuntos producen 0 aristas)
+    n_cited_any = _count_rows_with_col(rows, Col.CITED_BY_ID, seeds_only=True)
+    coc_empty = not _has_shared_item(rows, Col.CITED_BY_ID, seeds_only=True)
+    if coc_empty:
+        if n_cited_any == 0:
+            coc_reason: str | None = (
+                f"{n_cited_any}/{total_seeds} seeds con {Col.CITED_BY_ID}"
+            )
+        else:
+            coc_reason = (
+                f"{n_cited_any}/{total_seeds} seeds con {Col.CITED_BY_ID} "
+                f"pero ningún citante aparece en ≥2 seeds"
+            )
+    else:
+        coc_reason = None
+    preview.append(
+        {
+            "kind": str(NetworkKind.COCITATION),
+            "would_be_empty": coc_empty,
+            "reason": coc_reason,
+            # TODO(0037 1B): reapuntar fix_command al consolidar verbos
+            "fix_command": "b2g enrich" if coc_empty else None,
+        }
+    )
+
+    return preview
 
 
 class Networks:

--- a/tests/unit/test_status_10.py
+++ b/tests/unit/test_status_10.py
@@ -1,0 +1,893 @@
+"""Tests TDD — Fase 1A del hito 0.10.0: campos aditivos en ``b2g status --json``.
+
+Cubre los tres nuevos campos del contrato ADR 0037 §(e):
+
+1. ``next_best_action`` — único próximo comando recomendado (derivado del FSM).
+2. ``readiness`` — si el próximo paso va a dar fruto (preparación, no alcanzabilidad).
+3. ``build_preview`` — por cada red, predice vacío/no-vacío ANTES de correr build.
+
+Caso canónico (Nota 20): corpus sembrado desde BibTeX sin ``--resolve`` →
+las redes de citación/colaboración salen vacías; la red de keywords sale no-vacía
+si hay ``keywords_id`` poblados (p. ej. tras ``thesaurus``).
+
+Los campos son ADITIVOS: ``schema="1"`` se preserva, los campos viejos no cambian.
+
+Marcador: ``unit`` (DuckDB en tmp_path, sin red real).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pyarrow as pa
+import pytest
+
+from bib2graph.constants import NetworkKind
+from bib2graph.corpus import Corpus
+from bib2graph.cycle import CycleState, next_best_action
+from bib2graph.networks.facade import predict_build_preview
+from bib2graph.schemas import CORPUS_SCHEMA
+
+pytestmark = pytest.mark.unit
+
+# ---------------------------------------------------------------------------
+# Helpers de fixture
+# ---------------------------------------------------------------------------
+
+
+def _row(
+    id: str,
+    *,
+    is_seed: bool = True,
+    source_id: str | None = None,
+    curation_status: str = "candidate",
+    references_id: list[str] | None = None,
+    cited_by_id: list[str] | None = None,
+    authors_id: list[str] | None = None,
+    institutions_id: list[str] | None = None,
+    keywords_id: list[str] | None = None,
+    keywords_raw: list[str] | None = None,
+) -> dict[str, Any]:
+    """Fila mínima con schema canónico completo."""
+    return {
+        "id": id,
+        "source_id": source_id,
+        "doi": None,
+        "title": f"Paper {id}",
+        "year": 2020,
+        "abstract": None,
+        "source": None,
+        "language": None,
+        "publisher": None,
+        "research_areas": None,
+        "is_seed": is_seed,
+        "curation_status": curation_status,
+        "provenance": None,
+        "authors_raw": None,
+        "authors_id": authors_id,
+        "authors_affiliations": None,
+        "keywords_raw": keywords_raw,
+        "keywords_id": keywords_id,
+        "institutions_raw": None,
+        "institutions_id": institutions_id,
+        "references_id": references_id,
+        "references_doi": None,
+        "cited_by_id": cited_by_id,
+    }
+
+
+def _make_corpus(*rows: dict[str, Any]) -> Corpus:
+    """Construye un Corpus en memoria desde filas dict."""
+    table = pa.Table.from_pylist(list(rows), schema=CORPUS_SCHEMA)
+    return Corpus.from_arrow(table)
+
+
+def _seed_store(store_path: Path, rows: list[dict[str, Any]]) -> None:
+    """Persiste un conjunto de filas en un DuckDB temporal."""
+    from bib2graph.stores.duckdb import DuckDBStore
+
+    table = pa.Table.from_pylist(rows, schema=CORPUS_SCHEMA)
+    corpus = Corpus.from_arrow(table)
+    store = DuckDBStore(store_path)
+    store.persist(corpus)
+    store.close()
+
+
+def _seed_store_with_state(
+    store_path: Path,
+    rows: list[dict[str, Any]],
+    state: CycleState,
+) -> None:
+    """Persiste filas y fija el estado del lazo."""
+    from bib2graph.stores.duckdb import DuckDBStore
+
+    table = pa.Table.from_pylist(rows, schema=CORPUS_SCHEMA)
+    corpus = Corpus.from_arrow(table)
+    store = DuckDBStore(store_path)
+    store.persist(corpus)
+    store.backend.set_loop_state(state, cycle_round=1)
+    store.close()
+
+
+# ---------------------------------------------------------------------------
+# Pruebas unitarias puras: next_best_action (sin store)
+# ---------------------------------------------------------------------------
+
+
+class TestNextBestAction:
+    """Verifica el mapa determinista FSM → comando recomendado."""
+
+    def test_sin_estado_recomienda_seed(self) -> None:
+        assert next_best_action(None) == "seed"
+
+    def test_seeded_recomienda_chain(self) -> None:
+        assert next_best_action(CycleState.SEEDED) == "chain"
+
+    def test_foraged_recomienda_build(self) -> None:
+        assert next_best_action(CycleState.FORAGED) == "build"
+
+    def test_filtered_recomienda_build(self) -> None:
+        assert next_best_action(CycleState.FILTERED) == "build"
+
+    def test_built_recomienda_read(self) -> None:
+        assert next_best_action(CycleState.BUILT) == "read"
+
+    def test_monitored_recomienda_chain(self) -> None:
+        assert next_best_action(CycleState.MONITORED) == "chain"
+
+
+# ---------------------------------------------------------------------------
+# Pruebas unitarias puras: predict_build_preview (sin store, Corpus en memoria)
+# ---------------------------------------------------------------------------
+
+
+class TestPredictBuildPreview:
+    """Verifica predict_build_preview como función pura sobre Corpus."""
+
+    def test_devuelve_cinco_redes(self) -> None:
+        """El preview incluye siempre las 5 redes posibles."""
+        corpus = _make_corpus(_row("P1"))
+        preview = predict_build_preview(corpus)
+        assert len(preview) == 5
+
+    def test_cada_entrada_tiene_campos_requeridos(self) -> None:
+        """Cada entrada tiene kind, would_be_empty, reason, fix_command."""
+        corpus = _make_corpus(_row("P1"))
+        preview = predict_build_preview(corpus)
+        for entry in preview:
+            assert "kind" in entry
+            assert "would_be_empty" in entry
+            assert "reason" in entry
+            assert "fix_command" in entry
+
+    def test_corpus_sin_datos_id_todo_vacio(self) -> None:
+        """Sin ningún _id populado, todas las redes saldrían vacías."""
+        corpus = _make_corpus(
+            _row("P1"),
+            _row("P2"),
+        )
+        preview = predict_build_preview(corpus)
+        assert all(entry["would_be_empty"] for entry in preview), (
+            "Con corpus sin _id cols, todas las redes deben ser vacías"
+        )
+
+    def test_reason_no_nula_cuando_vacia(self) -> None:
+        """Si would_be_empty=True, reason no puede ser None."""
+        corpus = _make_corpus(_row("P1"))
+        preview = predict_build_preview(corpus)
+        for entry in preview:
+            if entry["would_be_empty"]:
+                assert entry["reason"] is not None, (
+                    f"{entry['kind']}: would_be_empty=True pero reason=None"
+                )
+                assert entry["fix_command"] is not None, (
+                    f"{entry['kind']}: would_be_empty=True pero fix_command=None"
+                )
+
+    def test_reason_nula_cuando_no_vacia(self) -> None:
+        """Si would_be_empty=False, reason y fix_command deben ser None."""
+        # Corpus con keywords_id con >= 2 elementos por paper → keyword_cooccurrence no vacía
+        corpus = _make_corpus(
+            _row("P1", keywords_id=["k1", "k2"]),
+            _row("P2", keywords_id=["k1", "k3"]),
+        )
+        preview = predict_build_preview(corpus)
+        kw_entry = next(
+            e for e in preview if e["kind"] == NetworkKind.KEYWORD_COOCCURRENCE
+        )
+        assert kw_entry["would_be_empty"] is False
+        assert kw_entry["reason"] is None
+        assert kw_entry["fix_command"] is None
+
+    # --- Caso canónico: BibTeX sin --resolve ---
+
+    def test_canonical_bibtex_sin_resolve_redes_vacias(self) -> None:
+        """Corpus BibTeX sin --resolve: references_id y cited_by_id vacíos → vacías.
+
+        Este es el caso de la Nota 20: el agente ve el vacío ANTES de build.
+        """
+        # Simula 15 papers de BibTeX sin --resolve:
+        # todos los _id cols están vacíos, solo keywords_raw está poblado.
+        rows = [
+            _row(f"P{i}", keywords_raw=["ecology", "diversity"]) for i in range(1, 16)
+        ]
+        corpus = _make_corpus(*rows)
+        preview = predict_build_preview(corpus)
+
+        # Indexar por kind para verificar cada una
+        by_kind = {str(e["kind"]): e for e in preview}
+
+        # bibliographic_coupling vacía: sin references_id
+        bc = by_kind[NetworkKind.BIBLIOGRAPHIC_COUPLING]
+        assert bc["would_be_empty"] is True
+        assert "references_id" in str(bc["reason"])
+        assert bc["fix_command"] == "b2g seed --resolve"
+
+        # cocitation vacía: sin cited_by_id
+        coc = by_kind[NetworkKind.COCITATION]
+        assert coc["would_be_empty"] is True
+        assert "cited_by_id" in str(coc["reason"])
+        assert coc["fix_command"] == "b2g enrich"
+
+        # author_collab vacía: sin authors_id
+        ac = by_kind[NetworkKind.AUTHOR_COLLAB]
+        assert ac["would_be_empty"] is True
+        assert "authors_id" in str(ac["reason"])
+        assert ac["fix_command"] == "b2g seed --resolve"
+
+        # institution_collab vacía: sin institutions_id
+        ic = by_kind[NetworkKind.INSTITUTION_COLLAB]
+        assert ic["would_be_empty"] is True
+        assert "institutions_id" in str(ic["reason"])
+        assert ic["fix_command"] == "b2g seed --resolve"
+
+        # keyword_cooccurrence vacía: keywords_raw tiene datos pero keywords_id no
+        # Fix debe ser thesaurus (puede generarlos sin red)
+        kw = by_kind[NetworkKind.KEYWORD_COOCCURRENCE]
+        assert kw["would_be_empty"] is True
+        assert kw["fix_command"] == "b2g thesaurus"
+
+    def test_keywords_id_poblado_produce_red_no_vacia(self) -> None:
+        """Con keywords_id >= 2 por paper, keyword_cooccurrence sale no-vacía.
+
+        Simula el estado AFTER thesaurus o AFTER seed --resolve donde
+        keywords_id está disponible.
+        """
+        corpus = _make_corpus(
+            _row("P1", keywords_id=["ecology", "complexity"]),
+            _row("P2", keywords_id=["ecology", "networks"]),
+        )
+        preview = predict_build_preview(corpus)
+        by_kind = {str(e["kind"]): e for e in preview}
+
+        kw = by_kind[NetworkKind.KEYWORD_COOCCURRENCE]
+        assert kw["would_be_empty"] is False
+        assert kw["reason"] is None
+        assert kw["fix_command"] is None
+
+    def test_references_id_dos_o_mas_papers_no_vacia(self) -> None:
+        """Con >= 2 papers con references_id, bibliographic_coupling no sale vacía."""
+        corpus = _make_corpus(
+            _row("P1", references_id=["R1", "R2"]),
+            _row("P2", references_id=["R1", "R3"]),
+        )
+        preview = predict_build_preview(corpus)
+        by_kind = {str(e["kind"]): e for e in preview}
+
+        bc = by_kind[NetworkKind.BIBLIOGRAPHIC_COUPLING]
+        assert bc["would_be_empty"] is False
+
+    def test_un_paper_con_references_no_alcanza(self) -> None:
+        """Solo 1 paper con referencias → bibliographic_coupling vacía (no hay par)."""
+        corpus = _make_corpus(
+            _row("P1", references_id=["R1", "R2"]),
+        )
+        preview = predict_build_preview(corpus)
+        by_kind = {str(e["kind"]): e for e in preview}
+
+        bc = by_kind[NetworkKind.BIBLIOGRAPHIC_COUPLING]
+        assert bc["would_be_empty"] is True
+
+    def test_cocitation_necesita_dos_seeds_con_cited_by(self) -> None:
+        """Co-citación: necesita >= 2 seeds con cited_by_id."""
+        # Solo 1 seed con cited_by_id → vacía
+        corpus = _make_corpus(
+            _row("P1", is_seed=True, cited_by_id=["C1", "C2"]),
+        )
+        preview = predict_build_preview(corpus)
+        by_kind = {str(e["kind"]): e for e in preview}
+        assert by_kind[NetworkKind.COCITATION]["would_be_empty"] is True
+
+        # 2 seeds con cited_by_id → no vacía
+        corpus2 = _make_corpus(
+            _row("P1", is_seed=True, cited_by_id=["C1", "C2"]),
+            _row("P2", is_seed=True, cited_by_id=["C1", "C3"]),
+        )
+        preview2 = predict_build_preview(corpus2)
+        by_kind2 = {str(e["kind"]): e for e in preview2}
+        assert by_kind2[NetworkKind.COCITATION]["would_be_empty"] is False
+
+    def test_author_collab_necesita_un_paper_con_dos_autores(self) -> None:
+        """author_collab: vacía si ningún paper tiene >= 2 authors_id."""
+        # 0 papers con >= 2 autores → vacía
+        corpus = _make_corpus(
+            _row("P1", authors_id=["A1"]),
+        )
+        preview = predict_build_preview(corpus)
+        by_kind = {str(e["kind"]): e for e in preview}
+        assert by_kind[NetworkKind.AUTHOR_COLLAB]["would_be_empty"] is True
+
+        # 1 paper con 2 autores → no vacía
+        corpus2 = _make_corpus(
+            _row("P1", authors_id=["A1", "A2"]),
+        )
+        preview2 = predict_build_preview(corpus2)
+        by_kind2 = {str(e["kind"]): e for e in preview2}
+        assert by_kind2[NetworkKind.AUTHOR_COLLAB]["would_be_empty"] is False
+
+    def test_fix_thesaurus_cuando_hay_keywords_raw_sin_id(self) -> None:
+        """Si keywords_raw existe pero keywords_id no, fix_command='b2g thesaurus'."""
+        corpus = _make_corpus(
+            _row("P1", keywords_raw=["ecology", "diversity"]),
+        )
+        preview = predict_build_preview(corpus)
+        by_kind = {str(e["kind"]): e for e in preview}
+        kw = by_kind[NetworkKind.KEYWORD_COOCCURRENCE]
+        assert kw["would_be_empty"] is True
+        assert kw["fix_command"] == "b2g thesaurus"
+
+    def test_fix_seed_resolve_cuando_no_hay_keywords_raw(self) -> None:
+        """Sin keywords_raw, fix_command para keyword_cooccurrence='b2g seed --resolve'."""
+        corpus = _make_corpus(_row("P1"))
+        preview = predict_build_preview(corpus)
+        by_kind = {str(e["kind"]): e for e in preview}
+        kw = by_kind[NetworkKind.KEYWORD_COOCCURRENCE]
+        assert kw["would_be_empty"] is True
+        assert kw["fix_command"] == "b2g seed --resolve"
+
+    def test_kinds_son_strings_de_networkkind(self) -> None:
+        """El campo kind de cada entrada es un string válido de NetworkKind."""
+        valid_kinds = {str(k) for k in NetworkKind}
+        corpus = _make_corpus(_row("P1"))
+        preview = predict_build_preview(corpus)
+        for entry in preview:
+            assert str(entry["kind"]) in valid_kinds, (
+                f"kind={entry['kind']!r} no es un NetworkKind válido"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Pruebas de integración: run_status con DuckDB temporal
+# ---------------------------------------------------------------------------
+
+
+class TestRunStatusCamposAditivos:
+    """Verifica que run_status incluye los tres campos aditivos."""
+
+    def test_run_status_tiene_tres_campos_aditivos(self, tmp_path: Path) -> None:
+        """run_status devuelve next_best_action, readiness y build_preview."""
+        from bib2graph.cli.commands.status import run_status
+
+        store_path = tmp_path / "test.duckdb"
+        _seed_store(store_path, [_row("P1"), _row("P2")])
+
+        data = run_status(store_path)
+
+        assert "next_best_action" in data, "Falta next_best_action"
+        assert "readiness" in data, "Falta readiness"
+        assert "build_preview" in data, "Falta build_preview"
+
+    def test_campos_viejos_siguen_presentes(self, tmp_path: Path) -> None:
+        """Los campos existentes no desaparecen (contrato aditivo)."""
+        from bib2graph.cli.commands.status import run_status
+
+        store_path = tmp_path / "test.duckdb"
+        _seed_store(store_path, [_row("P1")])
+
+        data = run_status(store_path)
+
+        # Campos pre-existentes
+        assert "loop_state" in data
+        assert "transitions_available" in data
+        assert "curation_available" in data
+        assert "round" in data
+        assert "counts_by_status" in data
+        assert "total_papers" in data
+        assert "referenced_not_fetched" in data
+
+    def test_next_best_action_sin_estado_es_seed(self, tmp_path: Path) -> None:
+        """Sin estado previo (store vacío), next_best_action='seed'."""
+        from bib2graph.cli.commands.status import run_status
+        from bib2graph.stores.duckdb import DuckDBStore
+
+        store_path = tmp_path / "empty.duckdb"
+        DuckDBStore(store_path)  # solo inicializa tablas
+
+        data = run_status(store_path)
+
+        assert data["next_best_action"] == "seed"
+
+    def test_next_best_action_seeded_es_chain(self, tmp_path: Path) -> None:
+        """Tras seed (SEEDED), next_best_action='chain'."""
+        from bib2graph.cli.commands.status import run_status
+
+        store_path = tmp_path / "seeded.duckdb"
+        _seed_store_with_state(store_path, [_row("P1")], CycleState.SEEDED)
+
+        data = run_status(store_path)
+
+        assert data["next_best_action"] == "chain"
+
+    def test_next_best_action_foraged_es_build(self, tmp_path: Path) -> None:
+        """Tras chain (FORAGED), next_best_action='build'."""
+        from bib2graph.cli.commands.status import run_status
+
+        store_path = tmp_path / "foraged.duckdb"
+        _seed_store_with_state(store_path, [_row("P1")], CycleState.FORAGED)
+
+        data = run_status(store_path)
+
+        assert data["next_best_action"] == "build"
+
+    def test_next_best_action_built_es_read(self, tmp_path: Path) -> None:
+        """Tras build (BUILT), next_best_action='read'."""
+        from bib2graph.cli.commands.status import run_status
+
+        store_path = tmp_path / "built.duckdb"
+        _seed_store_with_state(store_path, [_row("P1")], CycleState.BUILT)
+
+        data = run_status(store_path)
+
+        assert data["next_best_action"] == "read"
+
+    def test_build_preview_tiene_cinco_entradas(self, tmp_path: Path) -> None:
+        """build_preview incluye siempre las 5 redes posibles."""
+        from bib2graph.cli.commands.status import run_status
+
+        store_path = tmp_path / "test.duckdb"
+        _seed_store(store_path, [_row("P1")])
+
+        data = run_status(store_path)
+
+        assert len(data["build_preview"]) == 5
+
+    def test_readiness_tiene_campos_ready_y_reason(self, tmp_path: Path) -> None:
+        """readiness es un objeto con 'ready' (bool) y 'reason' (str | None)."""
+        from bib2graph.cli.commands.status import run_status
+
+        store_path = tmp_path / "test.duckdb"
+        _seed_store(store_path, [_row("P1")])
+
+        data = run_status(store_path)
+
+        readiness = data["readiness"]
+        assert "ready" in readiness
+        assert "reason" in readiness
+        assert isinstance(readiness["ready"], bool)
+
+    def test_readiness_false_cuando_build_y_todas_vacias(self, tmp_path: Path) -> None:
+        """Si next_action='build' y todas las redes están vacías, readiness.ready=False.
+
+        Este es el corazón del ADR 0037 §(e): el diagnóstico de red-vacía en
+        status-time, no post-hoc.
+        """
+        from bib2graph.cli.commands.status import run_status
+
+        store_path = tmp_path / "foraged_empty.duckdb"
+        # Corpus foraged pero sin ningún _id col poblado
+        rows = [_row(f"P{i}") for i in range(1, 10)]
+        _seed_store_with_state(store_path, rows, CycleState.FORAGED)
+
+        data = run_status(store_path)
+
+        assert data["next_best_action"] == "build"
+        readiness = data["readiness"]
+        assert readiness["ready"] is False
+        assert readiness["reason"] is not None
+
+    def test_readiness_true_cuando_build_con_keywords(self, tmp_path: Path) -> None:
+        """Si next_action='build' y al menos 1 red no sería vacía, readiness.ready=True."""
+        from bib2graph.cli.commands.status import run_status
+
+        store_path = tmp_path / "foraged_kw.duckdb"
+        rows = [
+            _row("P1", keywords_id=["k1", "k2"]),
+            _row("P2", keywords_id=["k1", "k3"]),
+        ]
+        _seed_store_with_state(store_path, rows, CycleState.FORAGED)
+
+        data = run_status(store_path)
+
+        assert data["next_best_action"] == "build"
+        assert data["readiness"]["ready"] is True
+
+    def test_readiness_true_para_built(self, tmp_path: Path) -> None:
+        """Para BUILT (next=read), readiness.ready=True independientemente del corpus."""
+        from bib2graph.cli.commands.status import run_status
+
+        store_path = tmp_path / "built.duckdb"
+        # BibTeX sin --resolve: source_id=None. Aun así, read es siempre productivo.
+        rows = [_row("P1")]
+        _seed_store_with_state(store_path, rows, CycleState.BUILT)
+
+        data = run_status(store_path)
+
+        assert data["readiness"]["ready"] is True, (
+            "readiness.ready debe ser True para BUILT (next=read)"
+        )
+
+    def test_readiness_true_para_chain_con_source_id(self, tmp_path: Path) -> None:
+        """Para SEEDED con source_id populado, chain es productivo → ready=True."""
+        from bib2graph.cli.commands.status import run_status
+
+        store_path = tmp_path / "seeded_with_source.duckdb"
+        rows = [_row("P1", source_id="W123456")]
+        _seed_store_with_state(store_path, rows, CycleState.SEEDED)
+
+        data = run_status(store_path)
+
+        assert data["next_best_action"] == "chain"
+        assert data["readiness"]["ready"] is True
+
+
+# ---------------------------------------------------------------------------
+# Caso canónico completo (Nota 20): BibTeX sin --resolve → diagnóstico en status-time
+# ---------------------------------------------------------------------------
+
+
+class TestCasoCanonicoNota20:
+    """El caso de trampa que motivó el ADR 0037 §(e).
+
+    Un agente que siembra desde BibTeX sin --resolve NO debe llegar a
+    construir redes vacías sin advertencia. ``status`` debe mostrar el
+    diagnóstico ANTES de que corra build.
+    """
+
+    def test_bibtex_sin_resolve_diagnostico_completo(self, tmp_path: Path) -> None:
+        """Corpus BibTeX (solo keywords_raw, sin _id cols) → diagnóstico correcto.
+
+        Verifica:
+        - redes de citación/colaboración → would_be_empty=True con fix
+        - keyword_cooccurrence → would_be_empty=True, fix='b2g thesaurus'
+        - readiness.ready=False (build sería inútil)
+        - next_best_action='build' (FSM en FORAGED)
+        """
+        from bib2graph.cli.commands.status import run_status
+
+        store_path = tmp_path / "bibtex_no_resolve.duckdb"
+        rows = [
+            _row(f"P{i}", keywords_raw=["ecology", "diversity", "networks"])
+            for i in range(1, 16)
+        ]
+        _seed_store_with_state(store_path, rows, CycleState.FORAGED)
+
+        data = run_status(store_path)
+
+        # next_best_action = "build" (FSM en FORAGED)
+        assert data["next_best_action"] == "build"
+
+        # readiness = False (todas las redes vacías)
+        assert data["readiness"]["ready"] is False
+
+        # build_preview indexado por kind
+        by_kind = {str(e["kind"]): e for e in data["build_preview"]}
+
+        # Redes de citación vacías
+        assert by_kind[NetworkKind.BIBLIOGRAPHIC_COUPLING]["would_be_empty"] is True
+        assert by_kind[NetworkKind.COCITATION]["would_be_empty"] is True
+
+        # Fix para citación/colaboración = seed --resolve
+        assert (
+            by_kind[NetworkKind.BIBLIOGRAPHIC_COUPLING]["fix_command"]
+            == "b2g seed --resolve"
+        )
+        assert by_kind[NetworkKind.COCITATION]["fix_command"] == "b2g enrich"
+
+        # Keyword fix = thesaurus (hay keywords_raw pero no keywords_id)
+        kw = by_kind[NetworkKind.KEYWORD_COOCCURRENCE]
+        assert kw["would_be_empty"] is True
+        assert kw["fix_command"] == "b2g thesaurus"
+
+    def test_bibtex_con_thesaurus_keyword_no_vacia(self, tmp_path: Path) -> None:
+        """Tras thesaurus, keywords_id se puebla → keyword_cooccurrence no-vacía.
+
+        Simula el estado AFTER 'b2g thesaurus': keywords_id tiene datos
+        pero references_id / cited_by_id siguen vacíos.
+        """
+        from bib2graph.cli.commands.status import run_status
+
+        store_path = tmp_path / "bibtex_con_thesaurus.duckdb"
+        rows = [
+            _row(
+                f"P{i}",
+                keywords_raw=["ecology", "diversity"],
+                keywords_id=["ecology", "diversity"],  # thesaurus aplicado
+            )
+            for i in range(1, 6)
+        ]
+        _seed_store_with_state(store_path, rows, CycleState.FORAGED)
+
+        data = run_status(store_path)
+
+        by_kind = {str(e["kind"]): e for e in data["build_preview"]}
+
+        # Keyword ya no vacía
+        kw = by_kind[NetworkKind.KEYWORD_COOCCURRENCE]
+        assert kw["would_be_empty"] is False
+
+        # readiness.ready=True (al menos 1 red no vacía)
+        assert data["readiness"]["ready"] is True
+
+        # Las demás siguen vacías (aún sin --resolve)
+        assert by_kind[NetworkKind.BIBLIOGRAPHIC_COUPLING]["would_be_empty"] is True
+        assert by_kind[NetworkKind.COCITATION]["would_be_empty"] is True
+
+
+# ---------------------------------------------------------------------------
+# P2 Tests: readiness para acción "chain" (ADR 0037 §(e))
+# ---------------------------------------------------------------------------
+
+
+class TestChainReadiness:
+    """Verifica readiness.ready para next_best_action='chain'.
+
+    El forrajeo en OpenAlex arranca del source_id.  BibTeX sin --resolve
+    no tiene source_id → chaining produce 0 papers nuevos → not ready.
+    """
+
+    def test_chain_sin_source_id_no_listo(self, tmp_path: Path) -> None:
+        """SEEDED con corpus BibTeX (sin source_id) → chain not ready."""
+        from bib2graph.cli.commands.status import run_status
+
+        store_path = tmp_path / "bibtex_seeded.duckdb"
+        rows = [_row(f"P{i}") for i in range(1, 6)]  # todos con source_id=None
+        _seed_store_with_state(store_path, rows, CycleState.SEEDED)
+
+        data = run_status(store_path)
+
+        assert data["next_best_action"] == "chain"
+        readiness = data["readiness"]
+        assert readiness["ready"] is False
+        assert readiness["reason"] is not None
+        # El reason debe mencionar source_id y la acción correctiva
+        assert "source_id" in str(readiness["reason"])
+        assert "seed --resolve" in str(readiness["reason"])
+
+    def test_chain_con_source_id_listo(self, tmp_path: Path) -> None:
+        """SEEDED con al menos 1 seed con source_id → chain ready."""
+        from bib2graph.cli.commands.status import run_status
+
+        store_path = tmp_path / "openalex_seeded.duckdb"
+        rows = [
+            _row("P1", source_id="W1000001"),
+            _row("P2", source_id="W1000002"),
+        ]
+        _seed_store_with_state(store_path, rows, CycleState.SEEDED)
+
+        data = run_status(store_path)
+
+        assert data["next_best_action"] == "chain"
+        assert data["readiness"]["ready"] is True
+        assert data["readiness"]["reason"] is None
+
+    def test_chain_mixto_al_menos_uno_con_source_listo(self, tmp_path: Path) -> None:
+        """Corpus mixto (algunos con source_id, otros sin) → chain ready."""
+        from bib2graph.cli.commands.status import run_status
+
+        store_path = tmp_path / "mixed_seeded.duckdb"
+        rows = [
+            _row("P1", source_id="W1000001"),
+            _row("P2"),  # sin source_id (BibTeX)
+            _row("P3"),  # sin source_id (BibTeX)
+        ]
+        _seed_store_with_state(store_path, rows, CycleState.SEEDED)
+
+        data = run_status(store_path)
+
+        assert data["next_best_action"] == "chain"
+        assert data["readiness"]["ready"] is True
+
+    def test_monitored_sin_source_id_no_listo(self, tmp_path: Path) -> None:
+        """MONITORED (también lleva a chain) sin source_id → not ready."""
+        from bib2graph.cli.commands.status import run_status
+
+        store_path = tmp_path / "monitored_bibtex.duckdb"
+        rows = [_row("P1")]  # source_id=None
+        _seed_store_with_state(store_path, rows, CycleState.MONITORED)
+
+        data = run_status(store_path)
+
+        assert data["next_best_action"] == "chain"
+        assert data["readiness"]["ready"] is False
+
+
+# ---------------------------------------------------------------------------
+# P1-test: no-divergencia entre predict_build_preview y build real (ADR 0037)
+# ---------------------------------------------------------------------------
+
+
+class TestNoDivergenciaPreviewVsBuild:
+    """P1-test: predict_build_preview debe coincidir con el build real.
+
+    Para cada corpus representativo, construye las redes reales con ``Networks``
+    y afirma que ``would_be_empty == (graph.number_of_edges() == 0)`` para cada
+    tipo de red.
+
+    Cubre específicamente los casos que exponían el bug original:
+    - refs disjuntas (OLD: predict=False, build=empty)
+    - autores duplicados (OLD: predict=False, build=empty)
+    - citantes disjuntos en co-citación (OLD: predict=False, build=empty)
+    """
+
+    def _assert_all_kinds_agree(self, corpus: Corpus) -> None:
+        """Verifica que preview.would_be_empty == build real para las 5 redes."""
+        from bib2graph.networks.facade import Networks, predict_build_preview
+        from bib2graph.networks.spec import NetworkSpec
+
+        preview = predict_build_preview(corpus)
+        by_kind = {str(e["kind"]): e for e in preview}
+
+        for kind in NetworkKind:
+            spec = NetworkSpec(kind=str(kind))
+            artifact = Networks.build(corpus, spec)
+            real_empty = artifact.graph.number_of_edges() == 0
+            pred_empty = bool(by_kind[str(kind)]["would_be_empty"])
+            assert pred_empty == real_empty, (
+                f"kind={kind}: preview.would_be_empty={pred_empty!r} "
+                f"pero el build real tiene {artifact.graph.number_of_edges()} aristas"
+            )
+
+    def test_corpus_sin_datos(self) -> None:
+        """Corpus sin ningún _id → todas las redes vacías."""
+        corpus = _make_corpus(_row("P1"), _row("P2"))
+        self._assert_all_kinds_agree(corpus)
+
+    def test_coupling_refs_disjuntas_bug_p1(self) -> None:
+        """CASO TRAMPA P1: refs disjuntas → coupling vacía aunque ≥2 papers tienen refs."""
+        # Bug original: n_refs=2 → OLD predicaba would_be_empty=False, build daba 0 aristas.
+        corpus = _make_corpus(
+            _row("P1", references_id=["R1", "R2"]),
+            _row("P2", references_id=["R3", "R4"]),  # disjuntas con P1
+        )
+        self._assert_all_kinds_agree(corpus)
+
+    def test_coupling_refs_compartidas(self) -> None:
+        """Refs compartidas → coupling no-vacía."""
+        corpus = _make_corpus(
+            _row("P1", references_id=["R1", "R2"]),
+            _row("P2", references_id=["R1", "R3"]),  # R1 compartida
+        )
+        self._assert_all_kinds_agree(corpus)
+
+    def test_autor_duplicado_bug_p1(self) -> None:
+        """CASO TRAMPA P1: [A1, A1] → tras dedup 1 único → author_collab vacía.
+
+        Bug original: _count_rows_with_multi_col contaba 1 paper con len(val)>=2
+        → predicaba would_be_empty=False, pero build daba 0 aristas.
+        """
+        corpus = _make_corpus(
+            _row("P1", authors_id=["A1", "A1"]),
+        )
+        self._assert_all_kinds_agree(corpus)
+
+    def test_autores_distintos(self) -> None:
+        """[A1, A2] → 2 distintos → author_collab no-vacía."""
+        corpus = _make_corpus(
+            _row("P1", authors_id=["A1", "A2"]),
+        )
+        self._assert_all_kinds_agree(corpus)
+
+    def test_institucion_duplicada_bug_p1(self) -> None:
+        """CASO TRAMPA P1: [I1, I1] → institution_collab vacía."""
+        corpus = _make_corpus(
+            _row("P1", institutions_id=["I1", "I1"]),
+        )
+        self._assert_all_kinds_agree(corpus)
+
+    def test_instituciones_distintas(self) -> None:
+        """[I1, I2] → institution_collab no-vacía."""
+        corpus = _make_corpus(
+            _row("P1", institutions_id=["I1", "I2"]),
+        )
+        self._assert_all_kinds_agree(corpus)
+
+    def test_keyword_duplicada_bug_p1(self) -> None:
+        """CASO TRAMPA P1: [k1, k1] → keyword_cooccurrence vacía."""
+        corpus = _make_corpus(
+            _row("P1", keywords_id=["k1", "k1"]),
+        )
+        self._assert_all_kinds_agree(corpus)
+
+    def test_keywords_distintas(self) -> None:
+        """[k1, k2] → keyword_cooccurrence no-vacía."""
+        corpus = _make_corpus(
+            _row("P1", keywords_id=["k1", "k2"]),
+        )
+        self._assert_all_kinds_agree(corpus)
+
+    def test_cocitation_citantes_disjuntos_bug_p1(self) -> None:
+        """CASO TRAMPA P1: citantes disjuntos → cocitation vacía.
+
+        Bug original: n_cited=2 seeds → OLD predicaba would_be_empty=False,
+        pero build daba 0 aristas porque ningún citante es compartido.
+        """
+        corpus = _make_corpus(
+            _row("P1", is_seed=True, cited_by_id=["C1"]),
+            _row("P2", is_seed=True, cited_by_id=["C2"]),  # C1≠C2: disjuntos
+        )
+        self._assert_all_kinds_agree(corpus)
+
+    def test_cocitation_citante_compartido(self) -> None:
+        """Citante compartido → cocitation no-vacía."""
+        corpus = _make_corpus(
+            _row("P1", is_seed=True, cited_by_id=["C1", "C2"]),
+            _row("P2", is_seed=True, cited_by_id=["C1", "C3"]),  # C1 compartido
+        )
+        self._assert_all_kinds_agree(corpus)
+
+    def test_corpus_con_none_en_lista(self) -> None:
+        """Listas con None como elementos → filtradas correctamente."""
+        corpus = _make_corpus(
+            _row("P1", authors_id=["A1", None]),  # solo A1 válido → no multi-distinct
+            _row("P2", authors_id=[None, None]),  # 0 válidos
+        )
+        self._assert_all_kinds_agree(corpus)
+
+
+# ---------------------------------------------------------------------------
+# Tests de contrato: schema="1" y compatibilidad con agentes existentes
+# ---------------------------------------------------------------------------
+
+
+class TestContratoEnvelope:
+    """Garantiza que los campos aditivos no rompen el envelope schema='1'."""
+
+    def test_envelope_schema_sigue_siendo_uno(self, tmp_path: Path) -> None:
+        """El envelope JSON tiene schema='1' con los campos nuevos."""
+        from bib2graph.cli._envelope import build_envelope
+
+        data = {
+            "loop_state": "FORAGED",
+            "transitions_available": ["build"],
+            "curation_available": ["accept", "reject"],
+            "round": 1,
+            "counts_by_status": {"candidate": 5},
+            "total_papers": 5,
+            "referenced_not_fetched": 0,
+            # Campos aditivos ADR 0037
+            "next_best_action": "build",
+            "readiness": {"ready": True, "reason": None},
+            "build_preview": [
+                {
+                    "kind": "keyword_cooccurrence",
+                    "would_be_empty": False,
+                    "reason": None,
+                    "fix_command": None,
+                }
+            ],
+            "workspace": {"root": "/tmp/ws", "source": "explicit"},
+            "networks_cache_stale": False,
+        }
+
+        envelope = build_envelope(
+            command="status",
+            ok=True,
+            data=data,
+            exit_code=0,
+        )
+
+        # Schema invariante
+        assert envelope["schema"] == "1"
+        assert envelope["ok"] is True
+        assert envelope["command"] == "status"
+        assert envelope["exit_code"] == 0
+
+        # Campos viejos siguen en data
+        assert envelope["data"]["loop_state"] == "FORAGED"
+        assert envelope["data"]["total_papers"] == 5
+
+        # Campos nuevos en data
+        assert envelope["data"]["next_best_action"] == "build"
+        assert envelope["data"]["readiness"]["ready"] is True
+        assert len(envelope["data"]["build_preview"]) == 1


### PR DESCRIPTION
**Fase 1A** del hito 0.10.0 (implementa [ADR 0037](docs/decisiones/0037-superficie-cli-10-verbos-ciclo.md) §(e)). Tres campos **aditivos** en `b2g status --json`, `schema="1"` intacto (mismo patrón que la enmienda R3 del ADR 0021).

## Qué agrega
- **`next_best_action`** — próximo comando recomendado, determinista desde el FSM (`cycle.next_best_action`).
- **`readiness {ready, reason}`** — si el próximo paso **dará fruto**, no solo si la transición FSM está permitida:
  - `build`: `ready=False` si **todas** las redes saldrían vacías.
  - `chain`: `ready=False` si **ningún seed tiene `source_id`** (BibTeX sin `--resolve` no trae nada de OpenAlex).
- **`build_preview`** (decisión (e)) — por cada red: `would_be_empty` + `reason` + `fix_command`, **antes** de `build`. Cierra de raíz la trampa de "redes vacías con cara de éxito" (Nota 20).

## Correctitud: preview ↔ build sin divergencia
El preview usa los **mismos predicados** que los proyectores:
- shared-refs (coupling/cocitación): no-vacía sii **algún ítem aparece en ≥2 papers distintos** (no "≥2 papers con datos").
- co-ocurrencia (autores/instituciones/keywords): no-vacía sii **algún paper tiene ≥2 entidades distintas no-None** (dedup con `set`, igual que el proyector).

Incluye el **test de no-divergencia que el ADR exige** (`TestNoDivergenciaPreviewVsBuild`): construye las redes reales con `Networks.build` y cruza `would_be_empty == (number_of_edges()==0)` para los 5 kinds, cubriendo los casos trampa de datos disjuntos (refs disjuntas, autor/institución/keyword duplicados).

## Proceso
Implementado por el `coder`, revisado por el `verifier` (atrapó un falso-ok en el predicado original y la falta del test de no-divergencia → corregidos), confirmado a mano. Gate verde: **898 passed**, mypy strict, ruff OK.

## Notas
- `# TODO(0037 1B)`: los `fix_command` (`b2g enrich`/`b2g thesaurus`) se reapuntan cuando 1B consolide verbos.
- `docs/API.md` (los tres campos) se actualiza en 1E (architect), por el contrato del repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)