### PR TITLE
feat(build): absorber networks via --spec + --scope/--min-weight + diagnóstico red-vacía (#159)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,10 @@
   `_write_artifacts` (mismos GraphML + metrics.json + clusters.csv que `build`); **NO** transiciona el
   `CycleState` ni sella `.corpus_hash` (transversal al lazo, como `enrich`/`curate`). `pyyaml` pasó a
   dependencia del núcleo (import perezoso). **516 tests verdes**. Ver `docs/API.md` §10.
+  **Absorbido por `b2g build --spec` (#159, ADR 0037 (a) / 0038):** `build` ahora carga el mismo YAML
+  (helper compartido `_build_from_spec_file`) y **sí** transiciona a `BUILT` + sella `.corpus_hash`
+  (decisión D1); `build` suma `--scope all|accepted|seeds` (default `all`) y `--min-weight` (solo modo
+  quick). `networks` y `--corpus-scope` quedan como **alias en deprecación** (cierran 0.11.0).
 - **MVP GUI — Hitos G1–G5 COMPLETOS · build entero del MVP (AS-BUILT 2026-06-18, ADR
   [0028](docs/decisiones/0028-arquitectura-gui-api-capa-servicios.md)):** los 5 hitos de construcción
   están **AS-BUILT** en `feat/gui-g1-capa-servicios` — G1 (capa de servicios neutral + contrato subido),

--- a/docs/API.md
+++ b/docs/API.md
@@ -93,7 +93,9 @@
 > **16° subcomando `b2g networks --spec`** (construye cada red con `Networks.build` y el helper
 > compartido `_write_artifacts`; mismo envelope que `build`; **NO** transiciona el `CycleState` ni
 > sella `.corpus_hash`). `pyyaml` pasó a dependencia del núcleo (import perezoso). Ver §10 +
-> §convenciones CLI.
+> §convenciones CLI. **(Actualización #159, ADR 0038):** esta capa declarativa fue **absorbida por
+> `b2g build --spec`** —que **sí** transiciona y sella (decisión D1)—; `networks` queda como alias en
+> **deprecación** (cierra 0.11.0). Ver §`build`.
 >
 > **Sincronizado con la capa declarativa de ecuación + `restore` — #33 / Ciclo 9a (AS-BUILT, 2026-06-17):**
 > dos cambios de la capa declarativa (ADR [0030](decisiones/0030-ecuacion-declarativa-corpus-ejemplo.md)).
@@ -435,17 +437,21 @@ resolución DOI→`source_id` del flujo BibTeX e2e, issues #110/#112, ADR
     que el Forager guarde `scent` en provenance) y **`cluster` siempre vacío** (integración con redes
     diferida). **Curación TRANSVERSAL: `curate` NO transiciona el `CycleState`** (disponible en cualquier
     estado del lazo, igual que `accept`/`reject`; ADR 0016 enmendado R3). `--json` con `schema="1"`.
-- **`networks`** (Hito 9, AS-BUILT 2026-06-17): **capa declarativa** — construye redes desde un YAML
-  versionable. **`b2g networks --spec <redes.yaml>`** carga la lista de specs con `load_specs` (§10;
+- **`networks`** (Hito 9, **EN DEPRECACIÓN — absorbido por `build --spec`**, ADR 0037 (a) / 0038,
+  ventana cierra 0.11.0): **capa declarativa** — construye redes desde un YAML versionable.
+  **`b2g networks --spec <redes.yaml>`** carga la lista de specs con `load_specs` (§10;
   clave raíz `networks:`), construye cada red con `Networks.build` y escribe artefactos con el helper
   compartido **`_write_artifacts`** (extraído de `build.py`): mismos GraphML + `metrics.json` +
-  `clusters.csv` que `build`, en `<out-dir>/<kind>/`. **`--out-dir`** override (default
-  `<workspace>/networks/`); resolución de store/workspace idéntica a `build` (`resolve_workspace`).
-  `--json` con `schema="1"`, mismo formato que `build` (lista de redes en `data["networks"]`, con
-  `clusters_csv` condicional). **Ejecución ad-hoc transversal al lazo: NO transiciona el `CycleState`
-  ni sella `networks/.corpus_hash`** (mismo criterio que `enrich`/`curate`). Errores accionables:
-  YAML malformado / spec inválida → `DataError` (exit 2); falta `python-louvain` → `DependencyError`
-  (exit 3).
+  `clusters.csv` que `build`, en `<out-dir>/<kind>/`. La carga YAML + proyección la comparte con
+  `build --spec` vía **`_build_from_spec_file`** (fuente única; frontera con #165). **`--out-dir`**
+  override (default `<workspace>/networks/`); resolución de store/workspace idéntica a `build`
+  (`resolve_workspace`). `--json` con `schema="1"`, mismo formato que `build` (lista de redes en
+  `data["networks"]`, con `clusters_csv` condicional). **Diferencia clave con `build --spec`:**
+  `networks` es **ad-hoc transversal al lazo** y **NO** transiciona el `CycleState` ni sella
+  `networks/.corpus_hash` (mismo criterio que `curate`); `build --spec` **sí** lo hace (decisión D1,
+  ADR 0038 — ver §`build`). **Recomendado:** usá `build --spec` (paso BUILD pleno). Errores
+  accionables: YAML malformado / spec inválida → `DataError` (exit 2); falta `python-louvain` →
+  `DependencyError` (exit 3).
 - **`gui`** (Hito G3 del MVP GUI, AS-BUILT 2026-06-18, ADR
   [0028](decisiones/0028-arquitectura-gui-api-capa-servicios.md), 19° subcomando): **levanta la API
   local FastAPI** (§0.2) con `uvicorn` y sirve la SPA buildeada de `gui/static/` si existe (AS-BUILT G4;
@@ -506,16 +512,57 @@ nodo→corpus por `Col.ID` — ese mapeo no existe para nodos que no son papers,
 (no crash) y el comando omite el archivo. Lo mismo aplica a `b2g networks --spec` (comparten
 `_write_artifacts`).
 
-**`build --corpus-scope [all|accepted|seeds_only]` (AS-BUILT #56):** filtra el corpus por estado de
-curación **antes** de proyectar (vía `Corpus.scoped`, §1.2). **Default `all`** = corpus completo
-(opt-in, sin cambio de comportamiento). `accepted` = semillas (`is_seed=True`) + papers aceptados;
-`seeds_only` = solo semillas. El `networks/.corpus_hash` se sella con el hash del corpus **FILTRADO**
-(no del vivo completo), y `clusters.csv`/`decorate` reflejan exactamente ese subset (sin drift). Si el
-scope deja **0 papers**: **exit 0** + `warning` accionable ("corré `b2g curate`… o usá
-`--corpus-scope=all`") — **no** es error; escribe `networks/` vacío con `.corpus_hash` vacío. El
-envelope `--json` suma `data["corpus_scope"]` (y `warnings`). **NO confundir con `NetworkSpec.scope`
-(§10):** ejes distintos. `--corpus-scope` filtra el **corpus entero** por curación (un input al
-`build`); `NetworkSpec.scope` (`full`/`seeds_only`) es **por-red declarativa** sobre `is_seed`.
+**`build` — dos modos, una superficie (AS-BUILT #159, ADR 0037 (a)(e) + 0038):** `build` absorbe la
+capacidad de `networks` vía `--spec`, sin perder el one-shot.
+
+- **`build` (sin `--spec`) = modo quick:** computa `Networks.quick` (4-5 redes principales).
+- **`build --spec <redes.yaml>` = modo declarativo:** carga la lista de specs con `load_specs`
+  (§10, clave raíz `networks:`) y construye cada red con `Networks.build`. El helper compartido
+  `_build_from_spec_file` (en `build.py`) es la **fuente única** para `build --spec` y para el alias
+  `networks` (frontera con #165). **A diferencia de `networks`** (alias en deprecación, ortogonal al
+  lazo, NO transiciona), **`build --spec` SÍ transiciona el FSM a `BUILT` y sella `.corpus_hash`** —es
+  un paso BUILD pleno (decisión PO **D1**, ADR 0038).
+
+**`--scope [all|accepted|seeds]` (default `all`, ADR 0038 P2):** filtra el corpus por estado de
+curación **antes** de proyectar (vía `Corpus.scoped`, §1.2). **Default `all`** = corpus completo (el
+one-shot corre sin curar). `accepted` = semillas (`is_seed=True`) + papers aceptados; `seeds` = solo
+semillas. Aplica en **ambos** modos (quick y spec). El `networks/.corpus_hash` se sella con el hash
+del corpus **FILTRADO** (no del vivo completo), y `clusters.csv`/`decorate` reflejan exactamente ese
+subset (sin drift). Si el scope deja **0 papers**: **exit 0** + `warning` accionable ("corré
+`b2g curate`… o usá `--scope=all`") — **no** es error; escribe `networks/` vacío con `.corpus_hash`
+vacío. **NO confundir con `NetworkSpec.scope` (§10):** ejes distintos. `--scope` filtra el **corpus
+entero** por curación (un input al `build`); `NetworkSpec.scope` (`full`/`seeds_only`) es **por-red
+declarativa** sobre `is_seed`.
+
+- **`--corpus-scope [all|accepted|seeds_only]` = alias DEPRECADO (oculto en `--help`):** vocab
+  antiguo previo a #159. Sigue funcionando con **aviso a stderr** y tiene precedencia si se pasa junto
+  a `--scope`; **la ventana cierra en 0.11.0** (ADR 0038 P1). Su vocab (`seeds_only`) es el vocab
+  interno de `Corpus.scoped`; `--scope seeds` mapea a él.
+
+**`--min-weight N` (solo modo quick):** descarta aristas con peso < N (default 1 = sin filtro). **Solo
+aplica sin `--spec`.** Con `--spec`, cada red usa el `min_weight` declarado en su YAML por-red, y
+pasar **`--min-weight` junto a `--spec` emite un warning a stderr** ("se ignora con `--spec`") — no
+falla, pero el valor del CLI se descarta.
+
+**Diagnóstico de red-vacía en build-time (ADR 0037 §(e), no-divergencia con status-time):** `build`
+reusa `predict_build_preview` (la **misma** fuente que usa `status`) para diagnosticar redes que salen
+vacías. En modo humano va como `warning` a stderr; en `--json` va en el envelope como
+**`data["empty_networks"]`** — una lista de `{kind, reason, fix_command}`, **separada** de
+`data["warnings"]` (que queda reservado para avisos **corpus-level**, p. ej. el scope con 0 papers).
+Si una red sale vacía por el `min_weight` del YAML (modo spec), el `reason` **culpa al spec**
+(no al `--min-weight` del CLI) y `fix_command=None`.
+
+**Esquema de respuesta `--json` (`data`):** `networks_built`, `artifacts_dir`, `corpus_hash`,
+**`scope`** = **token CLI** (`seeds`/`accepted`/`all`, gancho estable para #160 maturity),
+**`corpus_scope`** = vocab interno (`seeds_only`/…, backward-compat), `networks` (lista, con
+`clusters_csv` condicional), `warnings` (corpus-level) y `empty_networks` (diagnóstico por-red).
+Invariante: envelope `schema="1"`, exit codes y FSM intactos; todo lo de #159 es **aditivo**.
+
+> **No-divergencia es por-corpus.** La garantía de no-divergencia entre el diagnóstico de red-vacía de
+> `build` y el de `status` (ADR 0037 §(e)) es **sobre el mismo corpus de entrada**. Con `--scope != all`,
+> `predict_build_preview` corre sobre el **corpus filtrado**, así que los conteos del `reason` pueden
+> diferir legítimamente de los de `status` sobre el corpus completo. La **lógica es fuente única**; lo
+> que varía es el corpus que se le pasa.
 
 **`snapshot` (AS-BUILT #32, 2026-06-17):** `b2g snapshot` sella una foto reproducible del estado vivo
 (parquet + `manifest.json`, ADR 0017). **`--out-dir` pasó a override OPCIONAL** — sin él, escribe en
@@ -981,8 +1028,9 @@ class Corpus:
         OR `curation_status == 'accepted'`; `'seeds_only'` = `is_seed == True`. Scope inválido →
         `ValueError` accionable. Determinista: dos llamadas con el mismo scope dan corpora con el
         mismo `corpus_hash` (subset estable). `'all'` reusa el backend; los otros materializan el
-        filtro en un `InMemoryBackend`. Lo usa `b2g build --corpus-scope` para sellar el hash del
-        corpus FILTRADO. Issue #56. **NO confundir con `NetworkSpec.scope`** (§10): aquel es un
+        filtro en un `InMemoryBackend`. Lo usa `b2g build --scope` (vocab CLI `seeds`→`seeds_only`;
+        alias deprecado `--corpus-scope` usa este vocab interno) para sellar el hash del
+        corpus FILTRADO. Issue #56 / #159. **NO confundir con `NetworkSpec.scope`** (§10): aquel es un
         eje por-red (`full`/`seeds_only`) sobre `is_seed`; `scoped()` filtra el corpus entero por
         curación antes de proyectar."""
 
@@ -2200,14 +2248,16 @@ Migración de un `.duckdb` legacy: corré **`b2g init .`** en su carpeta para ad
 workspace (`--store` y el modo degenerado fueron eliminados en
 [#75](https://github.com/complexluise/bib2graph/issues/75)).
 
-El **modo declarativo** (`b2g networks --spec redes.yaml`, `NetworkSpec` desde YAML) está
-**construido** (Hito 9, AS-BUILT 2026-06-17): un YAML versionable describe qué redes calcular.
+El **modo declarativo** (`NetworkSpec` desde un YAML versionable) está **construido** y se invoca con
+**`b2g build --spec redes.yaml`** (AS-BUILT #159): un YAML versionable describe qué redes calcular.
 
 ```bash
-# Hito 9: pipeline declarativo desde un YAML versionable (dentro del workspace)
-b2g networks --spec redes.yaml --json   # carga load_specs(redes.yaml) → Networks.build por red →
+# Pipeline declarativo desde un YAML versionable (dentro del workspace)
+b2g build --spec redes.yaml --json      # carga load_specs(redes.yaml) → Networks.build por red →
                                         # escribe networks/<kind>/ (GraphML + metrics.json + clusters.csv)
+                                        # transiciona a BUILT y sella .corpus_hash (D1, ADR 0038)
 ```
 
-`b2g networks` es **ad-hoc / transversal al lazo**: **NO** transiciona el `CycleState` ni sella
-`networks/.corpus_hash` (igual criterio que `enrich`/`curate`). Ver §convenciones CLI.
+`b2g build --spec` es un **paso BUILD pleno**: transiciona el `CycleState` a `BUILT` y sella
+`networks/.corpus_hash`. El alias `b2g networks --spec` (**en deprecación**, cierra 0.11.0) hace lo
+mismo pero **NO** transiciona ni sella (ad-hoc transversal al lazo). Ver §convenciones CLI.

--- a/docs/decisiones/0037-superficie-cli-10-verbos-ciclo.md
+++ b/docs/decisiones/0037-superficie-cli-10-verbos-ciclo.md
@@ -230,3 +230,31 @@ diagnostica antes** —el agente no se queda con una "cara de éxito" vacía.
 - **Un comando "doctor" nuevo para el diagnóstico.** Rechazada: agrega superficie para decir lo que
   `status` —el mapa— debe decir. El diagnóstico entra como **campos aditivos** del envelope de
   `status` (mismo patrón que R3 del 0021), respetando el invariante de subcomandos.
+
+## Enmienda 2026-06-27 (append-only) — D1: `build --spec` es un paso BUILD pleno (#159)
+
+> Anotación append-only (no revierte nada de arriba; mismo patrón que la enmienda 2026-06-27 al
+> [0021](0021-cli-agente-native-contrato.md) §C). Decidida por el **PO** durante la implementación de
+> la absorción `networks`→`build --spec` (decisión (a)/(d) + ADR
+> [0038](0038-destino-verbos-huerfanos-0037.md)).
+
+La decisión (a) absorbió la capa declarativa de `networks` en **`build --spec`**, pero dejó implícito
+un matiz que la implementación tuvo que resolver: **¿`build --spec` transiciona el FSM y sella el
+hash, o se comporta como `networks` (ad-hoc, sin transición)?** El verbo `networks` —histórico— **no**
+transicionaba ni sellaba `.corpus_hash` (transversal al lazo, como `enrich`/`curate`).
+
+**D1 (PO):** **`build --spec` SÍ transiciona a `BUILT` y sella `networks/.corpus_hash`** —es un paso
+BUILD pleno, idéntico al `build` quick en lo que respecta al FSM—. El alias `networks` (en
+deprecación, cierra 0.11.0 por 0038 P1) **conserva** su comportamiento histórico (no transiciona, no
+sella). Es decir: lo que define la transición es **el verbo `build`**, no el modo (quick/spec).
+
+- **Por qué:** `build` *es* el paso BUILD del ciclo; correrlo con `--spec` sigue siendo materializar
+  redes en ese paso, así que debe avanzar el FSM y sellar la cache (coherente con la tabla de verbos
+  del 0037: `build → BUILT`). Mantener `--spec` sin transición reintroduciría la ambigüedad que la
+  absorción quería cerrar.
+- **Frontera con #165:** el helper compartido `_build_from_spec_file` es la **fuente única** de carga
+  YAML + proyección para `build --spec` y `networks`; cuando `networks` se retire (0.11.0), no habrá
+  reconciliación pendiente.
+- **Invariante:** envelope `schema="1"`, exit codes y la forma del FSM **no cambian**; D1 solo fija
+  *cuándo* se dispara la transición ya existente. Contrato AS-BUILT en
+  [`../API.md`](../API.md) §`build`.

--- a/src/bib2graph/cli/commands/build.py
+++ b/src/bib2graph/cli/commands/build.py
@@ -1,15 +1,29 @@
 """cli.commands.build — Subcomando ``b2g build``.
 
-Computa las redes bibliométricas con Networks.quick y escribe artefactos
-a disco. Transiciona el CycleState a BUILT tras persistir con éxito.
+Computa las redes bibliométricas y escribe artefactos a disco.
+Transiciona el CycleState a BUILT tras persistir con éxito.
+
+Modos de operación (ADR 0038, #159):
+  - **Sin ``--spec``** (one-shot): usa ``Networks.quick``.  Construye las 4-5
+    redes principales.
+  - **Con ``--spec``** (declarativo): carga un YAML con ``load_specs`` y
+    construye cada red con ``Networks.build``.  Absorbe la capacidad de
+    ``b2g networks``, pero con transición de FSM y sellado de hash (D1).
+
+En AMBOS modos:
+  - ``--scope`` pre-filtra el corpus (``all`` / ``accepted`` / ``seeds``).
+  - ``--min-weight`` filtra aristas con peso < N (default 1 = sin filtro).
+  - Se transiciona a BUILT y se sella ``networks/.corpus_hash``.
+  - Se diagnostican redes vacías en build-time, reusando ``predict_build_preview``
+    (fuente única con ``status``, ADR 0037 §(e)).
 
 ADR 0029 — workspace:
   El directorio de artefactos es ``<workspace>/networks/`` por defecto.
   Si se pasa ``--out-dir`` explícito, se usa ese.
 
 ADR 0029 — sellado por corpus_hash:
-  Escribe ``networks/.corpus_hash`` con el hash del corpus que produjo
-  las redes. Permite detectar staleness sin un build system completo.
+  Escribe ``networks/.corpus_hash`` con el hash del corpus **filtrado** que
+  produjo las redes. Permite detectar staleness sin un build system completo.
 
 Los artefactos se escriben en ``<networks_dir>/<kind>/``:
   - ``network.graphml``: el grafo en formato GraphML.
@@ -22,19 +36,85 @@ from __future__ import annotations
 
 import csv as _csv
 import json
+import sys
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import click
 
 from bib2graph.cli._envelope import build_envelope, emit, emit_human
-from bib2graph.cli._errors import DependencyError, handle_errors
+from bib2graph.cli._errors import DataError, DependencyError, handle_errors
 from bib2graph.cli._options import json_mode, json_option
 from bib2graph.cli._store import open_store, resolve_workspace
 
 if TYPE_CHECKING:
     from bib2graph.corpus import Corpus
     from bib2graph.networks.spec import NetworkArtifact
+
+
+# ---------------------------------------------------------------------------
+# Helper: mapeo del vocabulario CLI de --scope al vocabulario interno de corpus.scoped()
+# ---------------------------------------------------------------------------
+
+
+def _map_scope(scope: str) -> str:
+    """Mapea el vocab de ``--scope`` (CLI) al vocab interno de ``corpus.scoped()``.
+
+    ``--scope`` usa ``seeds`` (forma corta), mientras que ``corpus.scoped()``
+    espera ``seeds_only``.  Los demás valores son idénticos en ambos vocabs.
+
+    Args:
+        scope: Valor del flag ``--scope`` (``all`` | ``accepted`` | ``seeds``).
+
+    Returns:
+        Vocabulario interno: ``all`` | ``accepted`` | ``seeds_only``.
+    """
+    if scope == "seeds":
+        return "seeds_only"
+    return scope
+
+
+# ---------------------------------------------------------------------------
+# Helper compartido: carga de specs YAML + construcción de artefactos
+# ---------------------------------------------------------------------------
+
+
+def _build_from_spec_file(
+    corpus: Corpus,
+    spec_path: str | Path,
+) -> list[NetworkArtifact]:
+    """Carga specs YAML y construye artefactos con ``Networks.build``.
+
+    Helper compartido entre ``run_build --spec`` y ``run_networks``.
+    Centraliza la carga YAML + proyección para que ambos comandos no diverjan
+    (frontera con #165: cuando ``networks`` se retire, no habrá reconciliación).
+
+    Args:
+        corpus: Corpus ya filtrado (scope aplicado por quien llama).
+        spec_path: Ruta al archivo YAML con la definición de redes.
+
+    Returns:
+        Lista de ``NetworkArtifact`` en el orden del YAML.
+
+    Raises:
+        DataError: Si el YAML está malformado o alguna spec es inválida.
+        DependencyError: Si falta ``python-louvain`` al detectar comunidades.
+    """
+    from bib2graph.networks.facade import Networks
+    from bib2graph.networks.spec import load_specs
+
+    try:
+        specs = load_specs(spec_path)
+    except (ValueError, FileNotFoundError) as exc:
+        raise DataError(str(exc)) from exc
+
+    try:
+        return [Networks.build(corpus, spec) for spec in specs]
+    except ImportError as exc:
+        raise DependencyError(
+            f"Dependencia faltante para detectar comunidades: {exc}. "
+            "Instalá python-louvain: uv add python-louvain."
+        ) from exc
 
 
 # ---------------------------------------------------------------------------
@@ -165,16 +245,27 @@ def run_build(
     *,
     out_dir: str | Path | None = None,
     corpus_scope: str = "all",
+    spec_path: str | Path | None = None,
+    min_weight: int = 1,
+    scope_cli_token: str | None = None,
 ) -> dict[str, Any]:
     """Computa redes bibliométricas y escribe artefactos a disco.
 
-    Usa ``Networks.quick`` para las 4 redes principales (coupling, co-autoría,
-    institución, co-word). Escribe GraphML + metrics.json por red.
+    Modos de operación (#159 — absorción de ``networks``):
+    - **Sin ``spec_path``**: usa ``Networks.quick(corpus, min_weight=min_weight)``
+      para las 4-5 redes principales.
+    - **Con ``spec_path``**: carga YAML con ``load_specs`` y construye cada red
+      con ``Networks.build``.
+
+    En AMBOS modos:
+    - ``corpus_scope`` pre-filtra el corpus antes de construir redes.
+    - Se transiciona a BUILT y se sella ``networks/.corpus_hash`` con el hash
+      del corpus **filtrado** (D1 — ADR 0038).
+    - Se diagnostican redes vacías usando ``predict_build_preview`` como fuente
+      única (ADR 0037 §(e) — no-divergencia con ``status``).
+
     Para redes de paper con comunidades detectadas escribe también clusters.csv
     (tabla de resumen de comunidades, issue #31).
-    Sella ``networks/.corpus_hash`` con el hash del corpus **filtrado** que las
-    produjo (no del corpus vivo completo).
-    Transiciona a BUILT tras escribir con éxito.
 
     Args:
         store_path: Ruta al archivo ``.duckdb``.
@@ -182,19 +273,30 @@ def run_build(
         corpus_scope: Filtro de curación aplicado antes de construir las redes.
             ``'all'`` (default) = corpus completo; ``'accepted'`` = semillas +
             aceptados; ``'seeds_only'`` = solo semillas.
+        spec_path: Ruta al YAML de specs (opcional). Si se omite, usa quick.
+        min_weight: Peso mínimo de arista. Default 1 = sin filtro.
+            Solo aplica al modo quick (sin spec); en modo spec, ``NetworkSpec``
+            del YAML lleva su propio ``min_weight``.
+        scope_cli_token: Token CLI tal como lo tipió el usuario
+            (``'seeds'``/``'accepted'``/``'all'``). Si se pasa, ``data["scope"]``
+            expone este token en lugar del vocab interno. Permite que #160
+            (maturity) y la CLI sean consistentes. Si se omite (llamadas directas
+            sin CLI), ``data["scope"]`` queda igual a ``corpus_scope``.
 
     Returns:
         Dict con ``networks_built``, ``artifacts_dir``, ``corpus_hash``,
-        ``corpus_scope`` y lista de redes.
+        ``corpus_scope`` (vocab interno), ``scope`` (token CLI o vocab interno),
+        lista de redes, ``warnings`` y ``empty_networks``.
 
     Raises:
+        DataError: Si ``spec_path`` está malformado (modo spec).
         DependencyError: Si falta ``python-louvain``.
         StoreError: Si el store está bloqueado.
     """
     import warnings as _warnings
 
     from bib2graph.cycle import apply_transition
-    from bib2graph.networks.facade import Networks
+    from bib2graph.networks.facade import Networks, predict_build_preview
 
     store = open_store(store_path)
     try:
@@ -222,7 +324,7 @@ def run_build(
         if len(corpus) == 0:
             msg = (
                 f"scope='{corpus_scope}' dejó 0 papers; "
-                "corré `b2g curate` para aceptar papers o usá `--corpus-scope=all`."
+                "corré `b2g curate` para aceptar papers o usá `--scope=all`."
             )
             _warnings.warn(msg, stacklevel=2)
             build_warnings.append(msg)
@@ -234,22 +336,85 @@ def run_build(
                 "artifacts_dir": str(artifacts_dir),
                 "corpus_hash": "",
                 "corpus_scope": corpus_scope,
+                "scope": corpus_scope,
                 "networks": [],
                 "warnings": build_warnings,
+                "empty_networks": [],
             }
 
-        try:
-            artifacts = Networks.quick(corpus)
-        except ImportError as exc:
-            raise DependencyError(
-                f"Dependencia faltante para detectar comunidades: {exc}. "
-                "Instalá python-louvain: uv add python-louvain."
-            ) from exc
+        # Diagnóstico pre-build (ADR 0037 §(e), fuente única con status-time).
+        # Indexado por kind para lookup O(1) en el loop post-build.
+        preview_by_kind = {str(e["kind"]): e for e in predict_build_preview(corpus)}
+
+        # Construir artefactos según el modo.
+        if spec_path is not None:
+            # Modo declarativo: YAML → specs → Networks.build por red.
+            # _build_from_spec_file levanta DataError / DependencyError.
+            artifacts = _build_from_spec_file(corpus, spec_path)
+        else:
+            # Modo quick: Networks.quick con min_weight propagado a cada spec.
+            try:
+                artifacts = Networks.quick(corpus, min_weight=min_weight)
+            except ImportError as exc:
+                raise DependencyError(
+                    f"Dependencia faltante para detectar comunidades: {exc}. "
+                    "Instalá python-louvain: uv add python-louvain."
+                ) from exc
 
         networks_info = _write_artifacts(artifacts, corpus, artifacts_dir)
 
+        # Diagnóstico de redes vacías en build-time.
+        # Reusa los reason/fix_command del preview (fuente única — ADR 0037 §(e)).
+        # Si el preview predijo no-vacía pero salió vacía, sospechamos min_weight.
+        empty_networks: list[dict[str, object]] = []
+        for art in artifacts:
+            kind_str = str(art.spec.kind)
+            is_empty = (
+                art.graph.number_of_nodes() == 0 or art.graph.number_of_edges() == 0
+            )
+            if not is_empty:
+                continue
+
+            preview_entry = preview_by_kind.get(kind_str)
+            if preview_entry and preview_entry["would_be_empty"]:
+                # Preview ya predijo vacía — usar su reason/fix_command (no-divergencia).
+                reason: str = (
+                    str(preview_entry["reason"])
+                    if preview_entry["reason"]
+                    else "Red vacía"
+                )
+                fix_cmd: str | None = (
+                    str(preview_entry["fix_command"])
+                    if preview_entry["fix_command"]
+                    else None
+                )
+            elif spec_path is None and min_weight > 1:
+                # Modo quick: el --min-weight del CLI filtró todas las aristas.
+                reason = f"0 aristas con peso ≥ {min_weight}; bajá --min-weight"
+                fix_cmd = f"b2g build --min-weight {min_weight - 1}"
+            elif spec_path is not None and art.spec.min_weight > 1:
+                # Modo spec: el min_weight del propio YAML filtró todas las aristas.
+                # El --min-weight de la CLI NO se usa en modo spec → no sugerir bajarlo.
+                reason = (
+                    f"0 aristas con peso ≥ {art.spec.min_weight} "
+                    f"(min_weight del spec '{kind_str}'); ajustá el spec"
+                )
+                fix_cmd = None
+            else:
+                # Caso inesperado: red vacía sin causa clara identificable.
+                reason = "Red vacía (sin datos suficientes)"
+                fix_cmd = None
+
+            empty_networks.append(
+                {"kind": kind_str, "reason": reason, "fix_command": fix_cmd}
+            )
+            # Los diagnósticos de red vacía van solo en data["empty_networks"].
+            # data["warnings"] queda reservado para avisos de corpus-scope
+            # (p. ej. "0 papers"); esto mantiene la compat con tests pre-0.10.0
+            # que verifican data["warnings"] == [] cuando el corpus no está vacío.
+
         # ADR 0029 — sellar con corpus_hash del corpus FILTRADO (no del vivo completo).
-        # Esto garantiza que el hash refleja exactamente lo que produjo las redes.
+        # D1: en AMBOS modos (quick y spec) transicionar + sellar (ADR 0038).
         from bib2graph.backends.memory import compute_corpus_hash
 
         corpus_hash = compute_corpus_hash(corpus.to_arrow())
@@ -261,13 +426,21 @@ def run_build(
     finally:
         store.close()
 
+    # FIX 2 — gancho para #160 (maturity): "scope" expone el token CLI tal como
+    # lo tipió el usuario ("seeds"/"accepted"/"all"), NO el vocab interno
+    # ("seeds_only"). Esto hace que la superficie de agents-first sea consistente.
+    # Cuando se llama sin CLI (tests unitarios directos), scope_cli_token=None
+    # y se usa corpus_scope como fallback (preserva compat pre-0.10.0).
+    scope_display = scope_cli_token if scope_cli_token is not None else corpus_scope
     return {
         "networks_built": len(artifacts),
         "artifacts_dir": str(artifacts_dir),
         "corpus_hash": corpus_hash,
         "corpus_scope": corpus_scope,
+        "scope": scope_display,
         "networks": networks_info,
         "warnings": build_warnings,
+        "empty_networks": empty_networks,
     }
 
 
@@ -286,17 +459,51 @@ def run_build(
     ),
 )
 @click.option(
-    "--corpus-scope",
-    "corpus_scope",
-    type=click.Choice(["all", "accepted", "seeds_only"]),
+    "--scope",
+    "scope",
+    type=click.Choice(["all", "accepted", "seeds"]),
     default="all",
     show_default=True,
     help=(
         "Filtra el corpus antes de construir las redes. "
-        "'all' = corpus completo (default, sin cambio de comportamiento); "
-        "'accepted' = semillas (is_seed=True) + papers aceptados por curación; "
-        "'seeds_only' = solo semillas (is_seed=True). "
+        "'all' = corpus completo (default); "
+        "'accepted' = semillas (is_seed=True) + papers aceptados; "
+        "'seeds' = solo semillas (is_seed=True). "
         "Si el scope deja 0 papers, termina con exit 0 y un warning accionable."
+    ),
+)
+@click.option(
+    "--corpus-scope",
+    "corpus_scope_deprecated",
+    type=click.Choice(["all", "accepted", "seeds_only"]),
+    default=None,
+    hidden=True,
+    help=(
+        "DEPRECATED (cierra en 0.11.0): usar --scope. "
+        "Acepta los valores antiguos all|accepted|seeds_only."
+    ),
+)
+@click.option(
+    "--spec",
+    "spec_path",
+    type=click.Path(exists=True, dir_okay=False),
+    default=None,
+    help=(
+        "Ruta al YAML con la especificación de redes. "
+        "Si se pasa, usa Networks.build por spec en lugar de Networks.quick. "
+        "Sigue transicionando a BUILT y sellando corpus_hash (D1)."
+    ),
+)
+@click.option(
+    "--min-weight",
+    "min_weight",
+    type=int,
+    default=1,
+    show_default=True,
+    help=(
+        "Peso mínimo de arista (default 1 = sin filtro). "
+        "Aristas con peso < N se descartan. "
+        "Solo aplica al modo quick (sin --spec); en modo spec el YAML lleva su propio min_weight."
     ),
 )
 @json_option
@@ -305,13 +512,18 @@ def run_build(
 def build_cmd(
     ctx: click.Context,
     out_dir: str | None,
-    corpus_scope: str,
+    scope: str,
+    corpus_scope_deprecated: str | None,
+    spec_path: str | None,
+    min_weight: int,
     json_output: bool,
 ) -> None:
-    """Computa las 4 redes con Networks.quick y escribe artefactos.
+    """Computa redes bibliométricas y escribe artefactos.
 
-    Tras el build, el estado del lazo transiciona a BUILT.
-    El directorio networks/ queda sellado con .corpus_hash del corpus filtrado.
+    Sin ``--spec``: usa Networks.quick (4-5 redes principales).
+    Con ``--spec``: carga el YAML y construye cada red con Networks.build.
+
+    En ambos modos transiciona a BUILT y sella networks/.corpus_hash.
     """
     # ADR 0029: usar networks_dir del workspace si no se especifica --out-dir
     ws = resolve_workspace(ctx.obj)
@@ -319,8 +531,38 @@ def build_cmd(
     if effective_out_dir is None:
         effective_out_dir = ws.networks_dir
 
+    # Resolver scope: --corpus-scope deprecado tiene prioridad con aviso.
+    if corpus_scope_deprecated is not None:
+        print(
+            "AVISO: --corpus-scope está deprecado y se eliminará en 0.11.0; "
+            "usá --scope en su lugar.",
+            file=sys.stderr,
+        )
+        # El vocab deprecado (all|accepted|seeds_only) ya es el vocab interno.
+        # Preservamos el mismo token para scope_cli_token (compat pre-0.10.0).
+        internal_scope = corpus_scope_deprecated
+        cli_token: str = corpus_scope_deprecated
+    else:
+        # El vocab nuevo (all|accepted|seeds) necesita mapeo para seeds→seeds_only.
+        internal_scope = _map_scope(scope)
+        # scope es el token tal como lo tipió el usuario ("seeds"/"accepted"/"all").
+        cli_token = scope
+
+    # FIX 1a — footgun: --min-weight se ignora en modo spec.
+    # Avisar explícitamente para no perder la intención del usuario en silencio.
+    if spec_path is not None and min_weight > 1:
+        print(
+            "--min-weight se ignora con --spec; cada red usa el min_weight de su YAML.",
+            file=sys.stderr,
+        )
+
     data = run_build(
-        ws.library_path, out_dir=effective_out_dir, corpus_scope=corpus_scope
+        ws.library_path,
+        out_dir=effective_out_dir,
+        corpus_scope=internal_scope,
+        spec_path=spec_path,
+        min_weight=min_weight,
+        scope_cli_token=cli_token,
     )
 
     if json_mode(json_output):
@@ -333,8 +575,16 @@ def build_cmd(
         )
         emit(envelope)
     else:
+        # Warnings van a stderr en modo humano (ADR 0021 §C; patrón de status.py).
         for w in data.get("warnings", []):
-            emit_human(f"ADVERTENCIA: {w}")
+            print(f"ADVERTENCIA: {w}", file=sys.stderr)
+        # Diagnósticos de redes vacías también a stderr (no son warnings de corpus).
+        for en in data.get("empty_networks", []):
+            fix = f" Sugerencia: {en['fix_command']}" if en.get("fix_command") else ""
+            print(
+                f"ADVERTENCIA: Red '{en['kind']}' vacía — {en['reason']}.{fix}",
+                file=sys.stderr,
+            )
         emit_human(f"Redes construidas: {data['networks_built']}")
         emit_human(f"Artefactos en: {data['artifacts_dir']}")
         emit_human(f"corpus_hash: {data['corpus_hash']}")

--- a/src/bib2graph/cli/commands/networks.py
+++ b/src/bib2graph/cli/commands/networks.py
@@ -18,6 +18,12 @@ Los artefactos se escriben en ``<out_dir>/<kind>/``:
 
 Envelope ``--json`` (schema="1"): lista de redes en el mismo formato que
 ``b2g build``.
+
+#159 — helper compartido:
+  ``run_networks`` delega la carga YAML y proyección a ``_build_from_spec_file``
+  (definido en ``build.py``).  Esto garantiza que ``build --spec`` y
+  ``networks --spec`` nunca diverjan, y que #165 pueda retirar ``networks``
+  sin reconciliar dos implementaciones.
 """
 
 from __future__ import annotations
@@ -28,10 +34,10 @@ from typing import Any
 import click
 
 from bib2graph.cli._envelope import build_envelope, emit, emit_human
-from bib2graph.cli._errors import DataError, DependencyError, handle_errors
+from bib2graph.cli._errors import handle_errors
 from bib2graph.cli._options import json_mode, json_option
 from bib2graph.cli._store import open_store, resolve_workspace
-from bib2graph.cli.commands.build import _write_artifacts
+from bib2graph.cli.commands.build import _build_from_spec_file, _write_artifacts
 
 # ---------------------------------------------------------------------------
 # Función núcleo (testeable, sin Click)
@@ -46,9 +52,9 @@ def run_networks(
 ) -> dict[str, Any]:
     """Construye redes bibliométricas desde una especificación YAML.
 
-    Carga ``spec_path`` con ``load_specs``, construye cada red con
-    ``Networks.build`` y escribe artefactos con el helper ``_write_artifacts``
-    (compartido con ``run_build``).
+    Carga ``spec_path`` con ``load_specs`` (vía ``_build_from_spec_file``),
+    construye cada red con ``Networks.build`` y escribe artefactos con el
+    helper ``_write_artifacts`` (compartido con ``run_build``).
 
     NO transiciona el ``CycleState`` ni sella ``.corpus_hash``:
     esta operación es transversal al lazo bibliométrico (igual que ``enrich``
@@ -68,9 +74,6 @@ def run_networks(
         DependencyError: Si falta ``python-louvain``.
         StoreError: Si el store está bloqueado.
     """
-    from bib2graph.networks.facade import Networks
-    from bib2graph.networks.spec import load_specs
-
     store = open_store(store_path)
     corpus = store.load()
 
@@ -80,18 +83,9 @@ def run_networks(
     else:
         artifacts_dir = Path(out_dir)
 
-    try:
-        specs = load_specs(spec_path)
-    except (ValueError, FileNotFoundError) as exc:
-        raise DataError(str(exc)) from exc
-
-    try:
-        artifacts = [Networks.build(corpus, spec) for spec in specs]
-    except ImportError as exc:
-        raise DependencyError(
-            f"Dependencia faltante para detectar comunidades: {exc}. "
-            "Instalá python-louvain: uv add python-louvain."
-        ) from exc
+    # Delegar carga YAML + proyección al helper compartido con build --spec.
+    # Levanta DataError (YAML inválido) o DependencyError (louvain faltante).
+    artifacts = _build_from_spec_file(corpus, spec_path)
 
     networks_info = _write_artifacts(artifacts, corpus, artifacts_dir)
 

--- a/src/bib2graph/networks/facade.py
+++ b/src/bib2graph/networks/facade.py
@@ -620,7 +620,7 @@ class Networks:
         return _build_artifact(corpus, spec)
 
     @staticmethod
-    def quick(corpus: Corpus) -> list[NetworkArtifact]:
+    def quick(corpus: Corpus, *, min_weight: int = 1) -> list[NetworkArtifact]:
         """Construye las redes principales con configuración razonable.
 
         Arma specs para: acoplamiento bibliográfico (full), co-autoría,
@@ -633,6 +633,9 @@ class Networks:
 
         Args:
             corpus: Corpus de origen.
+            min_weight: Peso mínimo de arista (#159 — ``build --min-weight``).
+                Default 1 = sin filtro (comportamiento anterior intacto).
+                Si es > 1, las aristas con peso < N se filtran en todas las redes.
 
         Returns:
             Lista de 4 o 5 ``NetworkArtifact`` (coupling, co-autoría,
@@ -651,5 +654,5 @@ class Networks:
                 "para proyectar con los citantes disponibles."
             )
 
-        specs = [NetworkSpec(kind=k) for k in kinds]
+        specs = [NetworkSpec(kind=k, min_weight=min_weight) for k in kinds]
         return [_build_artifact(corpus, spec) for spec in specs]

--- a/tests/unit/test_build_absorber_networks.py
+++ b/tests/unit/test_build_absorber_networks.py
@@ -1,0 +1,1122 @@
+"""Tests TDD — ``b2g build`` absorbe capacidad de ``b2g networks`` (#159).
+
+Cubre las decisiones y contratos del sub-issue #159 (ADR 0038):
+
+1. **Paridad**: ``build --spec YAML`` produce los mismos artefactos que
+   ``networks --spec`` para el mismo YAML.
+2. **D1**: ``build --spec`` transiciona FSM a BUILT y sella ``.corpus_hash``
+   (comportamiento deliberadamente distinto a ``networks``).
+3. **Scopes**: ``--scope all|accepted|seeds`` filtran el corpus y sellan el hash
+   del corpus filtrado.
+4. **Alias deprecado**: ``--corpus-scope seeds_only`` sigue funcionando y avisa
+   deprecación a stderr; no contamina stdout en ``--json``.
+5. **min-weight**: aristas con peso < N se filtran; red vacía → warning específico.
+6. **No-divergencia** (ADR 0037 §(e)): corpus sin ``keywords_id`` → ``build``
+   exit 0, warning ``reason``/``fix_command`` coincide con ``predict_build_preview``.
+7. **--json**: warning solo en envelope, stdout exactamente una línea JSON,
+   ``data.empty_networks`` presente cuando aplica, ``schema="1"``.
+
+Marcador: ``unit`` (DuckDB en tmp_path, sin red real).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pyarrow as pa
+import pytest
+
+from bib2graph.constants import NetworkKind
+from bib2graph.corpus import Corpus
+from bib2graph.schemas import CORPUS_SCHEMA
+
+pytestmark = pytest.mark.unit
+
+# ---------------------------------------------------------------------------
+# Helpers de fixture
+# ---------------------------------------------------------------------------
+
+
+def _row(
+    id: str,
+    *,
+    is_seed: bool = True,
+    curation_status: str = "candidate",
+    references_id: list[str] | None = None,
+    authors_id: list[str] | None = None,
+    institutions_id: list[str] | None = None,
+    keywords_id: list[str] | None = None,
+    keywords_raw: list[str] | None = None,
+    cited_by_id: list[str] | None = None,
+) -> dict[str, Any]:
+    """Fila mínima con schema canónico completo."""
+    return {
+        "id": id,
+        "source_id": None,
+        "doi": None,
+        "title": f"Paper {id}",
+        "year": 2020,
+        "abstract": None,
+        "source": None,
+        "language": None,
+        "publisher": None,
+        "research_areas": None,
+        "is_seed": is_seed,
+        "curation_status": curation_status,
+        "provenance": None,
+        "authors_raw": None,
+        "authors_id": authors_id,
+        "authors_affiliations": None,
+        "keywords_raw": keywords_raw,
+        "keywords_id": keywords_id,
+        "institutions_raw": None,
+        "institutions_id": institutions_id,
+        "references_id": references_id,
+        "references_doi": None,
+        "cited_by_id": cited_by_id,
+    }
+
+
+def _make_corpus(*rows: dict[str, Any]) -> Corpus:
+    """Construye un Corpus en memoria desde filas dict."""
+    table = pa.Table.from_pylist(list(rows), schema=CORPUS_SCHEMA)
+    return Corpus.from_arrow(table)
+
+
+def _seed_store(store_path: Path, rows: list[dict[str, Any]]) -> None:
+    """Persiste un conjunto de filas en un DuckDB temporal."""
+    from bib2graph.stores.duckdb import DuckDBStore
+
+    table = pa.Table.from_pylist(rows, schema=CORPUS_SCHEMA)
+    corpus = Corpus.from_arrow(table)
+    store = DuckDBStore(store_path)
+    store.persist(corpus)
+    store.close()
+
+
+def _rows_con_referencias() -> list[dict[str, Any]]:
+    """3 papers con referencias compartidas → produce aristas de coupling."""
+    return [
+        _row(
+            f"P{i}",
+            references_id=[f"REF_{i}", "REF_SHARED"],
+            authors_id=[f"AUTH_{i}", "AUTH_0"],
+            keywords_id=[f"KW_{i}", "KW_SHARED"],
+            institutions_id=[f"INST_{i}"],
+        )
+        for i in range(3)
+    ]
+
+
+def _write_spec(path: Path, kinds: list[str]) -> None:
+    """Escribe un YAML de specs para los kinds dados."""
+    lines = ["networks:"]
+    for k in kinds:
+        lines.append(f"  - kind: {k}")
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# 1. Paridad: build --spec ≡ networks --spec
+# ---------------------------------------------------------------------------
+
+
+class TestParidadBuildVsNetworks:
+    """build --spec y networks --spec deben producir los mismos artefactos."""
+
+    def test_paridad_artefactos_mismos_nodos_aristas(self, tmp_path: Path) -> None:
+        """build --spec y networks --spec con el mismo YAML → mismos nodos/aristas."""
+        from bib2graph.cli.commands.build import run_build
+        from bib2graph.cli.commands.networks import run_networks
+
+        store_path = tmp_path / "lib.duckdb"
+        _seed_store(store_path, _rows_con_referencias())
+
+        spec_file = tmp_path / "redes.yaml"
+        _write_spec(spec_file, ["bibliographic_coupling"])
+
+        out_build = tmp_path / "out_build"
+        out_nets = tmp_path / "out_nets"
+
+        data_build = run_build(store_path, out_dir=out_build, spec_path=spec_file)
+        data_nets = run_networks(store_path, spec_file, out_dir=out_nets)
+
+        # Misma cantidad de redes
+        assert data_build["networks_built"] == data_nets["networks_built"]
+
+        # Mismos nodos y aristas por red (mismo kind)
+        build_by_kind = {n["kind"]: n for n in data_build["networks"]}
+        nets_by_kind = {n["kind"]: n for n in data_nets["networks"]}
+
+        for kind in build_by_kind:
+            assert kind in nets_by_kind, f"kind '{kind}' falta en networks"
+            assert build_by_kind[kind]["nodes"] == nets_by_kind[kind]["nodes"], (
+                f"kind={kind}: nodos divergen"
+            )
+            assert build_by_kind[kind]["edges"] == nets_by_kind[kind]["edges"], (
+                f"kind={kind}: aristas divergen"
+            )
+
+    def test_paridad_multiples_redes(self, tmp_path: Path) -> None:
+        """Con 2 redes en el YAML, build --spec y networks --spec coinciden."""
+        from bib2graph.cli.commands.build import run_build
+        from bib2graph.cli.commands.networks import run_networks
+
+        store_path = tmp_path / "lib.duckdb"
+        _seed_store(store_path, _rows_con_referencias())
+
+        spec_file = tmp_path / "redes.yaml"
+        _write_spec(spec_file, ["bibliographic_coupling", "keyword_cooccurrence"])
+
+        data_build = run_build(store_path, out_dir=tmp_path / "b", spec_path=spec_file)
+        data_nets = run_networks(store_path, spec_file, out_dir=tmp_path / "n")
+
+        assert data_build["networks_built"] == data_nets["networks_built"] == 2
+        build_kinds = {n["kind"] for n in data_build["networks"]}
+        nets_kinds = {n["kind"] for n in data_nets["networks"]}
+        assert build_kinds == nets_kinds
+
+
+# ---------------------------------------------------------------------------
+# 2. D1: build --spec transiciona FSM a BUILT y sella corpus_hash
+# ---------------------------------------------------------------------------
+
+
+class TestD1BuildSpecTransiciona:
+    """D1 (ADR 0038): build --spec DEBE transicionar a BUILT y sellar hash."""
+
+    def test_build_spec_transiciona_a_built(self, tmp_path: Path) -> None:
+        """build --spec cambia el CycleState a BUILT."""
+        from bib2graph.cli.commands.build import run_build
+        from bib2graph.cycle import CycleState
+        from bib2graph.stores.duckdb import DuckDBStore
+
+        store_path = tmp_path / "lib.duckdb"
+        _seed_store(store_path, _rows_con_referencias())
+
+        spec_file = tmp_path / "redes.yaml"
+        _write_spec(spec_file, ["bibliographic_coupling"])
+
+        # Estado antes: None (store recién creado)
+        store_before = DuckDBStore(store_path)
+        state_before = store_before.backend.loop_state()
+        store_before.close()
+        assert state_before is None
+
+        run_build(store_path, out_dir=tmp_path / "nets", spec_path=spec_file)
+
+        # Estado después: BUILT
+        store_after = DuckDBStore(store_path)
+        state_after = store_after.backend.loop_state()
+        store_after.close()
+        assert state_after == CycleState.BUILT
+
+    def test_build_spec_sella_corpus_hash(self, tmp_path: Path) -> None:
+        """build --spec escribe .corpus_hash en el directorio de redes."""
+        from bib2graph.cli.commands.build import run_build
+
+        store_path = tmp_path / "lib.duckdb"
+        _seed_store(store_path, _rows_con_referencias())
+
+        spec_file = tmp_path / "redes.yaml"
+        _write_spec(spec_file, ["bibliographic_coupling"])
+
+        out_dir = tmp_path / "nets"
+        data = run_build(store_path, out_dir=out_dir, spec_path=spec_file)
+
+        hash_file = out_dir / ".corpus_hash"
+        assert hash_file.exists(), ".corpus_hash no fue creado"
+        assert hash_file.read_text(encoding="utf-8") == data["corpus_hash"]
+        assert len(data["corpus_hash"]) > 0
+
+    def test_networks_no_transiciona_fsm(self, tmp_path: Path) -> None:
+        """networks --spec NO transiciona el FSM (contraste con D1)."""
+        from bib2graph.cli.commands.networks import run_networks
+        from bib2graph.stores.duckdb import DuckDBStore
+
+        store_path = tmp_path / "lib.duckdb"
+        _seed_store(store_path, _rows_con_referencias())
+
+        spec_file = tmp_path / "redes.yaml"
+        _write_spec(spec_file, ["bibliographic_coupling"])
+
+        store_before = DuckDBStore(store_path)
+        state_before = store_before.backend.loop_state()
+        store_before.close()
+
+        run_networks(store_path, spec_file, out_dir=tmp_path / "nets")
+
+        store_after = DuckDBStore(store_path)
+        state_after = store_after.backend.loop_state()
+        store_after.close()
+
+        # networks NO debe cambiar el estado
+        assert state_after == state_before
+
+
+# ---------------------------------------------------------------------------
+# 3. Scopes --scope all|accepted|seeds
+# ---------------------------------------------------------------------------
+
+
+class TestScopes:
+    """Los 3 scopes filtran el corpus y sellan el hash del filtrado."""
+
+    def _setup_corpus(self, store_path: Path) -> None:
+        """P1=seed, P2=accepted no-seed, P3=candidate no-seed."""
+        _seed_store(
+            store_path,
+            [
+                _row(
+                    "P1",
+                    is_seed=True,
+                    curation_status="candidate",
+                    references_id=["R1", "R2"],
+                    keywords_id=["k1", "k2"],
+                ),
+                _row(
+                    "P2",
+                    is_seed=False,
+                    curation_status="accepted",
+                    references_id=["R1", "R3"],
+                    keywords_id=["k1", "k3"],
+                ),
+                _row(
+                    "P3",
+                    is_seed=False,
+                    curation_status="candidate",
+                    references_id=["R2", "R3"],
+                    keywords_id=["k2", "k3"],
+                ),
+            ],
+        )
+
+    def test_scope_all_usa_corpus_completo(self, tmp_path: Path) -> None:
+        """--scope all (default) construye sobre los 3 papers."""
+        from bib2graph.cli.commands.build import run_build
+
+        store_path = tmp_path / "lib.duckdb"
+        self._setup_corpus(store_path)
+
+        data = run_build(store_path, out_dir=tmp_path / "nets", corpus_scope="all")
+
+        assert data["corpus_scope"] == "all"
+        assert data["scope"] == "all"
+        # Hay 3 papers con keywords_id → kw_cooccurrence debería tener nodos
+        kw_net = next(
+            (n for n in data["networks"] if n["kind"] == "keyword_cooccurrence"), None
+        )
+        assert kw_net is not None
+        assert kw_net["nodes"] == 3, "scope=all debe incluir los 3 papers"
+
+    def test_scope_accepted_filtra_seeds_y_aceptados(self, tmp_path: Path) -> None:
+        """--scope accepted excluye candidatos no-seed (P3)."""
+        from bib2graph.cli.commands.build import run_build
+
+        store_path = tmp_path / "lib.duckdb"
+        self._setup_corpus(store_path)
+
+        data = run_build(store_path, out_dir=tmp_path / "nets", corpus_scope="accepted")
+
+        assert data["corpus_scope"] == "accepted"
+        # Keyword net: nodos son keywords (k1,k2,k3 únicos en P1+P2+P3).
+        # Con scope=accepted solo P1(k1,k2) y P2(k1,k3) → se excluye P3(k2,k3).
+        # La diferencia observable es en ARISTAS: P3 aporta la arista (k2,k3);
+        # sin P3, quedan solo 2 aristas: (k1,k2) de P1 y (k1,k3) de P2.
+        kw_net = next(
+            (n for n in data["networks"] if n["kind"] == "keyword_cooccurrence"), None
+        )
+        assert kw_net is not None
+        assert kw_net["edges"] == 2, (
+            "scope=accepted excluye P3 (candidate): debe tener 2 aristas, no 3"
+        )
+
+    def test_scope_seeds_filtra_solo_semillas(self, tmp_path: Path) -> None:
+        """--scope seeds deja solo P1 (is_seed=True)."""
+        from bib2graph.cli.commands.build import run_build
+
+        store_path = tmp_path / "lib.duckdb"
+        self._setup_corpus(store_path)
+
+        data = run_build(
+            store_path, out_dir=tmp_path / "nets", corpus_scope="seeds_only"
+        )
+
+        assert data["corpus_scope"] == "seeds_only"
+        # Keyword net: solo P1 → 2 nodos de keywords (k1, k2 en combinaciones)
+        kw_net = next(
+            (n for n in data["networks"] if n["kind"] == "keyword_cooccurrence"), None
+        )
+        assert kw_net is not None
+        # P1 tiene kw_id=[k1, k2] → 2 nodos de keyword con 1 arista
+        assert kw_net["nodes"] == 2
+
+    def test_scope_sella_hash_del_corpus_filtrado(self, tmp_path: Path) -> None:
+        """El .corpus_hash sellado es el hash del subset filtrado, no del completo."""
+        from bib2graph.backends.memory import compute_corpus_hash
+        from bib2graph.cli.commands.build import run_build
+        from bib2graph.stores.duckdb import DuckDBStore
+
+        store_path = tmp_path / "lib.duckdb"
+        self._setup_corpus(store_path)
+
+        out_dir = tmp_path / "nets"
+        data = run_build(store_path, out_dir=out_dir, corpus_scope="accepted")
+
+        # Calcular el hash esperado del subset accepted
+        store = DuckDBStore(store_path)
+        corpus_full = store.load()
+        subset = corpus_full.scoped("accepted")
+        store.close()
+
+        expected_hash = compute_corpus_hash(subset.to_arrow())
+        assert data["corpus_hash"] == expected_hash
+
+        hash_file = out_dir / ".corpus_hash"
+        assert hash_file.read_text(encoding="utf-8") == expected_hash
+
+    def test_map_scope_seeds_a_seeds_only(self) -> None:
+        """_map_scope mapea 'seeds' → 'seeds_only'; otros valores pasan sin cambio."""
+        from bib2graph.cli.commands.build import _map_scope
+
+        assert _map_scope("seeds") == "seeds_only"
+        assert _map_scope("all") == "all"
+        assert _map_scope("accepted") == "accepted"
+
+
+# ---------------------------------------------------------------------------
+# 4. Alias deprecado: --corpus-scope
+# ---------------------------------------------------------------------------
+
+
+class TestAliasDeprecado:
+    """--corpus-scope funciona con aviso de deprecación; no contamina stdout en --json."""
+
+    def test_alias_deprecado_cli_avisa_a_stderr(self, tmp_path: Path) -> None:
+        """--corpus-scope emite aviso de deprecación a stderr."""
+        from click.testing import CliRunner
+
+        from bib2graph.cli import b2g
+        from bib2graph.workspace import Workspace
+
+        ws_dir = tmp_path / "ws"
+        ws = Workspace.init(ws_dir, "test")
+        _seed_store(ws.library_path, _rows_con_referencias())
+
+        runner = CliRunner()
+        result = runner.invoke(
+            b2g,
+            [
+                "--workspace",
+                str(ws_dir),
+                "build",
+                "--corpus-scope",
+                "seeds_only",
+            ],
+        )
+
+        assert result.exit_code == 0, f"Salida inesperada: {result.output}"
+        assert "deprecad" in result.stderr.lower(), "Debe avisar deprecación en stderr"
+
+    def test_alias_deprecado_no_contamina_stdout_json(self, tmp_path: Path) -> None:
+        """--corpus-scope con --json: el aviso va a stderr, stdout es JSON puro."""
+        from click.testing import CliRunner
+
+        from bib2graph.cli import b2g
+        from bib2graph.workspace import Workspace
+
+        ws_dir = tmp_path / "ws"
+        ws = Workspace.init(ws_dir, "test")
+        _seed_store(ws.library_path, _rows_con_referencias())
+
+        runner = CliRunner()
+        result = runner.invoke(
+            b2g,
+            [
+                "--workspace",
+                str(ws_dir),
+                "build",
+                "--corpus-scope",
+                "seeds_only",
+                "--json",
+            ],
+        )
+
+        assert result.exit_code == 0, f"Error: {result.output}"
+
+        # stdout (result.stdout) debe ser exactamente 1 línea JSON válida.
+        # Click 8.4.1: result.stdout = stdout puro; result.stderr = stderr puro.
+        stdout_lines = [line for line in result.stdout.splitlines() if line.strip()]
+        assert len(stdout_lines) == 1, (
+            f"stdout debe tener exactamente 1 línea JSON, tiene {len(stdout_lines)}: "
+            f"{result.stdout!r}"
+        )
+        envelope = json.loads(stdout_lines[0])
+        assert envelope["schema"] == "1"
+
+        # El aviso de deprecación va a stderr, no a stdout
+        assert "deprecad" in result.stderr.lower()
+
+    def test_alias_deprecado_seeds_only_funciona(self, tmp_path: Path) -> None:
+        """--corpus-scope seeds_only filtra correctamente (backward compat)."""
+        from bib2graph.cli.commands.build import run_build
+
+        store_path = tmp_path / "lib.duckdb"
+        # 2 seeds + 1 non-seed
+        _seed_store(
+            store_path,
+            [
+                _row("S1", is_seed=True, keywords_id=["k1", "k2"]),
+                _row("S2", is_seed=True, keywords_id=["k1", "k3"]),
+                _row("C1", is_seed=False, keywords_id=["k2", "k4"]),
+            ],
+        )
+
+        data = run_build(
+            store_path, out_dir=tmp_path / "nets", corpus_scope="seeds_only"
+        )
+
+        assert data["corpus_scope"] == "seeds_only"
+        kw_net = next(
+            (n for n in data["networks"] if n["kind"] == "keyword_cooccurrence"), None
+        )
+        # Solo seeds (S1, S2) → keyword nodes de k1, k2, k3 (3 nodos, no k4)
+        assert kw_net is not None
+        assert kw_net["nodes"] <= 3, "Solo keywords de seeds deben aparecer"
+
+
+# ---------------------------------------------------------------------------
+# 5. --min-weight: filtrado de aristas + warning específico
+# ---------------------------------------------------------------------------
+
+
+class TestMinWeight:
+    """--min-weight N filtra aristas; red vacía → warning específico de min_weight."""
+
+    def test_min_weight_1_default_sin_filtro(self, tmp_path: Path) -> None:
+        """min_weight=1 (default) no filtra nada."""
+        from bib2graph.cli.commands.build import run_build
+
+        store_path = tmp_path / "lib.duckdb"
+        _seed_store(store_path, _rows_con_referencias())
+
+        data_mw1 = run_build(store_path, out_dir=tmp_path / "nets1", min_weight=1)
+        data_default = run_build(store_path, out_dir=tmp_path / "nets2")
+
+        # Con min_weight=1 debe ser idéntico al default
+        assert data_mw1["networks_built"] == data_default["networks_built"]
+
+    def test_min_weight_alto_produce_redes_vacias(self, tmp_path: Path) -> None:
+        """min_weight=999 filtra todas las aristas → redes vacías con warning."""
+        from bib2graph.cli.commands.build import run_build
+
+        store_path = tmp_path / "lib.duckdb"
+        # Corpus con referencias compartidas (peso 1 por par)
+        _seed_store(store_path, _rows_con_referencias())
+
+        data = run_build(store_path, out_dir=tmp_path / "nets", min_weight=999)
+
+        # Debe haber redes vacías
+        assert any(
+            en.get("reason") and "999" in str(en["reason"])
+            for en in data["empty_networks"]
+        ), (
+            f"Esperaba warning de min_weight=999, empty_networks={data['empty_networks']}"
+        )
+
+    def test_min_weight_warning_reason_contiene_umbral(self, tmp_path: Path) -> None:
+        """El reason del warning de min_weight menciona el umbral N."""
+        from bib2graph.cli.commands.build import run_build
+
+        store_path = tmp_path / "lib.duckdb"
+        _seed_store(store_path, _rows_con_referencias())
+
+        data = run_build(store_path, out_dir=tmp_path / "nets", min_weight=50)
+
+        min_weight_warnings = [
+            en for en in data["empty_networks"] if "50" in str(en.get("reason", ""))
+        ]
+        # Debe haber al menos 1 red vacía con el umbral mencionado
+        assert len(min_weight_warnings) >= 1, (
+            f"Esperaba warning de min_weight=50, "
+            f"empty_networks={data['empty_networks']}"
+        )
+
+    def test_min_weight_quick_extiende_networkspec(self, tmp_path: Path) -> None:
+        """Networks.quick con min_weight pasa el valor a NetworkSpec."""
+        from bib2graph.networks.facade import Networks
+
+        corpus = _make_corpus(*_rows_con_referencias())
+        # min_weight=999 → todas las aristas filtradas
+        artifacts_999 = Networks.quick(corpus, min_weight=999)
+        # Verificar que el spec tiene min_weight=999
+        for art in artifacts_999:
+            assert art.spec.min_weight == 999
+
+    def test_min_weight_fix_command_baja_umbral(self, tmp_path: Path) -> None:
+        """El fix_command sugiere un umbral menor (min_weight - 1)."""
+        from bib2graph.cli.commands.build import run_build
+
+        store_path = tmp_path / "lib.duckdb"
+        _seed_store(store_path, _rows_con_referencias())
+
+        data = run_build(store_path, out_dir=tmp_path / "nets", min_weight=10)
+
+        for en in data["empty_networks"]:
+            if "10" in str(en.get("reason", "")):
+                assert en["fix_command"] is not None
+                assert "9" in str(en["fix_command"]), (
+                    f"fix_command debe sugerir min-weight=9, got: {en['fix_command']}"
+                )
+                break
+
+
+# ---------------------------------------------------------------------------
+# 6. No-divergencia: build-time ≡ status-time (ADR 0037 §(e))
+# ---------------------------------------------------------------------------
+
+
+class TestNoDivergencia:
+    """La razón/fix de redes vacías en build-time coincide con predict_build_preview.
+
+    NOTA sobre alcance de la no-divergencia (opcional, ADR 0037 §(e)):
+    La paridad build-vs-status es *por-corpus*. Cuando se usa ``--scope != all``,
+    ``run_build`` computa ``predict_build_preview`` sobre el corpus YA FILTRADO.
+    Esto es correcto: si status se llama sobre el corpus completo y build se llama
+    sobre un subset (accepted/seeds), los conteos en los ``reason`` pueden diferir
+    legítimamente. La invariante garantizada es que para el MISMO corpus, build y
+    status reportan el mismo reason/fix_command — no que coincidan cross-scope.
+    """
+
+    def test_keyword_warning_coincide_con_preview(self, tmp_path: Path) -> None:
+        """Corpus sin keywords_id → warning reason/fix_command == predict_build_preview."""
+        from bib2graph.cli.commands.build import run_build
+        from bib2graph.networks.facade import predict_build_preview
+        from bib2graph.stores.duckdb import DuckDBStore
+
+        store_path = tmp_path / "lib.duckdb"
+        # BibTeX sin --resolve: keywords_raw poblado, keywords_id vacío
+        rows = [
+            _row(f"P{i}", keywords_raw=["ecology", "diversity"]) for i in range(1, 5)
+        ]
+        _seed_store(store_path, rows)
+
+        data = run_build(store_path, out_dir=tmp_path / "nets")
+
+        # Obtener preview (como lo haría status)
+        store2 = DuckDBStore(store_path)
+        corpus2 = store2.load()
+        preview = predict_build_preview(corpus2)
+        store2.close()
+
+        kw_preview = next(
+            e for e in preview if e["kind"] == str(NetworkKind.KEYWORD_COOCCURRENCE)
+        )
+
+        # Encontrar la entrada de empty_networks para keyword_cooccurrence
+        kw_empty = next(
+            (
+                e
+                for e in data["empty_networks"]
+                if e["kind"] == str(NetworkKind.KEYWORD_COOCCURRENCE)
+            ),
+            None,
+        )
+
+        assert kw_empty is not None, (
+            "keyword_cooccurrence debe estar en empty_networks "
+            f"(corpus sin keywords_id); empty_networks={data['empty_networks']}"
+        )
+        assert kw_empty["reason"] == kw_preview["reason"], (
+            f"build-time reason != status-time reason: "
+            f"'{kw_empty['reason']}' != '{kw_preview['reason']}'"
+        )
+        assert kw_empty["fix_command"] == kw_preview["fix_command"], (
+            f"build-time fix_command != status-time fix_command: "
+            f"'{kw_empty['fix_command']}' != '{kw_preview['fix_command']}'"
+        )
+
+    def test_build_exit_0_con_redes_vacias(self, tmp_path: Path) -> None:
+        """build con redes vacías termina con exit 0 (no error), warnings en data."""
+        from bib2graph.cli.commands.build import run_build
+
+        store_path = tmp_path / "lib.duckdb"
+        # Sin ningún _id: todas las redes vacías
+        rows = [_row(f"P{i}") for i in range(1, 4)]
+        _seed_store(store_path, rows)
+
+        # No debe lanzar excepción
+        data = run_build(store_path, out_dir=tmp_path / "nets")
+
+        # networks_built > 0 (quick sí construye redes, aunque vacías)
+        assert data["networks_built"] >= 1
+        # Pero hay empty_networks
+        assert len(data["empty_networks"]) > 0
+
+
+# ---------------------------------------------------------------------------
+# 7. --json: stdout puro, envelope, data.empty_networks
+# ---------------------------------------------------------------------------
+
+
+class TestJsonOutput:
+    """--json: stdout una línea JSON, warnings en envelope, data.empty_networks."""
+
+    def test_json_stdout_una_sola_linea(self, tmp_path: Path) -> None:
+        """--json: stdout es exactamente 1 línea JSON (stdout puro, ADR 0021 §C)."""
+        from click.testing import CliRunner
+
+        from bib2graph.cli import b2g
+        from bib2graph.workspace import Workspace
+
+        ws_dir = tmp_path / "ws"
+        ws = Workspace.init(ws_dir, "test")
+        _seed_store(ws.library_path, _rows_con_referencias())
+
+        runner = CliRunner()
+        result = runner.invoke(
+            b2g,
+            ["--workspace", str(ws_dir), "build", "--json"],
+        )
+
+        assert result.exit_code == 0, f"Error: {result.output}"
+        # result.stdout = solo stdout (Click 8.4.1 separa stdout/stderr).
+        # En modo --json no hay prints a stderr (warnings van en envelope.warnings).
+        stdout_lines = [line for line in result.stdout.splitlines() if line.strip()]
+        assert len(stdout_lines) == 1, (
+            f"stdout debe tener exactamente 1 línea JSON, tiene {len(stdout_lines)}: "
+            f"{result.stdout!r}"
+        )
+        # Debe ser JSON válido
+        json.loads(stdout_lines[0])
+
+    def test_json_schema_1(self, tmp_path: Path) -> None:
+        """--json: envelope tiene schema='1'."""
+        from click.testing import CliRunner
+
+        from bib2graph.cli import b2g
+        from bib2graph.workspace import Workspace
+
+        ws_dir = tmp_path / "ws"
+        ws = Workspace.init(ws_dir, "test")
+        _seed_store(ws.library_path, _rows_con_referencias())
+
+        runner = CliRunner()
+        result = runner.invoke(
+            b2g,
+            ["--workspace", str(ws_dir), "build", "--json"],
+        )
+
+        assert result.exit_code == 0
+        envelope = json.loads(result.output)
+        assert envelope["schema"] == "1"
+        assert envelope["ok"] is True
+        assert envelope["command"] == "build"
+
+    def test_json_empty_networks_en_data(self, tmp_path: Path) -> None:
+        """Cuando hay redes vacías, data.empty_networks está en el envelope JSON."""
+        from click.testing import CliRunner
+
+        from bib2graph.cli import b2g
+        from bib2graph.workspace import Workspace
+
+        ws_dir = tmp_path / "ws"
+        ws = Workspace.init(ws_dir, "test")
+        # Sin _id: redes vacías
+        rows = [_row(f"P{i}") for i in range(1, 4)]
+        _seed_store(ws.library_path, rows)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            b2g,
+            ["--workspace", str(ws_dir), "build", "--json"],
+        )
+
+        assert result.exit_code == 0
+        envelope = json.loads(result.output)
+
+        # empty_networks debe estar en data
+        assert "empty_networks" in envelope["data"], (
+            "data.empty_networks debe estar presente cuando hay redes vacías"
+        )
+        assert len(envelope["data"]["empty_networks"]) > 0
+
+        # Cada entrada de empty_networks tiene kind, reason, fix_command
+        for en in envelope["data"]["empty_networks"]:
+            assert "kind" in en
+            assert "reason" in en
+            assert "fix_command" in en
+
+    def test_json_warnings_en_envelope_no_en_stdout(self, tmp_path: Path) -> None:
+        """Warnings van solo en envelope.warnings, NUNCA como línea extra en stdout."""
+        from click.testing import CliRunner
+
+        from bib2graph.cli import b2g
+        from bib2graph.workspace import Workspace
+
+        ws_dir = tmp_path / "ws"
+        ws = Workspace.init(ws_dir, "test")
+        rows = [_row(f"P{i}") for i in range(1, 4)]
+        _seed_store(ws.library_path, rows)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            b2g,
+            ["--workspace", str(ws_dir), "build", "--json"],
+        )
+
+        assert result.exit_code == 0
+
+        # stdout puro (result.stdout) debe ser 1 línea JSON.
+        # Warnings van en envelope.warnings (no prints sueltos a stdout en JSON mode).
+        stdout_lines = [line for line in result.stdout.splitlines() if line.strip()]
+        assert len(stdout_lines) == 1
+
+        envelope = json.loads(stdout_lines[0])
+        # Los warnings están en el envelope, no sueltos en stdout
+        assert isinstance(envelope.get("warnings"), list)
+
+    def test_json_data_tiene_scope_y_corpus_scope(self, tmp_path: Path) -> None:
+        """data incluye 'scope' (nuevo) y 'corpus_scope' (backward compat)."""
+        from click.testing import CliRunner
+
+        from bib2graph.cli import b2g
+        from bib2graph.workspace import Workspace
+
+        ws_dir = tmp_path / "ws"
+        ws = Workspace.init(ws_dir, "test")
+        _seed_store(ws.library_path, _rows_con_referencias())
+
+        runner = CliRunner()
+        result = runner.invoke(
+            b2g,
+            ["--workspace", str(ws_dir), "build", "--json"],
+        )
+
+        assert result.exit_code == 0
+        envelope = json.loads(result.output)
+        assert "scope" in envelope["data"], "data debe tener clave 'scope'"
+        assert "corpus_scope" in envelope["data"], (
+            "data debe tener clave 'corpus_scope' (compat)"
+        )
+
+    def test_build_spec_json_envelope_correcto(self, tmp_path: Path) -> None:
+        """build --spec --json emite envelope con schema='1' y claves de build."""
+        from click.testing import CliRunner
+
+        from bib2graph.cli import b2g
+        from bib2graph.workspace import Workspace
+
+        ws_dir = tmp_path / "ws"
+        ws = Workspace.init(ws_dir, "test")
+        _seed_store(ws.library_path, _rows_con_referencias())
+
+        spec_file = tmp_path / "redes.yaml"
+        _write_spec(spec_file, ["bibliographic_coupling"])
+
+        runner = CliRunner()
+        result = runner.invoke(
+            b2g,
+            [
+                "--workspace",
+                str(ws_dir),
+                "build",
+                "--spec",
+                str(spec_file),
+                "--json",
+            ],
+        )
+
+        assert result.exit_code == 0, f"Error: {result.output}"
+        envelope = json.loads(result.output)
+
+        assert envelope["schema"] == "1"
+        assert envelope["ok"] is True
+        assert envelope["command"] == "build"
+        assert envelope["exit_code"] == 0
+        assert "networks_built" in envelope["data"]
+        assert "corpus_hash" in envelope["data"]
+        assert envelope["data"]["networks_built"] == 1
+
+    def test_scope_seeds_cli_json(self, tmp_path: Path) -> None:
+        """--scope seeds via CLI en modo --json produce scope correcto en data."""
+        from click.testing import CliRunner
+
+        from bib2graph.cli import b2g
+        from bib2graph.workspace import Workspace
+
+        ws_dir = tmp_path / "ws"
+        ws = Workspace.init(ws_dir, "test")
+        rows = [
+            _row("S1", is_seed=True, keywords_id=["k1", "k2"]),
+            _row("C1", is_seed=False, keywords_id=["k3", "k4"]),
+        ]
+        _seed_store(ws.library_path, rows)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            b2g,
+            ["--workspace", str(ws_dir), "build", "--scope", "seeds", "--json"],
+        )
+
+        assert result.exit_code == 0, f"Error: {result.output}"
+        envelope = json.loads(result.output)
+        # corpus_scope = vocab interno (backward compat)
+        assert envelope["data"]["corpus_scope"] == "seeds_only"
+        # scope = token CLI tal como lo tipió el usuario (FIX 2 — gancho #160)
+        assert envelope["data"]["scope"] == "seeds"
+
+
+# ---------------------------------------------------------------------------
+# 8. FIX 1: --min-weight + --spec footgun; FIX 2: data["scope"] = token CLI
+# ---------------------------------------------------------------------------
+
+
+class TestFix1MinWeightSpec:
+    """FIX 1: --min-weight se ignora silenciosamente en modo --spec → avisar + diagnosticar bien."""
+
+    def test_spec_mas_min_weight_avisa_a_stderr(self, tmp_path: Path) -> None:
+        """--spec + --min-weight N>1 emite aviso a stderr; stdout sigue siendo JSON puro."""
+        from click.testing import CliRunner
+
+        from bib2graph.cli import b2g
+        from bib2graph.workspace import Workspace
+
+        ws_dir = tmp_path / "ws"
+        ws = Workspace.init(ws_dir, "test")
+        _seed_store(ws.library_path, _rows_con_referencias())
+
+        spec_file = tmp_path / "redes.yaml"
+        _write_spec(spec_file, ["bibliographic_coupling"])
+
+        runner = CliRunner()
+        result = runner.invoke(
+            b2g,
+            [
+                "--workspace",
+                str(ws_dir),
+                "build",
+                "--spec",
+                str(spec_file),
+                "--min-weight",
+                "5",
+                "--json",
+            ],
+        )
+
+        assert result.exit_code == 0, f"Error: {result.output}"
+
+        # stderr debe contener el aviso de que --min-weight se ignora con --spec
+        assert "ignora" in result.stderr.lower(), (
+            f"Esperaba aviso 'ignora' en stderr; stderr={result.stderr!r}"
+        )
+        assert "spec" in result.stderr.lower()
+
+        # stdout debe ser exactamente 1 línea JSON válida (sin contaminar)
+        stdout_lines = [line for line in result.stdout.splitlines() if line.strip()]
+        assert len(stdout_lines) == 1, (
+            f"stdout debe ser 1 línea JSON, tiene {len(stdout_lines)}: {result.stdout!r}"
+        )
+        json.loads(stdout_lines[0])
+
+    def test_spec_red_vacia_por_min_weight_del_yaml_reason_honesto(
+        self, tmp_path: Path
+    ) -> None:
+        """Red vacía en modo spec por min_weight del YAML → reason del spec, no del CLI.
+
+        El reason debe mencionar el min_weight del propio spec, NO sugerir
+        `--min-weight` de la CLI (que en modo spec no hace nada).
+        """
+        from bib2graph.cli.commands.build import run_build
+
+        store_path = tmp_path / "lib.duckdb"
+        # Corpus con referencias compartidas → preview dice "no vacía"
+        _seed_store(store_path, _rows_con_referencias())
+
+        # Spec con min_weight muy alto para forzar red vacía
+        spec_lines = [
+            "networks:",
+            "  - kind: bibliographic_coupling",
+            "    min_weight: 999",
+        ]
+        spec_file = tmp_path / "alto_umbral.yaml"
+        spec_file.write_text("\n".join(spec_lines) + "\n", encoding="utf-8")
+
+        data = run_build(store_path, out_dir=tmp_path / "nets", spec_path=spec_file)
+
+        bc_empty = next(
+            (
+                en
+                for en in data["empty_networks"]
+                if en["kind"] == str(NetworkKind.BIBLIOGRAPHIC_COUPLING)
+            ),
+            None,
+        )
+
+        assert bc_empty is not None, (
+            f"bibliographic_coupling debe estar en empty_networks; "
+            f"empty_networks={data['empty_networks']}"
+        )
+
+        # El reason debe mencionar el min_weight del spec (999), no el --min-weight CLI
+        assert "999" in str(bc_empty["reason"]), (
+            f"reason debe mencionar 999 (min_weight del spec); reason={bc_empty['reason']!r}"
+        )
+        assert "spec" in str(bc_empty["reason"]).lower(), (
+            f"reason debe mencionar 'spec'; reason={bc_empty['reason']!r}"
+        )
+
+        # fix_command DEBE ser None: --min-weight de la CLI no aplica en modo spec
+        assert bc_empty["fix_command"] is None, (
+            f"fix_command debe ser None en modo spec (CLI --min-weight no aplica); "
+            f"fix_command={bc_empty['fix_command']!r}"
+        )
+
+        # Verificación negativa: el reason NO debe sugerir `--min-weight` del CLI
+        assert "--min-weight" not in str(bc_empty["reason"]), (
+            f"reason no debe mencionar '--min-weight' del CLI en modo spec; "
+            f"reason={bc_empty['reason']!r}"
+        )
+
+    def test_spec_red_vacia_fix_command_no_es_min_weight_cli(
+        self, tmp_path: Path
+    ) -> None:
+        """En modo spec, el fix_command de una red vacía NUNCA es 'b2g build --min-weight N'."""
+        from bib2graph.cli.commands.build import run_build
+
+        store_path = tmp_path / "lib.duckdb"
+        _seed_store(store_path, _rows_con_referencias())
+
+        spec_lines = [
+            "networks:",
+            "  - kind: bibliographic_coupling",
+            "    min_weight: 999",
+        ]
+        spec_file = tmp_path / "alto.yaml"
+        spec_file.write_text("\n".join(spec_lines) + "\n", encoding="utf-8")
+
+        # Incluso si el usuario pasó --min-weight (ignorado en spec mode),
+        # el fix_command no debe sugerir bajarlo
+        data = run_build(
+            store_path,
+            out_dir=tmp_path / "nets",
+            spec_path=spec_file,
+            min_weight=5,  # ignorado en spec mode, pero presente en la firma
+        )
+
+        for en in data["empty_networks"]:
+            fix = en.get("fix_command")
+            if fix is not None:
+                assert "b2g build --min-weight" not in str(fix), (
+                    f"fix_command en modo spec no debe sugerir --min-weight CLI: {fix!r}"
+                )
+
+
+class TestFix2ScopeCliToken:
+    """FIX 2: data['scope'] expone el token CLI, no el vocab interno."""
+
+    def test_scope_seeds_cli_token_en_data(self, tmp_path: Path) -> None:
+        """--scope seeds → data['scope']='seeds' (token CLI), corpus_scope='seeds_only' (interno)."""
+        from click.testing import CliRunner
+
+        from bib2graph.cli import b2g
+        from bib2graph.workspace import Workspace
+
+        ws_dir = tmp_path / "ws"
+        ws = Workspace.init(ws_dir, "test")
+        _seed_store(
+            ws.library_path,
+            [
+                _row("S1", is_seed=True, references_id=["R1", "R2"]),
+                _row("C1", is_seed=False, references_id=["R1", "R3"]),
+            ],
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(
+            b2g,
+            ["--workspace", str(ws_dir), "build", "--scope", "seeds", "--json"],
+        )
+
+        assert result.exit_code == 0, f"Error: {result.output}"
+        envelope = json.loads(result.stdout)
+
+        # scope = token CLI
+        assert envelope["data"]["scope"] == "seeds", (
+            f"data['scope'] debe ser 'seeds' (token CLI), no 'seeds_only'; "
+            f"got {envelope['data']['scope']!r}"
+        )
+        # corpus_scope = vocab interno (backward compat)
+        assert envelope["data"]["corpus_scope"] == "seeds_only"
+
+    def test_scope_accepted_cli_token_en_data(self, tmp_path: Path) -> None:
+        """--scope accepted → data['scope']='accepted' (idéntico en ambos vocabs)."""
+        from click.testing import CliRunner
+
+        from bib2graph.cli import b2g
+        from bib2graph.workspace import Workspace
+
+        ws_dir = tmp_path / "ws"
+        ws = Workspace.init(ws_dir, "test")
+        _seed_store(ws.library_path, _rows_con_referencias())
+
+        runner = CliRunner()
+        result = runner.invoke(
+            b2g,
+            ["--workspace", str(ws_dir), "build", "--scope", "accepted", "--json"],
+        )
+
+        assert result.exit_code == 0
+        envelope = json.loads(result.stdout)
+        assert envelope["data"]["scope"] == "accepted"
+        assert envelope["data"]["corpus_scope"] == "accepted"
+
+    def test_scope_directo_run_build_sin_cli_token_backward_compat(
+        self, tmp_path: Path
+    ) -> None:
+        """run_build() directamente sin scope_cli_token → data['scope'] = corpus_scope (compat)."""
+        from bib2graph.cli.commands.build import run_build
+
+        store_path = tmp_path / "lib.duckdb"
+        _seed_store(store_path, _rows_con_referencias())
+
+        # Llamada directa sin scope_cli_token (tests pre-0.10.0)
+        data = run_build(
+            store_path, out_dir=tmp_path / "nets", corpus_scope="seeds_only"
+        )
+
+        # Backward compat: sin token CLI, scope == corpus_scope
+        assert data["corpus_scope"] == "seeds_only"
+        assert data["scope"] == "seeds_only"
+
+    def test_scope_alias_deprecado_preserva_vocab_interno(self, tmp_path: Path) -> None:
+        """--corpus-scope seeds_only (deprecado) → data['scope']='seeds_only' (mismo vocab)."""
+        from click.testing import CliRunner
+
+        from bib2graph.cli import b2g
+        from bib2graph.workspace import Workspace
+
+        ws_dir = tmp_path / "ws"
+        ws = Workspace.init(ws_dir, "test")
+        _seed_store(ws.library_path, _rows_con_referencias())
+
+        runner = CliRunner()
+        result = runner.invoke(
+            b2g,
+            [
+                "--workspace",
+                str(ws_dir),
+                "build",
+                "--corpus-scope",
+                "seeds_only",
+                "--json",
+            ],
+        )
+
+        assert result.exit_code == 0
+        envelope = json.loads(result.stdout)
+        # El alias deprecado usa el vocab interno tal cual (no hay nuevo token)
+        assert envelope["data"]["scope"] == "seeds_only"
+        assert envelope["data"]["corpus_scope"] == "seeds_only"


### PR DESCRIPTION
Closes #159. Sub-issue del epic #167 (superficie CLI 0.10.0, ADR 0037 a/e + 0038). Camino crítico.

## Qué
- **`build` absorbe `networks`** vía `build --spec YAML` (modo declarativo); el one-shot (`build` sin `--spec` = `Networks.quick`) se conserva. Helper compartido `_build_from_spec_file` = fuente única para `build --spec` y `networks` (prepara el retiro de `networks` en #165).
- **`build --spec` transiciona el FSM a BUILT y sella `.corpus_hash`** (paso BUILD pleno, decisión PO **D1**); `networks` sigue ortogonal hasta #165.
- **`--scope all|accepted|seeds`** (default `all`, ADR 0038 P2). `--corpus-scope ... seeds_only` → **alias deprecado oculto** (avisa a stderr; ventana cierra 0.11.0).
- **`--min-weight N`** filtra aristas; solo en modo quick. Con `--spec` se ignora **con aviso a stderr** (el umbral vive en el YAML por-red).
- **Diagnóstico de red-vacía en build-time** reusando `predict_build_preview` (no-divergencia con status-time, ADR 0037 §e, garantía **por-corpus**). Humano→stderr; `--json`→`data.empty_networks` (separado de `data.warnings`). En modo spec el `reason` culpa al `min_weight` del YAML, no al `--min-weight` CLI.
- `data.scope` = token CLI (`seeds`); `data.corpus_scope` = vocab interno (`seeds_only`), gancho estable para #160 (maturity).

## Tests
`tests/unit/test_build_absorber_networks.py` (34 tests): paridad build-vs-networks, D1 (transición+sellado), 3 scopes, alias deprecado, min-weight (quick y footgun spec), no-divergencia, stdout puro. Verifier: **PASA** (reservas de footgun min-weight+spec y scope-vocab resueltas). Gate verde local: ruff + mypy limpios, 1006 passed.

## Docs (lockstep)
`API.md` (build/networks/scope/`empty_networks`/no-divergencia por-corpus), `AGENTS.md`, **enmienda append-only D1 al ADR 0037**.

## Invariante
Envelope `schema="1"`, exit codes (ADR 0021 §D) y FSM (`apply_transition`, fuente única) **intactos**; todo aditivo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
