### PR TITLE
feat(cli): grupo noun-verb read {list,stats,show} absorbiendo inspect (#156)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,12 @@
   rehidrata un corpus curado sin red, Ciclo 9a; el 18° `b2g thesaurus` aplica el thesaurus curado,
   único paso explícito del preproc, #88, abajo; el 19° `b2g gui` levanta la API local FastAPI, Hito G3
   del MVP GUI, ADR 0028)—.
+  **Grupo noun-verb `read {list,stats,show}` (#156, ADR 0037 §b):** primer grupo del CLI (lectura pura
+  del corpus, no transiciona); `read list` filtra por `--query`/`--status`/`--seeds|--candidates`/`--year`,
+  `read stats --group-by {status,year,is_seed}`, `read show --id` (resuelve id/doi/source_id, ADR 0036).
+  `read` sin subcomando → ayuda + exit 0 (`invoke_without_command=True`, workaround Click 8.4); el
+  `command` del envelope usa la ruta completa (`"read list"`). `inspect` queda **en deprecación** (#165,
+  lo absorben `read show` + `status`) pero **sigue vivo**. Ver `docs/API.md` §Convenciones CLI.
   **645 tests verdes** (mypy/ruff limpios; el núcleo importa sin `duckdb`). Entre las
   redes, la **composición de comunidades es exportable**: `networks/cluster_table` (función pura)
   resume cada comunidad de una red de paper en una fila y `b2g build` la escribe como `clusters.csv`

--- a/docs/API.md
+++ b/docs/API.md
@@ -300,7 +300,9 @@ resolución DOI→`source_id` del flujo BibTeX e2e, issues #110/#112, ADR
   avisa, NO regenera — ver §`build`/`export`/`snapshot` abajo). **AS-BUILT #54 (2026-06-17):** `status`
   suma el campo aditivo `referenced_not_fetched` (nº de IDs que el backward chaining observó sin
   materializar — tabla `referenced_but_not_fetched`, §4/§5; `schema="1"` intacto), y `b2g chain` suma
-  `observed_refs_count` a su envelope JSON. `inspect`, `validate`.
+  `observed_refs_count` a su envelope JSON. **`read {list,stats,show}`** (grupo noun-verb, #156 /
+  ADR 0037 §b — ver §Grupo `read` abajo), `inspect` (**en deprecación**, #165: lo absorben `read show`
+  para papers y `status` para manifest/FSM; **sigue vivo** hasta cerrarse #165), `validate`.
 - **`seed`** (ADR [0030](decisiones/0030-ecuacion-declarativa-corpus-ejemplo.md), Ciclo 9a + Ciclo
   10 AS-BUILT 2026-06-17): tiene **exactamente TRES modos mutuamente excluyentes** (exactamente uno
   requerido; pasar más de uno o ninguno → error de uso, exit 1):
@@ -581,12 +583,38 @@ invalidación por hash, **no** un build-system (ADR [0029](decisiones/0029-works
 `filter`→`FILTERED`, `build`→`BUILT`, **`monitor`→`MONITORED`** (cleanup pre-v0.3),
 **`restore`→`FILTERED`** (Ciclo 9a, ADR 0030: el corpus restaurado ya pasó curación; reusa la
 transición permisiva `filter`);
-`accept`/`reject`/**`curate`**/`export`/`snapshot`/`status`/`inspect`/`validate`/**`enrich`**/**`networks`**
-**no transicionan** (`curate` es curación transversal; `enrich` y `networks` son ortogonales al lazo,
-ADR 0025 / Hito 9). El estado
+`accept`/`reject`/**`curate`**/**`read`**/`export`/`snapshot`/`status`/`inspect`/`validate`/**`enrich`**/**`networks`**
+**no transicionan** (`curate` y **`read`** son transversales/lectura pura; `enrich` y `networks` son
+ortogonales al lazo, ADR 0025 / Hito 9). El estado
 destino lo dicta `bib2graph.cycle.apply_transition`
 (fuente única de verdad; los comandos no hardcodean el destino). `seed` con **estado previo** se trata
 como **`reseed`** (loop-back a `SEEDED`, ronda++, acumula sobre lo curado).
+
+**Grupo `read {list,stats,show}` — primer grupo noun-verb del CLI (#156, ADR
+[0037](decisiones/0037-superficie-cli-10-verbos-ciclo.md) §b).** Es lectura pura del corpus (no
+transiciona el ciclo, §arriba). `read` **sin subcomando** imprime la ayuda y sale con **exit 0**
+(no es error de uso). El campo `command` del envelope usa la **ruta completa** del grupo noun-verb:
+`"read list"` / `"read stats"` / `"read show"` (convención para grupos: comando = `<grupo> <verbo>`,
+no solo el grupo). El `top` del ADR 0037 §b queda **diferido** (este hito materializa
+`list`/`stats`/`show`). La lógica vive en `service/reads.py` (`list_papers`, `corpus_stats`,
+`get_paper` extendido — §0.1), exportada en `service/__init__.py`.
+
+- **`read list`** — lista papers del corpus. Filtros (combinables, AND): `--query TEXT` (substring
+  **case-insensitive sobre el título únicamente**), `--status {candidate,accepted,rejected}`,
+  `--seeds` / `--candidates` (por `is_seed`), `--year INT`. Envelope:
+  `data = {papers: [{id, title, year, curation_status, is_seed}], count: int}`.
+- **`read stats --group-by {status,year,is_seed}`** (default `status`) — conteos agrupados. Envelope:
+  `data = {group_by: str, total: int, groups: [{key, count}]}`. Un valor de `--group-by` fuera del
+  `Choice` es **error de uso de Click → exit 1** (coherente con ADR 0010 uso=1/datos=2 y con todos
+  los `Choice` del repo; **no** es exit 2).
+- **`read show --id <ID>`** — delega en `service.get_paper(ws, ident)` (§0.1; resuelve **id | doi |
+  source_id**, prioridad id>doi>source_id, ADR 0036). Envelope: `data =` la **fila completa** del
+  corpus (~14 campos: `id, source_id, doi, title, year, abstract, is_seed, curation_status,
+  authors_raw, authors_id, keywords_id, references_id, cited_by_id, provenance`). `--id` que no
+  matchea ningún id/doi/source_id → `DataError`, **exit 2**.
+
+`inspect` (verbo plano) **sigue vivo pero en deprecación** (#165): `read show` lo absorbe para
+papers y `status` para manifest/FSM. **No** está removido en este hito.
 
 **Envelope JSON común y versionado** (ADR 0021 §C): en modo `--json`, cada subcomando emite **un
 objeto JSON** con `schema="1"`:
@@ -743,12 +771,18 @@ def list_rounds(ws: Workspace) -> list[dict[str, Any]]:
     Entrada viva: {id="live", round, loop_state, total_papers}. Raises StoreError.
     Ronda = snapshot (B-G2-1 Opción A); el contador loop_round se ve en la entrada "live"."""
 
-def get_paper(ws: Workspace, paper_id: str) -> dict[str, Any]:
-    """Fila del corpus (CORPUS_SCHEMA) por id. Devuelve:
+def get_paper(ws: Workspace, ident: str) -> dict[str, Any]:
+    """Fila del corpus (CORPUS_SCHEMA) resuelta por identidad source-agnóstica
+    (ADR 0036): `ident` matchea contra **id | doi | source_id**, con prioridad
+    `id` > `doi` > `source_id` (devuelve el primer match). Devuelve:
     {id, source_id, doi, title, year, abstract, is_seed, curation_status,
      authors_raw, authors_id, keywords_id, references_id, cited_by_id,
      provenance (list, parseada del JSON)}.
-    Raises DataError si el id no existe; StoreError si el store falla."""
+    Raises DataError si `ident` no matchea ningún id/doi/source_id;
+    StoreError si el store falla.
+    NOTA: el parámetro se renombró `paper_id`→`ident` (#156); el caller
+    `api/routers/reads.py` lo pasa posicional (sin ruptura). `read show --id`
+    delega en esta lectura (§Convenciones CLI · grupo `read`)."""
 
 def get_scent(ws: Workspace, paper_id: str) -> dict[str, Any]:
     """Score de acoplamiento bibliográfico real + vecinos compartidos (B-G2-2). Devuelve:
@@ -815,7 +849,7 @@ firma `build_envelope(data: dict)`.
 |---|---|---|---|
 | GET | `/api/workspace` | `reads.get_workspace(ws)` | dict de estado del workspace (§0.1) |
 | GET | `/api/rounds` | `reads.list_rounds(ws)` | `{"rounds": [...]}` (snapshots + entrada `live`) |
-| GET | `/api/paper/{id}` | `reads.get_paper(ws, id)` | fila del corpus (§0.1) |
+| GET | `/api/paper/{id}` | `reads.get_paper(ws, id)` | fila del corpus (§0.1; `id` resuelve id\|doi\|source_id, ADR 0036) |
 | GET | `/api/paper/{id}/scent` | `reads.get_scent(ws, id)` | score de acoplamiento + vecinos (§0.1) |
 | GET | `/api/network/{kind}` | `reads.get_network(ws, kind)` | `{nodes, edges, metrics}` (§0.1) |
 | GET | `/api/compare?a=&b=` | `reads.compare_rounds(ws, a, b)` | diff de rondas (§0.1) |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -571,6 +571,17 @@ trabajo posterior, pero la API se **diseña con estos principios desde el hito 1
    faltante"); la capacidad-de-source-faltante se convierte en `DependencyError` mediante un
    **pre-check `hasattr` en el borde** (p. ej. `chain.py` antes del `Forager`). Ver ADR 0021 §D.
 
+**Patrón noun-verb group (AS-BUILT #156, ADR
+[0037](decisiones/0037-superficie-cli-10-verbos-ciclo.md) §b).** `read {list,stats,show}` es el
+**primer grupo noun-verb** del CLI (en la capa Click): un `click.Group` (el sustantivo) con un
+subcomando por verbo, cada uno delegando en su `run_<verbo>`/función de `service/` (capas 2–3 sin
+cambios). Dos convenciones del grupo: (1) el `command` del envelope usa la **ruta completa**
+(`"read list"`, no `"read"`); (2) el grupo **sin subcomando** imprime ayuda y sale **exit 0** —no es
+error de uso— vía `invoke_without_command=True` + `ctx.get_help()` en el callback del grupo
+(**workaround a la regresión de Click 8.4** donde un grupo sin subcomando devolvía exit 2). Un valor
+de flag `Choice` inválido sigue siendo error de uso de Click → **exit 1** (no exit 2). Es el molde
+para los próximos grupos previstos por el ADR 0037 (`curate {…}`).
+
 Son **19 subcomandos** (`seed`, `chain`, `filter`, `build`, `export`, `snapshot`, `status`,
 `inspect`, `validate`, `accept`, `reject`, **`monitor`**, **`enrich`**, **`init`**, **`curate`**,
 **`networks`**, **`restore`**, **`thesaurus`**, **`gui`**); el 18° **`thesaurus`** —único paso de

--- a/src/bib2graph/cli/__init__.py
+++ b/src/bib2graph/cli/__init__.py
@@ -1,15 +1,18 @@
 """cli — CLI agente-native ``b2g`` (Hito 6 + ADR 0029 workspace).
 
-Arma el grupo Click principal, registra los 20 subcomandos y expone
-``main()`` como entry point del paquete.
+Arma el grupo Click principal, registra los 21 subcomandos (20 planos + el
+grupo noun-verb ``read``) y expone ``main()`` como entry point del paquete.
 
 Entry point en ``pyproject.toml``:
     b2g = "bib2graph.cli:main"
 
-Subcomandos:
+Subcomandos planos (20):
     init, seed, chain, filter, build, enrich, monitor, export, snapshot,
     status, inspect, validate, accept, reject, curate, networks, restore,
     thesaurus, gui, resolve.
+
+Grupos noun-verb (1):
+    read [list|stats|show]  — lecturas read-only del corpus (#156).
 
 Cada subcomando lleva:
   - ``--json``: salida JSON estructurada (envelope versionado, §API.md).
@@ -49,6 +52,7 @@ from bib2graph.cli.commands.init import init_cmd
 from bib2graph.cli.commands.inspect import inspect_cmd
 from bib2graph.cli.commands.monitor import monitor_cmd
 from bib2graph.cli.commands.networks import networks_cmd
+from bib2graph.cli.commands.read import read_grp
 from bib2graph.cli.commands.reject import reject_cmd
 from bib2graph.cli.commands.resolve import resolve_cmd
 from bib2graph.cli.commands.restore import restore_cmd
@@ -102,7 +106,7 @@ def b2g(ctx: click.Context, workspace: str | None) -> None:
 
     Subcomandos: init, seed, chain, filter, build, enrich, monitor, export,
     snapshot, status, inspect, validate, accept, reject, curate, networks,
-    restore, thesaurus, gui, resolve.
+    restore, thesaurus, gui, resolve, read [list|stats|show].
 
     Ejemplo:
         b2g init mi-investigacion
@@ -114,7 +118,7 @@ def b2g(ctx: click.Context, workspace: str | None) -> None:
     ctx.obj["workspace"] = workspace
 
 
-# Registrar los 20 subcomandos
+# Registrar los 20 subcomandos planos + el grupo noun-verb read (#156)
 b2g.add_command(init_cmd)
 b2g.add_command(seed_cmd)
 b2g.add_command(chain_cmd)
@@ -135,6 +139,7 @@ b2g.add_command(restore_cmd)
 b2g.add_command(thesaurus_cmd)
 b2g.add_command(gui_cmd)
 b2g.add_command(resolve_cmd)
+b2g.add_command(read_grp)
 
 
 def main() -> int:

--- a/src/bib2graph/cli/commands/read.py
+++ b/src/bib2graph/cli/commands/read.py
@@ -1,0 +1,252 @@
+"""cli.commands.read — Grupo noun-verb ``b2g read`` (#156, superficie CLI 0.10.0).
+
+Primer grupo noun-verb del repo.  Agrupa lecturas read-only del corpus bajo
+el verbo ``read``, con tres subcomandos:
+
+  ``read list``   — lista papers con filtros opcionales (query/status/seeds/year).
+  ``read stats``  — estadísticas del corpus agrupadas por status, year o is_seed.
+  ``read show``   — fila completa de un paper, resolviendo por id, doi o source_id.
+
+Cada subcomando delega la lógica en ``service.reads`` (capa neutral, ADR 0028):
+  - ``list_papers``  → ``read list``
+  - ``corpus_stats`` → ``read stats``
+  - ``get_paper``    → ``read show``
+
+Decisiones de esta implementación (#156):
+  - ``read`` sin subcomando → imprime ayuda y sale con exit 0
+    (``invoke_without_command=True`` + check en el body; Click 8.4 usa exit 2
+    con ``no_args_is_help=True`` en grupos — workaround deliberado).
+  - ``--json`` y ``B2G_JSON`` funcionan en los tres subcomandos (ADR 0021 #151).
+  - El ``command`` del envelope es la ruta completa (``"read list"``,
+    ``"read stats"``, ``"read show"``), no solo ``"read"``.
+  - ``--seeds`` y ``--candidates`` son mutuamente excluyentes (UsageError exit 1).
+  - ``inspect`` permanece intacto; su absorción es del sub-issue #165.
+  - El grupo queda abierto para que #157 agregue ``@read_grp.command("top")``.
+
+Exit codes: 0 éxito, 1 uso, 2 datos (paper inexistente), 5 store.
+"""
+
+from __future__ import annotations
+
+import click
+
+from bib2graph.cli._envelope import build_envelope, emit, emit_human
+from bib2graph.cli._errors import UsageError, handle_errors
+from bib2graph.cli._options import json_mode, json_option
+from bib2graph.cli._store import resolve_workspace
+
+# ---------------------------------------------------------------------------
+# Grupo raíz
+# ---------------------------------------------------------------------------
+
+
+@click.group("read", invoke_without_command=True)
+@click.pass_context
+def read_grp(ctx: click.Context) -> None:
+    """Lee papers del corpus (read-only).
+
+    Subcomandos: list, stats, show.
+
+    Ejemplos:
+        b2g read list --query "unequal exchange"
+        b2g read list --status accepted --json
+        b2g read stats --group-by year
+        b2g read show --id W2741809807
+        b2g read show --id 10.1016/j.ecolecon.2019.01.001
+    """
+    ctx.ensure_object(dict)
+    # Click 8.4: no_args_is_help=True en grupos termina con exit 2 (Missing command).
+    # Usamos invoke_without_command=True + check manual para exit 0 correcto.
+    if ctx.invoked_subcommand is None:
+        click.echo(ctx.get_help())
+
+
+# ---------------------------------------------------------------------------
+# read list
+# ---------------------------------------------------------------------------
+
+
+@read_grp.command("list")
+@click.option(
+    "--query",
+    default=None,
+    help="Texto a buscar en el título (substring, case-insensitive).",
+)
+@click.option(
+    "--status",
+    default=None,
+    type=click.Choice(["candidate", "accepted", "rejected"]),
+    help="Filtrar por curation_status exacto.",
+)
+@click.option(
+    "--seeds",
+    is_flag=True,
+    default=False,
+    help="Mostrar solo semillas (is_seed=True). Excluyente con --candidates.",
+)
+@click.option(
+    "--candidates",
+    is_flag=True,
+    default=False,
+    help="Mostrar solo no-semillas (is_seed=False). Excluyente con --seeds.",
+)
+@click.option(
+    "--year",
+    default=None,
+    type=int,
+    help="Filtrar por año exacto de publicación.",
+)
+@json_option
+@click.pass_context
+@handle_errors("read list")
+def list_cmd(
+    ctx: click.Context,
+    query: str | None,
+    status: str | None,
+    seeds: bool,
+    candidates: bool,
+    year: int | None,
+    json_output: bool,
+) -> None:
+    """Lista papers del corpus con filtros opcionales.
+
+    Los filtros se combinan con AND lógico.
+    Sin filtros devuelve todos los papers.
+
+    Campos devueltos por paper: id, title, year, curation_status, is_seed.
+    """
+    if seeds and candidates:
+        raise UsageError("--seeds y --candidates son mutuamente excluyentes.")
+
+    is_seed: bool | None = None
+    if seeds:
+        is_seed = True
+    elif candidates:
+        is_seed = False
+
+    from bib2graph.service.reads import list_papers
+
+    ws = resolve_workspace(ctx.obj)
+    data = list_papers(ws, query=query, status=status, is_seed=is_seed, year=year)
+
+    if json_mode(json_output):
+        envelope = build_envelope(
+            command="read list",
+            ok=True,
+            data=data,
+            exit_code=0,
+        )
+        emit(envelope)
+    else:
+        count = data["count"]
+        emit_human(f"Papers encontrados: {count}")
+        for paper in data["papers"]:
+            seed_marker = " [seed]" if paper.get("is_seed") else ""
+            emit_human(
+                f"  {paper['id']}  {paper.get('year') or '----'}"
+                f"  [{paper.get('curation_status')}]{seed_marker}"
+                f"  {paper.get('title') or ''}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# read stats
+# ---------------------------------------------------------------------------
+
+
+@read_grp.command("stats")
+@click.option(
+    "--group-by",
+    "group_by",
+    default="status",
+    type=click.Choice(["status", "year", "is_seed"]),
+    show_default=True,
+    help="Dimensión de agrupación.",
+)
+@json_option
+@click.pass_context
+@handle_errors("read stats")
+def stats_cmd(
+    ctx: click.Context,
+    group_by: str,
+    json_output: bool,
+) -> None:
+    """Estadísticas del corpus agrupadas por una dimensión.
+
+    Dimensiones válidas: status (default), year, is_seed.
+    """
+    from bib2graph.service.reads import corpus_stats
+
+    ws = resolve_workspace(ctx.obj)
+    data = corpus_stats(ws, group_by=group_by)
+
+    if json_mode(json_output):
+        envelope = build_envelope(
+            command="read stats",
+            ok=True,
+            data=data,
+            exit_code=0,
+        )
+        emit(envelope)
+    else:
+        emit_human(f"Total papers: {data['total']}")
+        emit_human(f"Agrupado por: {data['group_by']}")
+        for group in data["groups"]:
+            emit_human(f"  {group['key']}: {group['count']}")
+
+
+# ---------------------------------------------------------------------------
+# read show
+# ---------------------------------------------------------------------------
+
+
+@read_grp.command("show")
+@click.option(
+    "--id",
+    "ident",
+    required=True,
+    help=(
+        "Identificador del paper: id interno, DOI o source_id. "
+        "Se prueba en ese orden (ADR 0036)."
+    ),
+)
+@json_option
+@click.pass_context
+@handle_errors("read show")
+def show_cmd(
+    ctx: click.Context,
+    ident: str,
+    json_output: bool,
+) -> None:
+    """Muestra la fila completa de un paper.
+
+    Resuelve --id contra id, doi y source_id (en ese orden de prioridad).
+    Devuelve ~14 campos: id, source_id, doi, title, year, abstract, is_seed,
+    curation_status, authors_raw, authors_id, keywords_id, references_id,
+    cited_by_id, provenance.
+    """
+    from bib2graph.service.reads import get_paper
+
+    ws = resolve_workspace(ctx.obj)
+    data = get_paper(ws, ident)
+
+    if json_mode(json_output):
+        envelope = build_envelope(
+            command="read show",
+            ok=True,
+            data=data,
+            exit_code=0,
+        )
+        emit(envelope)
+    else:
+        emit_human(f"id:               {data.get('id')}")
+        emit_human(f"title:            {data.get('title')}")
+        emit_human(f"year:             {data.get('year')}")
+        emit_human(f"doi:              {data.get('doi')}")
+        emit_human(f"source_id:        {data.get('source_id')}")
+        emit_human(f"curation_status:  {data.get('curation_status')}")
+        emit_human(f"is_seed:          {data.get('is_seed')}")
+        abstract = data.get("abstract") or ""
+        emit_human(
+            f"abstract:         {abstract[:120]}{'…' if len(abstract) > 120 else ''}"
+        )

--- a/src/bib2graph/service/__init__.py
+++ b/src/bib2graph/service/__init__.py
@@ -10,6 +10,8 @@ Contrato público re-exportado:
   - ``code_for`` — helper de mapeo error→exit code (sin I/O).
   - ``get_workspace``, ``list_rounds``, ``get_paper``, ``get_scent``,
     ``get_network``, ``compare_rounds`` — lecturas del Hito G2 (ADR 0028).
+  - ``list_papers``, ``corpus_stats`` — lecturas del grupo ``read``
+    (#156, sub-issue de la superficie CLI 0.10.0).
   - ``accept_papers``, ``reject_papers``, ``curate_paper`` — escrituras del
     Hito G3 (ADR 0028).
   - ``resolve_dois`` — resolución DOI→source_id (ADR 0035).
@@ -30,10 +32,12 @@ from bib2graph.service.errors import (
 )
 from bib2graph.service.reads import (
     compare_rounds,
+    corpus_stats,
     get_network,
     get_paper,
     get_scent,
     get_workspace,
+    list_papers,
     list_rounds,
 )
 from bib2graph.service.resolve import resolve_dois
@@ -50,11 +54,13 @@ __all__ = [
     "build_envelope",
     "code_for",
     "compare_rounds",
+    "corpus_stats",
     "curate_paper",
     "get_network",
     "get_paper",
     "get_scent",
     "get_workspace",
+    "list_papers",
     "list_rounds",
     "reject_papers",
     "resolve_dois",

--- a/src/bib2graph/service/reads.py
+++ b/src/bib2graph/service/reads.py
@@ -1,4 +1,4 @@
-"""service.reads — Las 6 funciones de lectura del Hito G2 (ADR 0028).
+"""service.reads — Funciones de lectura de la capa de servicios (ADR 0028).
 
 Capa de servicios neutral: sin ``print``, ``sys.exit``, Click ni FastAPI.
 Cada función recibe el ``store_path`` o el ``Workspace`` ya resuelto (la
@@ -6,17 +6,24 @@ resolución de workspace se hace en el adaptador CLI), abre el store en
 modo lectura, y devuelve un ``dict`` serializable o lanza un ``B2GError``
 tipado.
 
-Lecturas implementadas:
+Lecturas del Hito G2 (6 originales):
   - ``get_workspace`` — estado del workspace activo (nombre, loop_state, ronda,
     conteos, staleness de cache de redes).
   - ``list_rounds`` — snapshots sellados en ``<workspace>/snapshots/`` más una
     entrada sintética ``id="live"`` para el corpus vivo.
-  - ``get_paper`` — fila completa del corpus por id (o ``DataError``).
+  - ``get_paper`` — fila completa del corpus resolviendo por id, doi o source_id
+    (ADR 0036; antes solo por id). Prioridad: id > doi > source_id.
   - ``get_scent`` — score de acoplamiento + vecinos compartidos de un paper
     ya en el corpus.
   - ``get_network`` — red de la ronda viva (desde cache ``networks/`` o recomputo).
   - ``compare_rounds`` — diff entre dos snapshots (added/removed paper_ids +
     métricas básicas).
+
+Lecturas del grupo ``read`` (sub-issue #156):
+  - ``list_papers`` — lista papers con filtros opcionales: query (título
+    substring CI), status, is_seed, year. Payload mínimo para listados.
+  - ``corpus_stats`` — estadísticas agregadas del corpus, agrupadas por
+    ``status``, ``year`` o ``is_seed``.
 
 Decisiones de producto (Bifurcaciones B-G2-1/B-G2-2/B-G2-3):
   - Ronda = snapshot sellado (Opción A). ``list_rounds``/``compare_rounds``
@@ -195,22 +202,28 @@ def list_rounds(ws: Workspace) -> list[dict[str, Any]]:
 # ---------------------------------------------------------------------------
 
 
-def get_paper(ws: Workspace, paper_id: str) -> dict[str, Any]:
+def get_paper(ws: Workspace, ident: str) -> dict[str, Any]:
     """Devuelve la fila completa del corpus para un paper.
+
+    Resuelve ``ident`` contra tres columnas en orden de prioridad:
+    ``Col.ID`` (exacto) → ``Col.DOI`` (exacto) → ``Col.SOURCE_ID`` (exacto).
+    Si varios matchean, gana el que coincide por ``id``.
+    Coherente con ADR 0036 (identidad source-agnóstica, DOI ancla).
 
     Incluye todos los campos del ``CORPUS_SCHEMA``: id, source_id, doi,
     title, year, abstract, is_seed, curation_status, authors_raw,
-    keywords_id, references_id, cited_by_id, provenance.
+    authors_id, keywords_id, references_id, cited_by_id, provenance.
 
     Args:
         ws: Workspace resuelto.
-        paper_id: Valor de ``Col.ID`` del paper buscado.
+        ident: Valor a buscar; se prueba contra id, doi y source_id en ese
+            orden.
 
     Returns:
         Dict con todos los campos de la fila del corpus.
 
     Raises:
-        DataError: Si el ``paper_id`` no existe en el corpus.
+        DataError: Si ``ident`` no coincide con ningún paper.
         StoreError: Si el store no existe o está bloqueado.
     """
     store = _open_readonly(ws.library_path)
@@ -218,12 +231,31 @@ def get_paper(ws: Workspace, paper_id: str) -> dict[str, Any]:
     table = corpus.to_arrow()
 
     rows = table.to_pylist()
-    matching = [r for r in rows if str(r.get(Col.ID)) == paper_id]
+
+    # Prioridad: id > doi > source_id (ADR 0036)
+    matching_by_id = [r for r in rows if str(r.get(Col.ID)) == ident]
+    if matching_by_id:
+        matching = matching_by_id
+    else:
+        matching_by_doi = [
+            r
+            for r in rows
+            if r.get(Col.DOI) is not None and str(r.get(Col.DOI)) == ident
+        ]
+        if matching_by_doi:
+            matching = matching_by_doi
+        else:
+            matching = [
+                r
+                for r in rows
+                if r.get(Col.SOURCE_ID) is not None
+                and str(r.get(Col.SOURCE_ID)) == ident
+            ]
 
     if not matching:
         raise DataError(
-            f"Paper '{paper_id}' no encontrado en el corpus. "
-            "Verificá el id con 'b2g status' o 'b2g inspect'."
+            f"Paper '{ident}' no encontrado en el corpus. "
+            "Verificá el id con 'b2g read list' o 'b2g status'."
         )
 
     row = matching[0]
@@ -606,4 +638,150 @@ def compare_rounds(ws: Workspace, round_a: str, round_b: str) -> dict[str, Any]:
         "removed_paper_ids": removed,
         "mutated_hubs": [],  # diferido: requiere redes construidas por snapshot
         "metrics_change": metrics_change,
+    }
+
+
+# ---------------------------------------------------------------------------
+# 7. list_papers  (sub-issue #156 — grupo read)
+# ---------------------------------------------------------------------------
+
+
+def list_papers(
+    ws: Workspace,
+    *,
+    query: str | None = None,
+    status: str | None = None,
+    is_seed: bool | None = None,
+    year: int | None = None,
+) -> dict[str, Any]:
+    """Lista papers del corpus con filtros opcionales.
+
+    Devuelve un payload mínimo por paper (id, title, year, curation_status,
+    is_seed) más el conteo total.  Diseñado para listar en el CLI/SPA sin
+    cargar campos pesados (abstract, referencias, autores).
+
+    Filtros combinables (todos opcionales, se aplican con AND lógico):
+    - ``query``: substring case-insensitive sobre el título.
+    - ``status``: valor exacto de ``curation_status``
+      (``"candidate"``, ``"accepted"``, ``"rejected"``).
+    - ``is_seed``: ``True`` → solo semillas; ``False`` → solo no-semillas.
+    - ``year``: año exacto de publicación.
+
+    Args:
+        ws: Workspace resuelto.
+        query: Texto a buscar en el título (substring, case-insensitive).
+        status: Valor exacto de ``curation_status``.
+        is_seed: Filtro por campo is_seed.
+        year: Año exacto de publicación.
+
+    Returns:
+        Dict con ``papers`` (lista de dicts mínimos) y ``count`` (int).
+
+    Raises:
+        StoreError: Si el store no existe o está bloqueado.
+    """
+    store = _open_readonly(ws.library_path)
+    corpus = store.load()
+    table = corpus.to_arrow()
+    rows = table.to_pylist()
+
+    result: list[dict[str, Any]] = []
+    for row in rows:
+        # Filtro por query: substring CI sobre el título
+        if query is not None:
+            title_val = str(row.get(Col.TITLE) or "")
+            if query.lower() not in title_val.lower():
+                continue
+
+        # Filtro por status (curation_status exacto)
+        if status is not None and str(row.get(Col.CURATION_STATUS)) != status:
+            continue
+
+        # Filtro por is_seed
+        if is_seed is not None and bool(row.get(Col.IS_SEED)) != is_seed:
+            continue
+
+        # Filtro por año exacto
+        if year is not None:
+            row_year = row.get(Col.YEAR)
+            if row_year is None or int(row_year) != year:
+                continue
+
+        result.append(
+            {
+                "id": row.get(Col.ID),
+                "title": row.get(Col.TITLE),
+                "year": row.get(Col.YEAR),
+                "curation_status": row.get(Col.CURATION_STATUS),
+                "is_seed": row.get(Col.IS_SEED),
+            }
+        )
+
+    return {"papers": result, "count": len(result)}
+
+
+# ---------------------------------------------------------------------------
+# 8. corpus_stats  (sub-issue #156 — grupo read)
+# ---------------------------------------------------------------------------
+
+_VALID_GROUP_BY: frozenset[str] = frozenset({"status", "year", "is_seed"})
+
+# Mapeo de alias CLI → nombre de columna SQL
+_GROUP_BY_COL: dict[str, str] = {
+    "status": Col.CURATION_STATUS.value,
+    "year": Col.YEAR.value,
+    "is_seed": Col.IS_SEED.value,
+}
+
+
+def corpus_stats(
+    ws: Workspace,
+    *,
+    group_by: str = "status",
+) -> dict[str, Any]:
+    """Estadísticas del corpus agrupadas por ``status``, ``year`` o ``is_seed``.
+
+    Para ``group_by="status"`` reutiliza la consulta GROUP BY de
+    ``get_workspace`` (``counts_by_status``); para ``year`` e ``is_seed``
+    aplica la misma estrategia sobre la columna correspondiente.
+
+    Args:
+        ws: Workspace resuelto.
+        group_by: Dimensión de agrupación.  Valores válidos:
+            ``"status"`` (default), ``"year"``, ``"is_seed"``.
+
+    Returns:
+        Dict con:
+        - ``group_by``: dimensión usada.
+        - ``total``: total de papers en el corpus.
+        - ``groups``: lista de ``{key, count}`` ordenada por clave.
+
+    Raises:
+        DataError: Si ``group_by`` no es un valor válido.
+        StoreError: Si el store no existe o está bloqueado.
+    """
+    if group_by not in _VALID_GROUP_BY:
+        valid = ", ".join(sorted(_VALID_GROUP_BY))
+        raise DataError(f"group_by '{group_by}' no válido. Valores admitidos: {valid}.")
+
+    store = _open_readonly(ws.library_path)
+    col = _GROUP_BY_COL[group_by]
+
+    counts_table = store.backend.query(
+        f"SELECT {col}, COUNT(*) AS cnt FROM corpus GROUP BY 1 ORDER BY 1"
+    )
+
+    groups: list[dict[str, Any]] = []
+    total = 0
+    if len(counts_table) > 0:
+        for row in counts_table.to_pylist():
+            key = row.get(col)
+            cnt = int(row["cnt"])
+            groups.append({"key": key, "count": cnt})
+            total += cnt
+
+    return {
+        "group_by": group_by,
+        "total": total,
+        "groups": groups,
     }

--- a/tests/unit/test_cli_read.py
+++ b/tests/unit/test_cli_read.py
@@ -1,0 +1,1048 @@
+"""Tests del grupo noun-verb ``b2g read`` (sub-issue #156).
+
+Cubre:
+1. Servicios nuevos (unit puro, sin Click):
+   - ``list_papers``: sin filtros, con --query (CI), --status, is_seed, year.
+   - ``corpus_stats``: group_by status/year/is_seed; group_by inválido → DataError.
+   - ``get_paper`` extendido: resuelve por id, doi, source_id; inexistente → DataError.
+
+2. CLI ``read list --json``: envelope schema="1", exit 0, data.papers + count.
+3. CLI ``read stats --json --group-by <X>``: forma del envelope.
+4. CLI ``read show --id <X> --json``: ~14 campos; inexistente → DataError exit 2.
+5. ``b2g read`` sin subcomando → ayuda (exit 0).
+6. stdout puro: una sola línea JSON, sin ruido.
+
+Marcador: ``unit`` (DuckDB en tmp_path, sin red real).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pyarrow as pa
+import pytest
+from click.testing import CliRunner
+
+from bib2graph.cli import b2g
+from bib2graph.schemas import CORPUS_SCHEMA
+
+pytestmark = pytest.mark.unit
+
+# ---------------------------------------------------------------------------
+# Helpers compartidos
+# ---------------------------------------------------------------------------
+
+
+def _row(
+    *,
+    id: str,
+    title: str = "Título de prueba",
+    year: int | None = 2020,
+    is_seed: bool = True,
+    curation_status: str = "candidate",
+    doi: str | None = None,
+    source_id: str | None = None,
+    references_id: list[str] | None = None,
+    cited_by_id: list[str] | None = None,
+) -> dict[str, Any]:
+    """Fila mínima con schema completo para tests de read.
+
+    Usa los nombres canónicos del CORPUS_SCHEMA (source_id, no openalex_id).
+    """
+    return {
+        "id": id,
+        "source_id": source_id,
+        "doi": doi,
+        "title": title,
+        "year": year,
+        "abstract": None,
+        "source": None,
+        "language": "en",
+        "publisher": None,
+        "research_areas": None,
+        "is_seed": is_seed,
+        "curation_status": curation_status,
+        "provenance": None,
+        "authors_raw": ["Autor A"],
+        "authors_id": ["oa:author1"],
+        "authors_affiliations": None,
+        "keywords_raw": None,
+        "keywords_id": None,
+        "institutions_raw": None,
+        "institutions_id": None,
+        "references_id": references_id,
+        "references_doi": None,
+        "cited_by_id": cited_by_id,
+    }
+
+
+def _init_workspace(tmp_path: Path, name: str = "test-ws") -> Any:
+    """Crea y devuelve un Workspace inicializado en tmp_path."""
+    from bib2graph.workspace import Workspace
+
+    ws_dir = tmp_path / name
+    return Workspace.init(ws_dir, name)
+
+
+def _seed_store(ws: Any, rows: list[dict[str, Any]]) -> None:
+    """Persiste filas en el store del workspace."""
+    from bib2graph.corpus import Corpus
+    from bib2graph.stores.duckdb import DuckDBStore
+
+    table = pa.Table.from_pylist(rows, schema=CORPUS_SCHEMA)
+    corpus = Corpus.from_arrow(table)
+    store = DuckDBStore(ws.library_path)
+    store.persist(corpus)
+
+
+def _assert_one_json_line(stdout: str, *, schema: str = "1") -> dict[str, Any]:
+    """Aserta exactamente una línea JSON con schema correcto; devuelve el dict."""
+    lines = [ln for ln in stdout.splitlines() if ln.strip()]
+    assert len(lines) == 1, (
+        f"Se esperaba exactamente 1 línea en stdout, se obtuvieron {len(lines)}:\n"
+        f"{stdout!r}"
+    )
+    data = json.loads(lines[0])
+    assert data.get("schema") == schema
+    return data
+
+
+# ---------------------------------------------------------------------------
+# 1. Servicios — list_papers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_list_papers_sin_filtros_devuelve_todos(tmp_path: Path) -> None:
+    """list_papers sin filtros devuelve todos los papers con campos mínimos."""
+    from bib2graph.service.reads import list_papers
+
+    ws = _init_workspace(tmp_path)
+    rows = [
+        _row(id="P1", title="Paper uno", year=2021),
+        _row(id="P2", title="Paper dos", year=2022),
+        _row(id="P3", title="Paper tres", year=2023),
+    ]
+    _seed_store(ws, rows)
+
+    result = list_papers(ws)
+
+    assert result["count"] == 3
+    assert len(result["papers"]) == 3
+    ids = {p["id"] for p in result["papers"]}
+    assert ids == {"P1", "P2", "P3"}
+    # Campos mínimos presentes
+    for paper in result["papers"]:
+        assert "id" in paper
+        assert "title" in paper
+        assert "year" in paper
+        assert "curation_status" in paper
+        assert "is_seed" in paper
+
+
+@pytest.mark.unit
+def test_list_papers_query_filtra_por_titulo_ci(tmp_path: Path) -> None:
+    """list_papers --query filtra substring case-insensitive en el título."""
+    from bib2graph.service.reads import list_papers
+
+    ws = _init_workspace(tmp_path)
+    rows = [
+        _row(id="P1", title="Unequal Exchange in World Trade"),
+        _row(id="P2", title="Capital Accumulation and Growth"),
+        _row(id="P3", title="UNEQUAL DISTRIBUTION OF WEALTH"),
+    ]
+    _seed_store(ws, rows)
+
+    result = list_papers(ws, query="unequal")
+
+    assert result["count"] == 2
+    ids = {p["id"] for p in result["papers"]}
+    assert ids == {"P1", "P3"}
+
+
+@pytest.mark.unit
+def test_list_papers_status_filtra_por_curation_status(tmp_path: Path) -> None:
+    """list_papers filtra por curation_status exacto."""
+    from bib2graph.service.reads import list_papers
+
+    ws = _init_workspace(tmp_path)
+    rows = [
+        _row(id="P1", curation_status="candidate"),
+        _row(id="P2", curation_status="accepted"),
+        _row(id="P3", curation_status="rejected"),
+        _row(id="P4", curation_status="accepted"),
+    ]
+    _seed_store(ws, rows)
+
+    result = list_papers(ws, status="accepted")
+
+    assert result["count"] == 2
+    ids = {p["id"] for p in result["papers"]}
+    assert ids == {"P2", "P4"}
+
+
+@pytest.mark.unit
+def test_list_papers_seeds_filtra_is_seed_true(tmp_path: Path) -> None:
+    """list_papers con is_seed=True devuelve solo semillas."""
+    from bib2graph.service.reads import list_papers
+
+    ws = _init_workspace(tmp_path)
+    rows = [
+        _row(id="P1", is_seed=True),
+        _row(id="P2", is_seed=False),
+        _row(id="P3", is_seed=True),
+    ]
+    _seed_store(ws, rows)
+
+    result = list_papers(ws, is_seed=True)
+
+    assert result["count"] == 2
+    assert all(p["is_seed"] is True for p in result["papers"])
+
+
+@pytest.mark.unit
+def test_list_papers_candidates_filtra_is_seed_false(tmp_path: Path) -> None:
+    """list_papers con is_seed=False devuelve solo no-semillas."""
+    from bib2graph.service.reads import list_papers
+
+    ws = _init_workspace(tmp_path)
+    rows = [
+        _row(id="P1", is_seed=True),
+        _row(id="P2", is_seed=False),
+        _row(id="P3", is_seed=False),
+    ]
+    _seed_store(ws, rows)
+
+    result = list_papers(ws, is_seed=False)
+
+    assert result["count"] == 2
+    assert all(p["is_seed"] is False for p in result["papers"])
+
+
+@pytest.mark.unit
+def test_list_papers_year_filtra_por_anio(tmp_path: Path) -> None:
+    """list_papers filtra por año exacto."""
+    from bib2graph.service.reads import list_papers
+
+    ws = _init_workspace(tmp_path)
+    rows = [
+        _row(id="P1", year=2019),
+        _row(id="P2", year=2021),
+        _row(id="P3", year=2021),
+        _row(id="P4", year=2023),
+    ]
+    _seed_store(ws, rows)
+
+    result = list_papers(ws, year=2021)
+
+    assert result["count"] == 2
+    ids = {p["id"] for p in result["papers"]}
+    assert ids == {"P2", "P3"}
+
+
+@pytest.mark.unit
+def test_list_papers_filtros_combinados(tmp_path: Path) -> None:
+    """list_papers combina filtros con AND lógico."""
+    from bib2graph.service.reads import list_papers
+
+    ws = _init_workspace(tmp_path)
+    rows = [
+        _row(id="P1", title="Unequal Exchange", year=2020, curation_status="accepted"),
+        _row(id="P2", title="Unequal Trade", year=2021, curation_status="accepted"),
+        _row(id="P3", title="Unequal Income", year=2020, curation_status="candidate"),
+    ]
+    _seed_store(ws, rows)
+
+    result = list_papers(ws, query="unequal", status="accepted", year=2020)
+
+    assert result["count"] == 1
+    assert result["papers"][0]["id"] == "P1"
+
+
+# ---------------------------------------------------------------------------
+# 2. Servicios — corpus_stats
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_corpus_stats_group_by_status(tmp_path: Path) -> None:
+    """corpus_stats agrupa por curation_status y devuelve conteos correctos."""
+    from bib2graph.service.reads import corpus_stats
+
+    ws = _init_workspace(tmp_path)
+    rows = [
+        _row(id="P1", curation_status="candidate"),
+        _row(id="P2", curation_status="accepted"),
+        _row(id="P3", curation_status="candidate"),
+        _row(id="P4", curation_status="rejected"),
+    ]
+    _seed_store(ws, rows)
+
+    result = corpus_stats(ws, group_by="status")
+
+    assert result["group_by"] == "status"
+    assert result["total"] == 4
+    groups_map = {g["key"]: g["count"] for g in result["groups"]}
+    assert groups_map["candidate"] == 2
+    assert groups_map["accepted"] == 1
+    assert groups_map["rejected"] == 1
+
+
+@pytest.mark.unit
+def test_corpus_stats_group_by_year(tmp_path: Path) -> None:
+    """corpus_stats agrupa por año."""
+    from bib2graph.service.reads import corpus_stats
+
+    ws = _init_workspace(tmp_path)
+    rows = [
+        _row(id="P1", year=2020),
+        _row(id="P2", year=2021),
+        _row(id="P3", year=2020),
+    ]
+    _seed_store(ws, rows)
+
+    result = corpus_stats(ws, group_by="year")
+
+    assert result["group_by"] == "year"
+    assert result["total"] == 3
+    groups_map = {str(g["key"]): g["count"] for g in result["groups"]}
+    assert groups_map["2020"] == 2
+    assert groups_map["2021"] == 1
+
+
+@pytest.mark.unit
+def test_corpus_stats_group_by_is_seed(tmp_path: Path) -> None:
+    """corpus_stats agrupa por is_seed."""
+    from bib2graph.service.reads import corpus_stats
+
+    ws = _init_workspace(tmp_path)
+    rows = [
+        _row(id="P1", is_seed=True),
+        _row(id="P2", is_seed=False),
+        _row(id="P3", is_seed=True),
+    ]
+    _seed_store(ws, rows)
+
+    result = corpus_stats(ws, group_by="is_seed")
+
+    assert result["group_by"] == "is_seed"
+    assert result["total"] == 3
+    # Cada grupo tiene key=True o key=False y count correspondiente
+    assert len(result["groups"]) == 2
+
+
+@pytest.mark.unit
+def test_corpus_stats_group_by_invalido_lanza_dataerror(tmp_path: Path) -> None:
+    """corpus_stats con group_by inválido lanza DataError."""
+    from bib2graph.service.errors import DataError
+    from bib2graph.service.reads import corpus_stats
+
+    ws = _init_workspace(tmp_path)
+    _seed_store(ws, [_row(id="P1")])
+
+    with pytest.raises(DataError, match="no válido"):
+        corpus_stats(ws, group_by="autor")
+
+
+@pytest.mark.unit
+def test_corpus_stats_default_es_status(tmp_path: Path) -> None:
+    """corpus_stats sin parámetro usa group_by='status' por defecto."""
+    from bib2graph.service.reads import corpus_stats
+
+    ws = _init_workspace(tmp_path)
+    _seed_store(ws, [_row(id="P1", curation_status="candidate")])
+
+    result = corpus_stats(ws)
+
+    assert result["group_by"] == "status"
+    assert "groups" in result
+
+
+# ---------------------------------------------------------------------------
+# 3. Servicios — get_paper extendido (id | doi | source_id)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_get_paper_resuelve_por_id(tmp_path: Path) -> None:
+    """get_paper resuelve por id interno (comportamiento original)."""
+    from bib2graph.service.reads import get_paper
+
+    ws = _init_workspace(tmp_path)
+    rows = [_row(id="P1", title="Paper uno", doi="10.1/p1", source_id="W1234")]
+    _seed_store(ws, rows)
+
+    result = get_paper(ws, "P1")
+
+    assert result["id"] == "P1"
+    assert result["title"] == "Paper uno"
+
+
+@pytest.mark.unit
+def test_get_paper_resuelve_por_doi(tmp_path: Path) -> None:
+    """get_paper resuelve por DOI cuando no hay match por id."""
+    from bib2graph.service.reads import get_paper
+
+    ws = _init_workspace(tmp_path)
+    rows = [_row(id="W123", title="Paper con DOI", doi="10.1016/j.ecolecon.2019")]
+    _seed_store(ws, rows)
+
+    result = get_paper(ws, "10.1016/j.ecolecon.2019")
+
+    assert result["id"] == "W123"
+    assert result["doi"] == "10.1016/j.ecolecon.2019"
+
+
+@pytest.mark.unit
+def test_get_paper_resuelve_por_source_id(tmp_path: Path) -> None:
+    """get_paper resuelve por source_id cuando no hay match por id ni doi."""
+    from bib2graph.service.reads import get_paper
+
+    ws = _init_workspace(tmp_path)
+    rows = [_row(id="P1", title="Paper con source_id", source_id="W2741809807")]
+    _seed_store(ws, rows)
+
+    result = get_paper(ws, "W2741809807")
+
+    assert result["id"] == "P1"
+    assert result["source_id"] == "W2741809807"
+
+
+@pytest.mark.unit
+def test_get_paper_prioriza_id_sobre_doi(tmp_path: Path) -> None:
+    """Cuando ident coincide con id de un paper y doi de otro, gana el id."""
+    from bib2graph.service.reads import get_paper
+
+    ws = _init_workspace(tmp_path)
+    # P-DOI tiene id="VALOR" y P2 tiene doi="VALOR"
+    rows = [
+        _row(id="VALOR", title="Coincide por id", doi="10.1/otro"),
+        _row(id="P2", title="Coincide por doi", doi="VALOR"),
+    ]
+    _seed_store(ws, rows)
+
+    result = get_paper(ws, "VALOR")
+
+    # id gana sobre doi
+    assert result["id"] == "VALOR"
+    assert result["title"] == "Coincide por id"
+
+
+@pytest.mark.unit
+def test_get_paper_mismo_paper_tres_ids(tmp_path: Path) -> None:
+    """El mismo paper es encontrable por id, doi y source_id."""
+    from bib2graph.service.reads import get_paper
+
+    ws = _init_workspace(tmp_path)
+    rows = [
+        _row(
+            id="W999",
+            title="Paper multi-identificador",
+            doi="10.1234/test",
+            source_id="W999_openalex",
+        )
+    ]
+    _seed_store(ws, rows)
+
+    by_id = get_paper(ws, "W999")
+    by_doi = get_paper(ws, "10.1234/test")
+    by_source = get_paper(ws, "W999_openalex")
+
+    assert by_id["id"] == by_doi["id"] == by_source["id"] == "W999"
+    assert by_id["title"] == by_doi["title"] == by_source["title"]
+
+
+@pytest.mark.unit
+def test_get_paper_inexistente_lanza_dataerror(tmp_path: Path) -> None:
+    """get_paper con ident que no existe lanza DataError."""
+    from bib2graph.service.errors import DataError
+    from bib2graph.service.reads import get_paper
+
+    ws = _init_workspace(tmp_path)
+    _seed_store(ws, [_row(id="P1")])
+
+    with pytest.raises(DataError, match="no encontrado"):
+        get_paper(ws, "id-que-no-existe")
+
+
+@pytest.mark.unit
+def test_get_paper_devuelve_catorce_campos(tmp_path: Path) -> None:
+    """get_paper devuelve los ~14 campos documentados."""
+    from bib2graph.service.reads import get_paper
+
+    ws = _init_workspace(tmp_path)
+    rows = [
+        _row(
+            id="P1",
+            title="Paper completo",
+            year=2022,
+            doi="10.1/p1",
+            source_id="W001",
+            is_seed=True,
+            curation_status="accepted",
+            references_id=["R1", "R2"],
+        )
+    ]
+    _seed_store(ws, rows)
+
+    result = get_paper(ws, "P1")
+
+    expected_keys = {
+        "id",
+        "source_id",
+        "doi",
+        "title",
+        "year",
+        "abstract",
+        "is_seed",
+        "curation_status",
+        "authors_raw",
+        "authors_id",
+        "keywords_id",
+        "references_id",
+        "cited_by_id",
+        "provenance",
+    }
+    for key in expected_keys:
+        assert key in result, f"Falta clave: {key}"
+
+
+# ---------------------------------------------------------------------------
+# 4. Neutralidad de transporte — service/reads.py sigue siendo neutral
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_service_reads_sigue_siendo_neutral_despues_de_nuevas_funciones() -> None:
+    """list_papers y corpus_stats no rompen la neutralidad de service.reads."""
+    import ast
+    import importlib
+    import pathlib
+
+    mod = importlib.import_module("bib2graph.service.reads")
+    source_file = mod.__file__
+    assert source_file is not None
+    tree = ast.parse(pathlib.Path(source_file).read_text(encoding="utf-8"))
+
+    forbidden = {"click", "fastapi"}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert alias.name.split(".")[0] not in forbidden
+        elif isinstance(node, ast.ImportFrom):
+            assert (node.module or "").split(".")[0] not in forbidden
+        elif isinstance(node, ast.Call):
+            if (
+                isinstance(node.func, ast.Attribute)
+                and isinstance(node.func.value, ast.Name)
+                and node.func.value.id == "sys"
+                and node.func.attr == "exit"
+            ):
+                raise AssertionError("service.reads llama a sys.exit")
+            if isinstance(node.func, ast.Name) and node.func.id == "print":
+                raise AssertionError("service.reads llama a print()")
+
+
+# ---------------------------------------------------------------------------
+# 5. CLI — read list --json
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_cli_read_list_json_envelope_forma(tmp_path: Path) -> None:
+    """read list --json devuelve envelope schema='1', ok=True, data.papers + count."""
+    ws = _init_workspace(tmp_path)
+    _seed_store(
+        ws,
+        [
+            _row(id="P1", title="Alpha", curation_status="candidate"),
+            _row(id="P2", title="Beta", curation_status="accepted"),
+        ],
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        b2g,
+        ["--workspace", str(ws.root), "read", "list", "--json"],
+        catch_exceptions=False,
+    )
+    data = _assert_one_json_line(result.stdout)
+
+    assert data["ok"] is True
+    assert data["command"] == "read list"
+    assert data["exit_code"] == 0
+    assert "papers" in data["data"]
+    assert "count" in data["data"]
+    assert data["data"]["count"] == 2
+
+
+@pytest.mark.unit
+def test_cli_read_list_query_filtra(tmp_path: Path) -> None:
+    """read list --query filtra por título en el CLI."""
+    ws = _init_workspace(tmp_path)
+    _seed_store(
+        ws,
+        [
+            _row(id="P1", title="Ecología Política"),
+            _row(id="P2", title="Economía Ambiental"),
+        ],
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        b2g,
+        ["--workspace", str(ws.root), "read", "list", "--query", "ecolog", "--json"],
+        catch_exceptions=False,
+    )
+    data = _assert_one_json_line(result.stdout)
+
+    assert data["data"]["count"] == 1
+    assert data["data"]["papers"][0]["id"] == "P1"
+
+
+@pytest.mark.unit
+def test_cli_read_list_status_filtra(tmp_path: Path) -> None:
+    """read list --status accepted filtra por curation_status."""
+    ws = _init_workspace(tmp_path)
+    _seed_store(
+        ws,
+        [
+            _row(id="P1", curation_status="accepted"),
+            _row(id="P2", curation_status="candidate"),
+            _row(id="P3", curation_status="accepted"),
+        ],
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        b2g,
+        [
+            "--workspace",
+            str(ws.root),
+            "read",
+            "list",
+            "--status",
+            "accepted",
+            "--json",
+        ],
+        catch_exceptions=False,
+    )
+    data = _assert_one_json_line(result.stdout)
+
+    assert data["data"]["count"] == 2
+
+
+@pytest.mark.unit
+def test_cli_read_list_seeds_filtra(tmp_path: Path) -> None:
+    """read list --seeds filtra a is_seed=True."""
+    ws = _init_workspace(tmp_path)
+    _seed_store(
+        ws,
+        [
+            _row(id="P1", is_seed=True),
+            _row(id="P2", is_seed=False),
+        ],
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        b2g,
+        ["--workspace", str(ws.root), "read", "list", "--seeds", "--json"],
+        catch_exceptions=False,
+    )
+    data = _assert_one_json_line(result.stdout)
+
+    assert data["data"]["count"] == 1
+    assert data["data"]["papers"][0]["id"] == "P1"
+
+
+@pytest.mark.unit
+def test_cli_read_list_candidates_filtra(tmp_path: Path) -> None:
+    """read list --candidates filtra a is_seed=False."""
+    ws = _init_workspace(tmp_path)
+    _seed_store(
+        ws,
+        [
+            _row(id="P1", is_seed=True),
+            _row(id="P2", is_seed=False),
+            _row(id="P3", is_seed=False),
+        ],
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        b2g,
+        ["--workspace", str(ws.root), "read", "list", "--candidates", "--json"],
+        catch_exceptions=False,
+    )
+    data = _assert_one_json_line(result.stdout)
+
+    assert data["data"]["count"] == 2
+
+
+@pytest.mark.unit
+def test_cli_read_list_year_filtra(tmp_path: Path) -> None:
+    """read list --year filtra por año exacto."""
+    ws = _init_workspace(tmp_path)
+    _seed_store(
+        ws,
+        [
+            _row(id="P1", year=2020),
+            _row(id="P2", year=2021),
+        ],
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        b2g,
+        ["--workspace", str(ws.root), "read", "list", "--year", "2021", "--json"],
+        catch_exceptions=False,
+    )
+    data = _assert_one_json_line(result.stdout)
+
+    assert data["data"]["count"] == 1
+    assert data["data"]["papers"][0]["id"] == "P2"
+
+
+@pytest.mark.unit
+def test_cli_read_list_seeds_candidates_mutuamente_excluyentes(tmp_path: Path) -> None:
+    """read list --seeds --candidates → UsageError (exit 1)."""
+    ws = _init_workspace(tmp_path)
+    _seed_store(ws, [_row(id="P1")])
+
+    runner = CliRunner()
+    result = runner.invoke(
+        b2g,
+        [
+            "--workspace",
+            str(ws.root),
+            "read",
+            "list",
+            "--seeds",
+            "--candidates",
+            "--json",
+        ],
+        catch_exceptions=False,
+    )
+    data = _assert_one_json_line(result.stdout)
+
+    assert data["ok"] is False
+    assert result.exit_code == 1
+
+
+# ---------------------------------------------------------------------------
+# 6. CLI — read stats --json
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_cli_read_stats_json_envelope_forma(tmp_path: Path) -> None:
+    """read stats --json devuelve envelope con group_by, total y groups."""
+    ws = _init_workspace(tmp_path)
+    _seed_store(
+        ws,
+        [
+            _row(id="P1", curation_status="candidate"),
+            _row(id="P2", curation_status="accepted"),
+        ],
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        b2g,
+        ["--workspace", str(ws.root), "read", "stats", "--json"],
+        catch_exceptions=False,
+    )
+    data = _assert_one_json_line(result.stdout)
+
+    assert data["ok"] is True
+    assert data["command"] == "read stats"
+    payload = data["data"]
+    assert "group_by" in payload
+    assert "total" in payload
+    assert "groups" in payload
+    assert payload["total"] == 2
+
+
+@pytest.mark.unit
+def test_cli_read_stats_group_by_year(tmp_path: Path) -> None:
+    """read stats --group-by year agrupa por año."""
+    ws = _init_workspace(tmp_path)
+    _seed_store(
+        ws,
+        [
+            _row(id="P1", year=2020),
+            _row(id="P2", year=2021),
+            _row(id="P3", year=2020),
+        ],
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        b2g,
+        ["--workspace", str(ws.root), "read", "stats", "--group-by", "year", "--json"],
+        catch_exceptions=False,
+    )
+    data = _assert_one_json_line(result.stdout)
+
+    payload = data["data"]
+    assert payload["group_by"] == "year"
+    assert payload["total"] == 3
+    groups_map = {str(g["key"]): g["count"] for g in payload["groups"]}
+    assert groups_map["2020"] == 2
+    assert groups_map["2021"] == 1
+
+
+@pytest.mark.unit
+def test_cli_read_stats_group_by_is_seed(tmp_path: Path) -> None:
+    """read stats --group-by is_seed agrupa por semilla."""
+    ws = _init_workspace(tmp_path)
+    _seed_store(
+        ws,
+        [
+            _row(id="P1", is_seed=True),
+            _row(id="P2", is_seed=False),
+        ],
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        b2g,
+        [
+            "--workspace",
+            str(ws.root),
+            "read",
+            "stats",
+            "--group-by",
+            "is_seed",
+            "--json",
+        ],
+        catch_exceptions=False,
+    )
+    data = _assert_one_json_line(result.stdout)
+
+    assert data["ok"] is True
+    assert data["data"]["group_by"] == "is_seed"
+    assert data["data"]["total"] == 2
+
+
+# ---------------------------------------------------------------------------
+# 7. CLI — read show --json
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_cli_read_show_por_id_json(tmp_path: Path) -> None:
+    """read show --id <id> devuelve ~14 campos en el envelope."""
+    ws = _init_workspace(tmp_path)
+    _seed_store(
+        ws,
+        [
+            _row(
+                id="P1",
+                title="Paper de prueba",
+                year=2023,
+                doi="10.1/p1",
+                source_id="W001",
+                is_seed=True,
+                curation_status="accepted",
+                references_id=["R1"],
+            )
+        ],
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        b2g,
+        ["--workspace", str(ws.root), "read", "show", "--id", "P1", "--json"],
+        catch_exceptions=False,
+    )
+    data = _assert_one_json_line(result.stdout)
+
+    assert data["ok"] is True
+    assert data["command"] == "read show"
+    assert data["exit_code"] == 0
+    payload = data["data"]
+    assert payload["id"] == "P1"
+    assert payload["title"] == "Paper de prueba"
+    assert payload["year"] == 2023
+    assert payload["doi"] == "10.1/p1"
+    assert payload["source_id"] == "W001"
+    assert payload["is_seed"] is True
+    assert payload["curation_status"] == "accepted"
+    # provenance es lista
+    assert isinstance(payload["provenance"], list)
+
+
+@pytest.mark.unit
+def test_cli_read_show_por_doi_json(tmp_path: Path) -> None:
+    """read show --id <doi> resuelve por DOI."""
+    ws = _init_workspace(tmp_path)
+    _seed_store(
+        ws,
+        [_row(id="W999", title="Paper DOI", doi="10.9999/test")],
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        b2g,
+        [
+            "--workspace",
+            str(ws.root),
+            "read",
+            "show",
+            "--id",
+            "10.9999/test",
+            "--json",
+        ],
+        catch_exceptions=False,
+    )
+    data = _assert_one_json_line(result.stdout)
+
+    assert data["ok"] is True
+    assert data["data"]["id"] == "W999"
+
+
+@pytest.mark.unit
+def test_cli_read_show_por_source_id_json(tmp_path: Path) -> None:
+    """read show --id <source_id> resuelve por source_id."""
+    ws = _init_workspace(tmp_path)
+    _seed_store(
+        ws,
+        [_row(id="P1", title="Paper source_id", source_id="W2741809807")],
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        b2g,
+        [
+            "--workspace",
+            str(ws.root),
+            "read",
+            "show",
+            "--id",
+            "W2741809807",
+            "--json",
+        ],
+        catch_exceptions=False,
+    )
+    data = _assert_one_json_line(result.stdout)
+
+    assert data["ok"] is True
+    assert data["data"]["id"] == "P1"
+
+
+@pytest.mark.unit
+def test_cli_read_show_inexistente_dataerror_exit2(tmp_path: Path) -> None:
+    """read show --id INEXISTENTE → DataError, ok=False, exit_code=2."""
+    ws = _init_workspace(tmp_path)
+    _seed_store(ws, [_row(id="P1")])
+
+    runner = CliRunner()
+    result = runner.invoke(
+        b2g,
+        [
+            "--workspace",
+            str(ws.root),
+            "read",
+            "show",
+            "--id",
+            "INEXISTENTE",
+            "--json",
+        ],
+        catch_exceptions=False,
+    )
+    data = _assert_one_json_line(result.stdout)
+
+    assert data["ok"] is False
+    assert data["exit_code"] == 2
+    assert result.exit_code == 2
+
+
+# ---------------------------------------------------------------------------
+# 8. read sin subcomando → imprime ayuda (exit 0)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_cli_read_sin_subcomando_imprime_ayuda() -> None:
+    """b2g read sin subcomando → no_args_is_help=True → exit 0 con ayuda."""
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        result = runner.invoke(b2g, ["read"])
+    # no_args_is_help=True hace exit con código 0 y escribe la ayuda
+    assert result.exit_code == 0
+    assert "list" in result.output
+    assert "stats" in result.output
+    assert "show" in result.output
+
+
+# ---------------------------------------------------------------------------
+# 9. stdout puro — una sola línea JSON
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_cli_read_list_stdout_una_linea_json(tmp_path: Path) -> None:
+    """read list --json: stdout es exactamente una línea no-vacía."""
+    ws = _init_workspace(tmp_path)
+    _seed_store(ws, [_row(id="P1")])
+
+    runner = CliRunner()
+    result = runner.invoke(
+        b2g,
+        ["--workspace", str(ws.root), "read", "list", "--json"],
+        catch_exceptions=False,
+    )
+    lineas = [ln for ln in result.stdout.splitlines() if ln.strip()]
+    assert len(lineas) == 1
+
+
+@pytest.mark.unit
+def test_cli_read_show_stdout_una_linea_json(tmp_path: Path) -> None:
+    """read show --json (error o éxito): stdout es exactamente una línea."""
+    ws = _init_workspace(tmp_path)
+    _seed_store(ws, [_row(id="P1")])
+
+    runner = CliRunner()
+    result = runner.invoke(
+        b2g,
+        ["--workspace", str(ws.root), "read", "show", "--id", "P1", "--json"],
+        catch_exceptions=False,
+    )
+    lineas = [ln for ln in result.stdout.splitlines() if ln.strip()]
+    assert len(lineas) == 1
+
+
+@pytest.mark.unit
+def test_cli_read_stats_stdout_una_linea_json(tmp_path: Path) -> None:
+    """read stats --json: stdout es exactamente una línea."""
+    ws = _init_workspace(tmp_path)
+    _seed_store(ws, [_row(id="P1", curation_status="candidate")])
+
+    runner = CliRunner()
+    result = runner.invoke(
+        b2g,
+        ["--workspace", str(ws.root), "read", "stats", "--json"],
+        catch_exceptions=False,
+    )
+    lineas = [ln for ln in result.stdout.splitlines() if ln.strip()]
+    assert len(lineas) == 1
+
+
+# ---------------------------------------------------------------------------
+# 10. read sin workspace → UsageError → envelope de error (exit 1)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_cli_read_list_sin_workspace_exit1_json() -> None:
+    """read list --json sin workspace → UsageError → envelope error, exit 1."""
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        result = runner.invoke(b2g, ["read", "list", "--json"], catch_exceptions=False)
+    data = _assert_one_json_line(result.stdout)
+    assert data["ok"] is False
+    assert result.exit_code == 1


### PR DESCRIPTION
Closes #156. Sub-issue del epic #167 (superficie CLI 0.10.0, ADR 0037 b + 0036). Desbloquea #157 (`read top`).

## Qué
- **Primer grupo noun-verb del repo:** `read {list,stats,show}`. `read` sin subcomando → ayuda + exit 0 (workaround `invoke_without_command=True` por regresión de Click 8.4).
- **`read list`:** `--query` (solo título, substring CI) + `--status`/`--seeds`/`--candidates`/`--year`. Envelope `data={papers:[{id,title,year,curation_status,is_seed}], count}`.
- **`read stats --group-by {status,year,is_seed}`** (default `status`). `data={group_by,total,groups:[{key,count}]}`.
- **`read show --id`:** delega en `get_paper`, devuelve la fila completa (~14 campos).
- **`get_paper(ws, ident)`** resuelve por **id | doi | source_id** (prioridad id>doi>source_id, **ADR 0036**); `DataError` si no matchea. Caller `api/routers/reads.py` sin ruptura.
- Lógica nueva en `service/reads.py` (`list_papers`, `corpus_stats`, `get_paper` extendido), exportada en `service/__init__` — la capa de servicios sigue dueña (ADR 0028/0032).
- **`inspect` queda INTACTO** (su deprecación es #165). `command` del envelope = ruta completa (`"read list"`...). Gancho abierto para `read top` (#157).

## Tests
`tests/unit/test_cli_read.py` (39 tests): servicio (`list_papers`/`corpus_stats`/`get_paper` por id/doi/source_id) + CLI (filtros, formas de envelope, exit-0 sin args, DataError exit 2, stdout puro). Verifier: **PASA** (reservas de docs-drift y exit-code resueltas/ratificadas). Gate verde local: ruff + mypy limpios, 1045 passed.

## Notas de contrato
- `read stats --group-by <inválido>` → **exit 1** (error de uso de Click, coherente con ADR 0010 uso=1/datos=2); `read show --id` sin match → `DataError` exit 2.
- Docs en lockstep: `API.md` (get_paper id|doi|source_id, grupo `read`), `ARCHITECTURE.md` (patrón noun-verb), `AGENTS.md`. Sin ADR nuevo (aplica 0036/0037 ya firmados).

## Invariante
Envelope `schema="1"`, exit codes y stdout puro (#151) **intactos**; todo aditivo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
