### PR TITLE
refactor(cli): curate como grupo noun-verb {dump,apply,accept,reject,filter} (#155)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,14 @@
   reason/fix_command). `read` sin subcomando → ayuda + exit 0 (`invoke_without_command=True`, workaround Click 8.4); el
   `command` del envelope usa la ruta completa (`"read list"`). `inspect` queda **en deprecación** (#165,
   lo absorben `read show` + `status`) pero **sigue vivo**. Ver `docs/API.md` §Convenciones CLI.
+  **Grupo noun-verb `curate {dump,apply,accept,reject,filter}` (#155, ADR 0037 §b):** SEGUNDO grupo del
+  CLI. **BREAKING:** la forma-flag `curate --dump`/`--from-csv` y `--all` fueron **eliminadas sin alias**
+  (`dump --scope all` reemplaza a `--all`; `apply <csv>` reemplaza a `--from-csv`). A diferencia de `read`
+  (transversal entero), **la transición la define el VERBO** (precedente D1 de #159): solo
+  **`curate filter`→`FILTERED`**; `dump`/`apply`/`accept`/`reject` son transversales. Lógica fuente única
+  en `service/curate.py` (`run_curate_dump`/`run_curate_from_csv`/`filter_corpus` con `decided_at`
+  inyectado). Los verbos sueltos `accept`/`reject`/`filter` siguen vivos como **alias deprecados**
+  (retiro 0.11.0, ADR 0038 P1 + enmienda #155). Ver `docs/API.md` §`curate`.
   **645 tests verdes** (mypy/ruff limpios; el núcleo importa sin `duckdb`). Entre las
   redes, la **composición de comunidades es exportable**: `networks/cluster_table` (función pura)
   resume cada comunidad de una red de paper en una fila y `b2g build` la escribe como `clusters.csv`

--- a/docs/API.md
+++ b/docs/API.md
@@ -141,7 +141,7 @@
 > materializa el principio **CLI-puro** del PO (ADR
 > [0030](decisiones/0030-ecuacion-declarativa-corpus-ejemplo.md) §AS-BUILT Ciclo B). `build_corpus.py`
 > **eliminado**: el ejemplo se arma y reproduce **100% por CLI** (`seed --spec equation.yaml`
-> `max_results 80` → `curate --from-csv curacion.csv` 10 `accepted` → `enrich --max-citing 25` →
+> `max_results 80` → `curate apply curacion.csv` 10 `accepted` → `enrich --max-citing 25` →
 > `snapshot`). Corpus = **~80 filas** (70 `candidate` + 10 `accepted` enriquecidas), **co-citación
 > presente** (rala) — antes 137 filas / co-citación vacía (9b). Nuevo artefacto congelado
 > **`curacion.csv`** (receta determinista de curación). Gate R2 ajustado (piso `n>=50`,
@@ -404,41 +404,60 @@ resolución DOI→`source_id` del flujo BibTeX e2e, issues #110/#112, ADR
   `networks/`/`snapshots/`/`exports/`; **`b2g init .`** inicializa el cwd. Si la carpeta ya es un
   workspace → error (`WorkspaceExistsError`). **NO transiciona** el `CycleState`. `data` =
   `{root, name, ...}`; `--json` con `schema="1"`.
-- **`curate`** (#22 + #26, AS-BUILT 2026-06-16): **curación en lote vía CSV** —cierra el hueco de la
-  [Nota 09](Notas/09-sesion-qa-prueba-ecologia-valoraciones.md) B4/B5/P1 (la curación a escala no era
-  viable con `accept`/`reject` por `--ids` uno a uno). **Dos modos mutuamente excluyentes** (exactamente
-  uno; pasar ambos o ninguno → error de uso, exit 1):
-  - **`--dump`** escribe un CSV revisable offline (Excel/Calc). Default
+- **`curate`** (#22 + #26 origen; **grupo noun-verb AS-BUILT #155**, ADR 0037 (b)): **grupo de
+  curación** con cinco subcomandos —`{dump, apply, accept, reject, filter}`—. Reorganiza la superficie
+  de curación a `b2g curate <verbo>` (decisión (b) del ADR
+  [0037](decisiones/0037-superficie-cli-10-verbos-ciclo.md), 2° grupo noun-verb tras `read`).
+  **`b2g curate` sin subcomando → help + exit 0.**
+  **BREAKING (autorizado por ADR 0037 (b), sin alias):** la **forma-flag** `curate --dump` /
+  `curate --from-csv` fue **ELIMINADA**; `curate --all` también (usar `--scope all`). La lógica vive en
+  `service/curate.py` (fuente única, ver §0); el CLI solo parsea y delega.
+
+  **La transición del FSM la define el VERBO, no el grupo** (precedente D1 de #159): **`curate filter`
+  transiciona a `FILTERED`**; `dump`/`apply`/`accept`/`reject` son **transversales** (NO transicionan,
+  disponibles en cualquier estado del lazo). Esto matiza la regla previa "curate es transversal" —cierta
+  como bloque, ahora por-verbo (ver enmienda en el ADR 0037).
+
+  - **`curate dump`** (= ex `--dump`) escribe un CSV revisable offline (Excel/Calc). Default
     `<workspace>/exports/curacion.csv`; **`--out`** lo override. **`--scope [candidates|seeds|all]`**
     (default `candidates`) elige qué papers volcar: `candidates` = forrajeados a revisar
     (`curation_status == 'candidate'` **AND** `is_seed == False`, **excluye semillas** —arregla #72,
     donde el dump arrastraba seeds); `seeds` = semillas originales (`is_seed == True`); `all` = todo el
-    corpus. **`--all`** queda como **alias deprecado de `--scope all`** (tiene precedencia si se pasan
-    ambos). Sin candidatos (scope `candidates`/`seeds` vacío) → error accionable que sugiere `--scope all`
-    o `b2g chain`. Columnas (16, orden estable): `id, source_id, title, year, authors, venue, doi,
-    keywords, cited_by_count, references_count, is_seed, openalex_url, scent_score, cluster, decision,
-    note`. **Todas read-only salvo `decision` y `note`** (las editables por el humano). `venue` sale de
-    `source`; `keywords` se une con `" | "` (igual que `authors`); `openalex_url` es una **columna
-    derivada OpenAlex-específica**: se construye `https://openalex.org/<source_id>` solo cuando el
-    `source_id` parece un ID de OpenAlex (`W…`), si no queda vacía. **`cited_by_count`/`references_count` hoy salen vacías**:
-    no existen como escalares en el schema canónico de 23 columnas, así que la columna queda como
-    placeholder para llenado manual (limitación conocida, no falla). `decision` refleja el
-    `curation_status` actual (`candidate`→`undecided`, `accepted`→`accepted`, `rejected`→`rejected`).
-    `data` = `{csv_path, papers_exported, columns}`.
-  - **`--from-csv <archivo>`** aplica las decisiones en lote y persiste: `accepted`→`accept`,
-    `rejected`→`reject`, `undecided`→no-op (case-insensitive). **Idempotente** (reimportar el mismo CSV
-    = mismo `corpus_hash`; el reloj `decided_at` se inyecta en la **frontera CLI**, R2/ADR 0017, fuera
-    de la identidad). **Validación accionable** (exit 2): CSV sin `id`/`decision` → error que nombra las
-    columnas requeridas; `decision` con un valor fuera de `{accepted, rejected, undecided}` → error con
-    los valores válidos. **IDs huérfanos** (en el CSV pero no en el corpus) **NO se aplican** y se
-    reportan en `not_found_count` + aviso humano (cierra el no-op silencioso). `data` =
-    `{accepted_count, rejected_count, skipped_count, not_found_count, total_rows}` —los `*_count` de
-    accept/reject cuentan papers **efectivamente** encontrados y marcados, no filas del CSV.
-  - **`note` es advisory:** hace round-trip en el dump pero **se ignora al importar** (`ProvenanceEvent`
+    corpus. **`--all` ELIMINADO** (usar `--scope all`). Sin candidatos (scope `candidates`/`seeds`
+    vacío) → error accionable que sugiere `--scope all` o `b2g chain`. Columnas (16, orden estable):
+    `id, source_id, title, year, authors, venue, doi, keywords, cited_by_count, references_count,
+    is_seed, openalex_url, scent_score, cluster, decision, note`. **Todas read-only salvo `decision` y
+    `note`** (las editables por el humano). `venue` sale de `source`; `keywords` se une con `" | "`
+    (igual que `authors`); `openalex_url` es una **columna derivada OpenAlex-específica**: se construye
+    `https://openalex.org/<source_id>` solo cuando el `source_id` parece un ID de OpenAlex (`W…`), si no
+    queda vacía. **`cited_by_count`/`references_count` hoy salen vacías**: no existen como escalares en
+    el schema canónico de 23 columnas, así que la columna queda como placeholder para llenado manual
+    (limitación conocida, no falla). `decision` refleja el `curation_status` actual
+    (`candidate`→`undecided`, `accepted`→`accepted`, `rejected`→`rejected`). `data` =
+    `{csv_path, papers_exported, columns}`. Transversal (NO transiciona).
+  - **`curate apply <csv>`** (= ex `--from-csv`) aplica las decisiones en lote y persiste:
+    `accepted`→`accept`, `rejected`→`reject`, `undecided`→no-op (case-insensitive). **Idempotente**
+    (reimportar el mismo CSV = mismo `corpus_hash`; el reloj `decided_at` se inyecta en la **frontera
+    CLI**, R2/ADR 0017, fuera de la identidad). **Validación accionable** (exit 2): CSV sin
+    `id`/`decision` → error que nombra las columnas requeridas; `decision` con un valor fuera de
+    `{accepted, rejected, undecided}` → error con los valores válidos. **IDs huérfanos** (en el CSV pero
+    no en el corpus) **NO se aplican** y se reportan en `not_found_count` + aviso humano (cierra el no-op
+    silencioso). `data` = `{accepted_count, rejected_count, skipped_count, not_found_count, total_rows}`
+    —los `*_count` de accept/reject cuentan papers **efectivamente** encontrados y marcados, no filas del
+    CSV. Transversal (NO transiciona).
+  - **`curate accept --ids ... [--by NOMBRE]`** / **`curate reject --ids ... [--by NOMBRE]`**: aceptan
+    o rechazan papers por ID (curación uno-a-uno o en lote por flags). Comparten la lógica de servicio
+    (`accept_papers`/`reject_papers`) con los verbos sueltos `accept`/`reject` (que quedan INTACTOS como
+    alias deprecados, retiro 0.11.0 — ver §verbos huérfanos y ADR 0038). Transversales (NO transicionan).
+  - **`curate filter`** (flags PRISMA `--year-gte`/`--year-lte`, `--language`, `--type`,
+    `--min-citations`): aplica criterios de inclusión/exclusión MARCANDO `rejected` (no borra; conserva
+    la trazabilidad PRISMA) con conteo por paso. **Transiciona el `CycleState` a `FILTERED`** (único
+    verbo del grupo que transiciona). Comparte `filter_corpus` con el verbo suelto `filter` (alias
+    deprecado, retiro 0.11.0).
+  - **`note` es advisory:** hace round-trip en `dump` pero **se ignora en `apply`** (`ProvenanceEvent`
     no tiene campo de anotación; persistirla → ADR futuro). **`scent_score` best-effort** (vacío hasta
     que el Forager guarde `scent` en provenance) y **`cluster` siempre vacío** (integración con redes
-    diferida). **Curación TRANSVERSAL: `curate` NO transiciona el `CycleState`** (disponible en cualquier
-    estado del lazo, igual que `accept`/`reject`; ADR 0016 enmendado R3). `--json` con `schema="1"`.
+    diferida). `--json` con `schema="1"` en todos los subcomandos.
 - **`networks`** (Hito 9, **EN DEPRECACIÓN — absorbido por `build --spec`**, ADR 0037 (a) / 0038,
   ventana cierra 0.11.0): **capa declarativa** — construye redes desde un YAML versionable.
   **`b2g networks --spec <redes.yaml>`** carga la lista de specs con `load_specs` (§10;
@@ -580,11 +599,14 @@ cache **no existe** (nunca se corrió `build`), **no** es stale. `status` **avis
 invalidación por hash, **no** un build-system (ADR [0029](decisiones/0029-workspace-por-investigacion.md)).
 
 **Transiciones automáticas del ciclo** (ADR 0021 §F; AS-BUILT R3): `seed`→`SEEDED`, `chain`→`FORAGED`,
-`filter`→`FILTERED`, `build`→`BUILT`, **`monitor`→`MONITORED`** (cleanup pre-v0.3),
+`filter`→`FILTERED`, **`curate filter`→`FILTERED`** (#155: dentro del grupo `curate` la transición la
+define el VERBO, no el grupo —precedente D1 de #159), `build`→`BUILT`,
+**`monitor`→`MONITORED`** (cleanup pre-v0.3),
 **`restore`→`FILTERED`** (Ciclo 9a, ADR 0030: el corpus restaurado ya pasó curación; reusa la
 transición permisiva `filter`);
-`accept`/`reject`/**`curate`**/**`read`**/`export`/`snapshot`/`status`/`inspect`/`validate`/**`enrich`**/**`networks`**
-**no transicionan** (`curate` y **`read`** son transversales/lectura pura; `enrich` y `networks` son
+`accept`/`reject`/**`curate {dump,apply,accept,reject}`**/**`read`**/`export`/`snapshot`/`status`/`inspect`/`validate`/**`enrich`**/**`networks`**
+**no transicionan** (los verbos transversales de `curate` y **`read`** son transversales/lectura pura
+—**salvo `curate filter`**, que sí transiciona; `enrich` y `networks` son
 ortogonales al lazo, ADR 0025 / Hito 9). El estado
 destino lo dicta `bib2graph.cycle.apply_transition`
 (fuente única de verdad; los comandos no hardcodean el destino). `seed` con **estado previo** se trata
@@ -636,6 +658,22 @@ materializó en #157 (antes diferido). La lógica vive en `service/reads.py` (`l
 
 `inspect` (verbo plano) **sigue vivo pero en deprecación** (#165): `read show` lo absorbe para
 papers y `status` para manifest/FSM. **No** está removido en este hito.
+
+**Grupo `curate {dump,apply,accept,reject,filter}` — SEGUNDO grupo noun-verb del CLI (#155, ADR
+[0037](decisiones/0037-superficie-cli-10-verbos-ciclo.md) §b).** Mismo patrón que `read`: `curate`
+**sin subcomando** imprime la ayuda y sale con **exit 0**; el `command` del envelope usa la **ruta
+completa** (`"curate dump"`, `"curate apply"`, `"curate accept"`, `"curate reject"`,
+`"curate filter"`). La semántica de cada verbo está arriba (§`curate`). **A diferencia de `read`
+(transversal entero), la transición la define el VERBO** (precedente D1 de #159): solo
+`curate filter` transiciona a `FILTERED` (vía `apply_transition`, fuente única); el resto es
+transversal. La lógica vive en `service/curate.py` (fuente única CLI/FastAPI, §0):
+**`run_curate_dump`**, **`run_curate_from_csv`** (el verbo `apply`), **`filter_corpus`** y
+`accept_papers`/`reject_papers`. **`filter_corpus(store_path, *, year_gte, year_lte, language,
+type_in, min_citations, decided_at)`** recibe el **reloj `decided_at` inyectado** por ambos callers
+(el subcomando `curate filter` y el verbo suelto `filter`), preservando la neutralidad de servicio
+(ADR [0017](decisiones/0017-reproducibilidad-historia-snapshot.md): el reloj entra por la frontera,
+no por el servicio). **BREAKING:** la forma-flag `curate --dump`/`--from-csv` y `--all` fueron
+eliminadas sin alias (autorizado por ADR 0037 §b).
 
 **Envelope JSON común y versionado** (ADR 0021 §C): en modo `--json`, cada subcomando emite **un
 objeto JSON** con `schema="1"`:
@@ -947,6 +985,15 @@ de un solo paper que valida `decision ∈ {accepted, rejected}`). Todas verifica
 (`DataError` si faltan), abren el store con `_open_writable` (`StoreLockedError`/`OSError` → `StoreError`)
 e **inyectan `decided_at`** desde la frontera. **`run_accept`/`run_reject` (CLI) quedan como shims que
 delegan**, con su firma intacta (`by="cli"`, `decided_at` inyectado), así que `test_cli.py` no cambia.
+
+**Extensión #155 (grupo `curate` noun-verb).** `service/curate.py` consolida la **fuente única** de
+toda la curación (CLI y FastAPI): suma **`run_curate_dump`** (= `curate dump`), **`run_curate_from_csv`**
+(= `curate apply`) y **`filter_corpus(store_path, *, year_gte, year_lte, language, type_in,
+min_citations, decided_at)`** (= `curate filter` y el verbo suelto `filter`) a las ya existentes
+`accept_papers`/`reject_papers`/`curate_paper`. `filter_corpus` recibe el **reloj `decided_at`
+inyectado** por ambos callers (subcomando y verbo suelto) → neutralidad de servicio restaurada
+(ADR [0017](decisiones/0017-reproducibilidad-historia-snapshot.md): el reloj entra por la frontera,
+no por el servicio). Las funciones de comando del CLI quedan como **shims que delegan**.
 
 **Subcomando `b2g gui`.** Ver [`ARCHITECTURE.md`](ARCHITECTURE.md) §6.3 y §convenciones CLI (19°
 subcomando): levanta `uvicorn.run` sobre `create_app`, sirve la SPA buildeada de `gui/static/` **si
@@ -1428,7 +1475,7 @@ epic GUI #34). Reglas:
   - **`equation.yaml`** — la ecuación de procedencia (cargable con `EquationSpec`, §2). Documenta
     "de qué búsqueda salió este corpus"; **no** es el comando del gate.
   - **`curacion.csv`** *(cuando el ejemplo pasa por curación)* — las decisiones de curación
-    congeladas que `b2g curate --from-csv` consume: **receta determinista** de curación (aplicarlo
+    congeladas que `b2g curate apply` consume: **receta determinista** de curación (aplicarlo
     al corpus sembrado produce el mismo estado, independiente de cuándo se corra).
   - **`README.md`** — qué demuestra y con qué comandos se arma/reproduce. **Es la procedencia:**
     la **receta CLI** documentada (armado con red + reproducción offline), no un script.
@@ -1440,7 +1487,7 @@ epic GUI #34). Reglas:
 - **Ejemplos existentes:**
   - **`examples/valoraciones/`** (Ciclo B, AS-BUILT 2026-06-17): **~80 filas** (70 `candidate` +
     10 `accepted` enriquecidos), armado **100% por CLI** (sin script): `seed --spec equation.yaml`
-    (`max_results: 80`) → `curate --from-csv curacion.csv` → `enrich --max-citing 25` → `snapshot`.
+    (`max_results: 80`) → `curate apply curacion.csv` → `enrich --max-citing 25` → `snapshot`.
     **Co-citación presente** (rala) + coupling/author/institution/keyword sustanciales. Verificado por
     el gate R2 `tests/unit/test_example_r2_gate.py` (`corpus_hash` estable + comunidades Louvain
     estables entre corridas; piso `n>=50`, las 5 redes con datos). Se rehidrata con

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -607,6 +607,18 @@ corpus desde un parquet curado **sin red** (inverso de `snapshot`; preserva `dec
 una opción desconocida como `--store` —eliminada en #75—, o ningún workspace resoluble) sale **sin
 envelope** (Click aborta el parseo: stderr + exit 1).
 
+> **AS-BUILT — superficie noun-verb (ADR [0037](decisiones/0037-superficie-cli-10-verbos-ciclo.md)
+> /[0038](decisiones/0038-destino-verbos-huerfanos-0037.md)):** la superficie del 0021 (verbos planos,
+> arriba) se reorganiza a **10 verbos que mapean el ciclo**, con **dos grupos noun-verb**:
+> **`read {list,stats,show,top}`** (1°, #156/#157) y **`curate {dump,apply,accept,reject,filter}`**
+> (2°, #155). En el grupo `curate` la transición la define el **VERBO** (precedente D1 de #159):
+> **`curate filter`→`FILTERED`**, el resto transversal. La lógica es fuente única en `service/`
+> (`service/reads.py`, `service/curate.py`). Los **verbos planos** `accept`/`reject`/`filter`/`inspect`
+> /`networks`/`monitor`/`resolve` quedan como **alias deprecados** (retiro **0.11.0**, ADR 0038 P1 +
+> enmienda #155 que sumó `filter` al gap), y `restore`→`snapshot restore`, `enrich`→`chain`/`build`,
+> `thesaurus` retirado (ADR 0038). El **contrato vivo de la superficie** está en
+> [`API.md`](API.md) §convenciones CLI (no se replica acá para evitar drift).
+
 **AS-BUILT R5 — UTF-8 en la frontera (Nota 06 RAÍZ 3):** `main()` llama `_force_utf8()` (reconfigura
 `sys.stdout`/`stderr` a UTF-8, con guarda por si la stream no es reconfigurable) **antes de que Click
 lea nada**. Sin esto, el envelope `--json` (`ensure_ascii=False`) y `--help` corrompen acentos en la

--- a/docs/decisiones/0037-superficie-cli-10-verbos-ciclo.md
+++ b/docs/decisiones/0037-superficie-cli-10-verbos-ciclo.md
@@ -258,3 +258,29 @@ sella). Es decir: lo que define la transición es **el verbo `build`**, no el mo
 - **Invariante:** envelope `schema="1"`, exit codes y la forma del FSM **no cambian**; D1 solo fija
   *cuándo* se dispara la transición ya existente. Contrato AS-BUILT en
   [`../API.md`](../API.md) §`build`.
+
+## Enmienda 2026-06-27 (append-only) — D2: en el grupo `curate` la transición la define el VERBO (#155)
+
+> Anotación append-only (gemela de la D1 de arriba; no revierte nada). Decidida por el **PO** durante
+> la implementación del grupo noun-verb `curate` (decisión (b)), sub-issue
+> [#155](https://github.com/complexluise/bib2graph/issues/155).
+
+La decisión (b) agrupó `dump`/`apply`/`accept`/`reject`/`filter` bajo `curate`. El cuerpo de arriba
+trata la curación como **transversal** (ver tabla de verbos: "`accept`/`reject`/`filter`→`curate …`"),
+y eso era cierto **como bloque** cuando eran verbos planos. Pero al volverse grupo surgió el mismo
+matiz que la D1 resolvió para `build`: **¿el grupo `curate` es transversal entero, o la transición la
+define cada verbo?** El verbo suelto `filter` —histórico— transicionaba a `FILTERED`.
+
+**D2 (PO):** **dentro del grupo `curate`, la transición del FSM la define el VERBO, no el grupo**
+—mismo principio que la D1 (el verbo `build`, no el modo, define la transición)—. Concretamente:
+
+- **`curate filter` transiciona a `FILTERED`** (idéntico al verbo suelto `filter`; reusa
+  `apply_transition`, fuente única).
+- **`curate dump` / `curate apply` / `curate accept` / `curate reject` son transversales** (NO
+  transicionan, disponibles en cualquier estado del lazo).
+
+Esto **matiza** —no revierte— la regla "curate es transversal" del cuerpo: era verdadera como bloque
+de verbos planos; ahora es por-verbo. **Invariante:** envelope `schema="1"`, exit codes y la forma del
+FSM **no cambian**; D2 solo fija *qué verbo del grupo* dispara la transición ya existente. La lógica es
+fuente única en `service/curate.py` (`filter_corpus` con `decided_at` inyectado, neutralidad de
+servicio ADR 0017). Contrato AS-BUILT en [`../API.md`](../API.md) §`curate`.

--- a/docs/decisiones/0038-destino-verbos-huerfanos-0037.md
+++ b/docs/decisiones/0038-destino-verbos-huerfanos-0037.md
@@ -173,3 +173,22 @@ contra `--help`**.
 - **Cerrar la ventana de deprecación por fecha calendario en vez de por versión.** Rechazada (P1):
   el criterio por **versión (0.11.0)** es verificable, reproducible y no depende del calendario de
   release; es coherente con cómo el proyecto versiona (release-please).
+
+## Enmienda 2026-06-27 (append-only) — corrige el gap de P1: `filter` también entra a la ventana (#155)
+
+> Anotación append-only (no revierte nada de arriba). Surge de la implementación del grupo `curate`
+> noun-verb (sub-issue [#155](https://github.com/complexluise/bib2graph/issues/155)): al absorber
+> `filter` en `curate filter` se constató que **P1 omitió `filter`** de la lista de aliases en
+> deprecación.
+
+El parámetro **(P1)** enumeró los aliases que cierran en `0.11.0` como *"`networks`, `accept`,
+`reject`, `inspect`, `monitor` —más `resolve` y el entry-point `bib2graph`"*. Pero el ADR
+[0037](0037-superficie-cli-10-verbos-ciclo.md) (decisión (b)) absorbió **`accept`/`reject`/`filter`**
+en el grupo `curate`: los tres verbos planos quedan como alias deprecados. P1 listó `accept` y
+`reject` pero **omitió `filter`** —un gap, no una decisión—.
+
+**Corrección:** el verbo suelto **`filter` se suma a la ventana de deprecación**, con el mismo
+criterio que `accept`/`reject`: sigue funcionando **con aviso** durante 0.10.x y **se elimina en
+0.11.0**, como alias deprecado del nuevo **`curate filter`**. (`filter` y `curate filter` comparten la
+lógica de servicio `filter_corpus`, fuente única; el suelto es un shim que delega.) El resto de P1 no
+cambia. AS-BUILT del grupo `curate` en [`../API.md`](../API.md) §`curate`.

--- a/docs/features/C-curar.feature
+++ b/docs/features/C-curar.feature
@@ -84,7 +84,7 @@ Característica: Curar el corpus con filtros PRISMA y biblioteca viva
 
   # --- C4 (escala) · Curación en lote vía CSV ---
   Escenario: C4 — Volcar candidatos a CSV para revisión offline
-    Cuando ejecuto "b2g curate --dump --json"
+    Cuando ejecuto "b2g curate dump --json"
     Entonces el exit code es 0
     Y se escribe "exports/curacion.csv" con las 16 columnas estables
     Y "data.papers_exported" es un entero >= 0
@@ -92,13 +92,13 @@ Característica: Curar el corpus con filtros PRISMA y biblioteca viva
     # Solo "decision" y "note" son editables por el humano.
 
   Escenario: C4 — Volcar semillas o todo el corpus con --scope
-    Cuando ejecuto "b2g curate --dump --scope all --json"
+    Cuando ejecuto "b2g curate dump --scope all --json"
     Entonces el exit code es 0
     Y "data.papers_exported" cubre todo el corpus (candidates + seeds + accepted + rejected)
 
   Escenario: C4 — Reimportar las decisiones del CSV en lote (idempotente)
     Dado un "exports/curacion.csv" con la columna "decision" editada
-    Cuando ejecuto "b2g curate --from-csv exports/curacion.csv --json"
+    Cuando ejecuto "b2g curate apply exports/curacion.csv --json"
     Entonces el exit code es 0
     Y "data.accepted_count" cuenta papers efectivamente marcados como accepted
     Y "data.rejected_count" cuenta papers efectivamente marcados como rejected
@@ -106,9 +106,9 @@ Característica: Curar el corpus con filtros PRISMA y biblioteca viva
     Y "data.not_found_count" cuenta IDs del CSV ausentes del corpus (huérfanos, sin abortar)
     # Idempotente: reimportar el mismo CSV deja el mismo corpus_hash (note se ignora al importar).
 
-  Escenario: C4 — from-csv con una decision inválida falla accionable
+  Escenario: C4 — apply con una decision inválida falla accionable
     Dado un CSV con un valor de "decision" fuera de {accepted, rejected, undecided}
-    Cuando ejecuto "b2g curate --from-csv exports/curacion.csv --json"
+    Cuando ejecuto "b2g curate apply exports/curacion.csv --json"
     Entonces el exit code es 2
     Y "error.code" indica un error de datos (DataError)
 

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -34,7 +34,7 @@ vuelven **ejecutables con `pytest-bdd`** apuntando a este mismo directorio, sin 
 | C1 dedup/normalización autores+inst. | **`@pendiente`** | **No hay subcomando CLI**: `normalize`/`deduplicate_keywords` son API de librería (`preprocessors/`), no `b2g`. Instituciones diferidas (ROADMAP C1). El CLI no expone preprocesamiento |
 | C2 thesaurus multilingüe | **`@pendiente`** | **No hay subcomando CLI**: `apply_thesaurus` es API de librería (`preprocessors/thesaurus.py`), no `b2g`. Determinista, sin fallback LLM (ADR 0022/0011) |
 | C3 filtros incl/excl con conteo | verde | `filter` con `data.steps[].count_before/count_after/excluded` (flujo PRISMA) |
-| C4 aceptar/rechazar + biblioteca viva | verde | `accept`/`reject --ids`, `curate --dump`/`--from-csv`; persiste y crece entre corridas |
+| C4 aceptar/rechazar + biblioteca viva | verde | `curate {dump,apply,accept,reject,filter}` (grupo noun-verb #155); `accept`/`reject --ids` sueltos vivos (alias deprecados); persiste y crece entre corridas |
 | D1 cinco proyecciones | verde (parcial) | `build` da 4 redes; la 5ª (cocitación) requiere `enrich` previo (cited_by_id). Instituciones salen si hay `institutions_id` |
 | D2 métricas y comunidades | verde | `metrics.json` (density, etc.) + comunidades Louvain; `clusters.csv` en redes de paper |
 | D3 asortatividad + composición + proxy | **`@pendiente`** | **No hay camino CLI**: `assortativity()`/`community_composition()` existen como funciones puras en `networks/analyzer.py` y se re-exportan en `networks/__init__.py`, pero `facade._build_artifact` fija `assortativity=None` y **no consume** `NetworkSpec.assortativity_attribute`. Es API de librería, no de CLI |
@@ -62,9 +62,9 @@ uv run b2g chain --direction both --depth 1 --max-citing 25 --json
 
 # C — curar
 uv run b2g filter --year-gte 2010 --language en --json
-uv run b2g curate --dump --json                    # escribe exports/curacion.csv (solo candidatos)
+uv run b2g curate dump --json                      # escribe exports/curacion.csv (solo candidatos)
 # (editar la columna decision en exports/curacion.csv)
-uv run b2g curate --from-csv exports/curacion.csv --json
+uv run b2g curate apply exports/curacion.csv --json
 uv run b2g accept --ids oa:abc123 --json
 
 # D — redes

--- a/src/bib2graph/cli/__init__.py
+++ b/src/bib2graph/cli/__init__.py
@@ -1,18 +1,19 @@
-"""cli — CLI agente-native ``b2g`` (Hito 6 + ADR 0029 workspace).
+"""cli — CLI agente-native ``b2g`` (Hito 6 + ADR 0029 workspace + #155 surface CLI 0.10.0).
 
-Arma el grupo Click principal, registra los 21 subcomandos (20 planos + el
-grupo noun-verb ``read``) y expone ``main()`` como entry point del paquete.
+Arma el grupo Click principal, registra los subcomandos planos y los grupos
+noun-verb, y expone ``main()`` como entry point del paquete.
 
 Entry point en ``pyproject.toml``:
     b2g = "bib2graph.cli:main"
 
-Subcomandos planos (20):
+Subcomandos planos (19):
     init, seed, chain, filter, build, enrich, monitor, export, snapshot,
-    status, inspect, validate, accept, reject, curate, networks, restore,
+    status, inspect, validate, accept, reject, networks, restore,
     thesaurus, gui, resolve.
 
-Grupos noun-verb (1):
-    read [list|stats|show]  — lecturas read-only del corpus (#156).
+Grupos noun-verb (2):
+    read   [list|stats|show|top] — lecturas read-only del corpus (#156/#157).
+    curate [dump|apply|accept|reject|filter] — curación en lote (#155).
 
 Cada subcomando lleva:
   - ``--json``: salida JSON estructurada (envelope versionado, §API.md).
@@ -43,7 +44,7 @@ import click
 from bib2graph.cli.commands.accept import accept_cmd
 from bib2graph.cli.commands.build import build_cmd
 from bib2graph.cli.commands.chain import chain_cmd
-from bib2graph.cli.commands.curate import curate_cmd
+from bib2graph.cli.commands.curate import curate_grp
 from bib2graph.cli.commands.enrich import enrich_cmd
 from bib2graph.cli.commands.export import export_cmd
 from bib2graph.cli.commands.filter import filter_cmd
@@ -105,8 +106,9 @@ def b2g(ctx: click.Context, workspace: str | None) -> None:
     error accionable (exit 1) que sugiere 'b2g init' o '--workspace'.
 
     Subcomandos: init, seed, chain, filter, build, enrich, monitor, export,
-    snapshot, status, inspect, validate, accept, reject, curate, networks,
-    restore, thesaurus, gui, resolve, read [list|stats|show].
+    snapshot, status, inspect, validate, accept, reject, networks,
+    restore, thesaurus, gui, resolve,
+    read [list|stats|show|top], curate [dump|apply|accept|reject|filter].
 
     Ejemplo:
         b2g init mi-investigacion
@@ -118,7 +120,7 @@ def b2g(ctx: click.Context, workspace: str | None) -> None:
     ctx.obj["workspace"] = workspace
 
 
-# Registrar los 20 subcomandos planos + el grupo noun-verb read (#156)
+# Registrar subcomandos planos + grupos noun-verb read (#156) y curate (#155)
 b2g.add_command(init_cmd)
 b2g.add_command(seed_cmd)
 b2g.add_command(chain_cmd)
@@ -133,7 +135,7 @@ b2g.add_command(inspect_cmd)
 b2g.add_command(validate_cmd)
 b2g.add_command(accept_cmd)
 b2g.add_command(reject_cmd)
-b2g.add_command(curate_cmd)
+b2g.add_command(curate_grp)
 b2g.add_command(networks_cmd)
 b2g.add_command(restore_cmd)
 b2g.add_command(thesaurus_cmd)

--- a/src/bib2graph/cli/commands/curate.py
+++ b/src/bib2graph/cli/commands/curate.py
@@ -1,699 +1,219 @@
-"""cli.commands.curate — Subcomando ``b2g curate``.
+"""cli.commands.curate — Grupo noun-verb ``b2g curate`` (#155, superficie CLI 0.10.0).
 
-Curación en lote (#22 dump + #26 import + #72 fix scope + #58 columnas):
-permite revisar y marcar papers en una tabla externa (Excel/Calc) y
-reimportar las decisiones al corpus.
+Convierte ``curate`` de comando plano con flags en un **grupo noun-verb** con
+cinco subcomandos:
+
+  ``curate dump``    — exporta papers a CSV para revisión offline.
+  ``curate apply``   — reimporta decisiones desde el CSV editado.
+  ``curate accept``  — acepta papers por id (transversal, sin FSM).
+  ``curate reject``  — rechaza papers por id (transversal, sin FSM).
+  ``curate filter``  — aplica filtros PRISMA y transiciona a FILTERED.
+
+Molde: ``read.py`` (#156/#157) — grupo noun-verb con ``invoke_without_command=True``
+y check manual para exit 0 sin subcomando (Click 8.4 usa exit 2 con
+``no_args_is_help=True`` en grupos).
+
+BREAKING (#155):
+  - ``curate --dump`` y ``curate --from-csv`` eliminados (sin alias).
+  - ``curate --all`` eliminado; usar ``curate dump --scope all``.
+
+TRANSVERSAL (ADR 0016 enmendado, R3):
+  ``dump``, ``apply``, ``accept`` y ``reject`` son transversales: no transicionan
+  el CycleState.  ``filter`` SÍ transiciona a FILTERED (el verbo define la
+  transición, precedente D1 de #159).
+
+Capa de servicios (#155):
+  Toda la lógica vive en ``service.curate``; este módulo son shims delgados
+  que inyectan el reloj (frontera CLI, R2/ADR 0017) y emiten el envelope.
+
+Backward compat con tests existentes:
+  ``CSV_COLUMNS``, ``CURATE_CSV_FILENAME``, ``CSV_REQUIRED_COLUMNS``,
+  ``VALID_DECISIONS``, ``VALID_SCOPES``, ``run_curate_dump``,
+  ``run_curate_from_csv`` se re-exportan desde ``service.curate`` para que los
+  tests que importan de ``bib2graph.cli.commands.curate`` sigan funcionando.
 
 Flujo canónico:
-    b2g curate --dump                       # exporta candidatos forrajeados
-    b2g curate --dump --scope seeds         # exporta semillas
-    b2g curate --dump --scope all           # exporta todo el corpus
-    b2g curate --dump --all                 # alias de --scope all (deprecado)
-    b2g curate --dump --out mi.csv          # override de ruta de salida
-    b2g curate --from-csv mi.csv            # reimporta las decisiones del CSV
-
-El CSV que ``--dump`` produce tiene exactamente las columnas que ``--from-csv``
-lee, lo que garantiza el round-trip sin fricción.
-
-Columnas (readonly salvo decision/note):
-    id              — identificador canónico del paper (readonly)
-    source_id       — identificador del motor de extracción (readonly)
-    title           — título (readonly)
-    year            — año de publicación (readonly)
-    authors         — lista de autores separada por \" | \" (readonly)
-    venue           — nombre de la revista/fuente (readonly)
-    doi             — DOI del paper (readonly)
-    keywords        — lista de keywords separada por \" | \" (readonly)
-    cited_by_count  — conteo de citaciones; vacío si no está en el corpus (readonly)
-    references_count— conteo de referencias; vacío si no está en el corpus (readonly)
-    is_seed         — True si es semilla original (readonly)
-    openalex_url    — URL directa a OpenAlex (derivada de source_id si es W…) (readonly)
-    scent_score     — best-effort desde provenance del candidato; vacío si no hay
-    cluster         — reservado para futura integración de redes; siempre vacío hoy
-    decision        — editable: accepted | rejected | undecided
-    note            — editable: texto libre, advisory (round-trip solo)
-
-Semántica de scope (#72 / #58):
-    candidates (default) — papers forrajeados a revisar:
-        curation_status == 'candidate' AND is_seed == False.
-        Excluye semillas (que nacen con is_seed=True y status=candidate).
-    seeds               — papers con is_seed == True.
-    all                 — todo el corpus (candidates + seeds + accepted + rejected).
-
-``note`` es advisory:
-    ``ProvenanceEvent`` no tiene un campo genérico de anotación. Registrar la
-    nota en ``decided_by`` (el único campo libre en provenance) contaminaría
-    semántica. Por lo tanto la nota se preserva en el CSV (round-trip) pero
-    NO se persiste en el corpus. El docstring lo declara explícitamente.
-
-``scent_score`` best-effort:
-    Si hay eventos de chaining en el provenance del paper, se lee el campo
-    ``scent`` que el Forager puede haber guardado. Si no existe, queda vacío.
-    No se falla por ausencia.
-
-``cluster`` best-effort:
-    Reservado para cuando los grafos de red estén disponibles. Siempre vacío
-    en esta versión. No se falla por ausencia.
-
-``cited_by_count`` / ``references_count`` best-effort:
-    No están en el schema canónico de 23 columnas (no los almacena OpenAlex
-    pipeline). Se dejan vacíos; la columna existe para que el humano la llene
-    manualmente si quiere.
-
-``openalex_url`` derivada:
-    Si hay ``source_id`` (ej. ``W2741809807`` de OpenAlex), la URL es
-    ``https://openalex.org/<source_id>``. Si no hay source_id o no es un ID
-    de OpenAlex (W…), queda vacío.
-
-Idempotencia:
-    Reimportar el mismo CSV produce el mismo estado. ``accept``/``reject`` del
-    Corpus son idempotentes (``apply_curation`` en el backend verifica el id).
-
-R2 (ADR 0017 enmendado):
-    ``decided_at`` se inyecta en la frontera CLI (aquí), no en el núcleo.
-    El hash del Corpus excluye timestamps de provenance.
-
-CURACIÓN TRANSVERSAL (ADR 0016 enmendado, R3):
-    ``curate`` es curación transversal: no transiciona el CycleState.
-    Disponible en cualquier estado del lazo.
+    b2g curate dump                          # exporta candidatos a curacion.csv
+    b2g curate dump --scope all              # exporta todo el corpus
+    b2g curate dump --out mi.csv             # override de ruta
+    b2g curate apply curacion.csv            # aplica decisiones
+    b2g curate apply curacion.csv --by maria # con identificador de curador
+    b2g curate accept --ids W1 --ids W2      # acepta por id
+    b2g curate reject --ids W3               # rechaza por id
+    b2g curate filter --year-gte 2018        # filtra y transiciona a FILTERED
 """
 
 from __future__ import annotations
 
-import csv
 from datetime import UTC, datetime
-from pathlib import Path
-from typing import Any
 
 import click
 
 from bib2graph.cli._envelope import build_envelope, emit, emit_human
-from bib2graph.cli._errors import DataError, UsageError, handle_errors
+from bib2graph.cli._errors import handle_errors
 from bib2graph.cli._options import json_mode, json_option
-from bib2graph.cli._store import open_store, resolve_workspace
-from bib2graph.constants import Col, CurationStatus
+from bib2graph.cli._store import resolve_library_path, resolve_workspace
+from bib2graph.service.curate import (
+    CSV_COLUMNS,
+    CSV_REQUIRED_COLUMNS,
+    CURATE_CSV_FILENAME,
+    VALID_DECISIONS,
+    VALID_SCOPES,
+    run_curate_dump,
+    run_curate_from_csv,
+)
 
-# ---------------------------------------------------------------------------
-# Constantes del CSV de curación
-# ---------------------------------------------------------------------------
-
-CURATE_CSV_FILENAME = "curacion.csv"
-
-# Columnas del CSV: orden estable y conocido por el humano y la reimportación.
-# Las columnas readonly van primero; decision y note son las editables.
-CSV_COLUMNS = [
-    "id",
-    "source_id",
-    "title",
-    "year",
-    "authors",
-    "venue",
-    "doi",
-    "keywords",
-    "cited_by_count",
-    "references_count",
-    "is_seed",
-    "openalex_url",
-    "scent_score",
-    "cluster",
-    "decision",
-    "note",
+__all__ = [
+    "CSV_COLUMNS",
+    "CSV_REQUIRED_COLUMNS",
+    "CURATE_CSV_FILENAME",
+    "VALID_DECISIONS",
+    "VALID_SCOPES",
+    "curate_grp",
+    "run_curate_dump",
+    "run_curate_from_csv",
 ]
 
-# Columnas requeridas para que ``--from-csv`` acepte el archivo.
-CSV_REQUIRED_COLUMNS = {"id", "decision"}
-
-# Valores válidos para la columna ``decision``.
-VALID_DECISIONS = {
-    CurationStatus.ACCEPTED,
-    CurationStatus.REJECTED,
-    "undecided",
-}
-
-# Mapa de curation_status → decision en el dump
-_STATUS_TO_DECISION: dict[str, str] = {
-    CurationStatus.CANDIDATE: "undecided",
-    CurationStatus.ACCEPTED: "accepted",
-    CurationStatus.REJECTED: "rejected",
-}
-
-# Scope válidos para --dump
-VALID_SCOPES = {"candidates", "seeds", "all"}
-
 
 # ---------------------------------------------------------------------------
-# Helpers internos
+# Grupo raíz
 # ---------------------------------------------------------------------------
 
 
-def _authors_display(row: dict[str, Any]) -> str:
-    """Extrae los autores de una fila del corpus y los une con ' | '.
+@click.group("curate", invoke_without_command=True)
+@click.pass_context
+def curate_grp(ctx: click.Context) -> None:
+    """Curación del corpus: dump, apply, accept, reject, filter.
 
-    Usa ``authors_raw`` si disponible, ``authors_id`` como fallback.
-    Devuelve cadena vacía si no hay datos.
+    Subcomandos: dump, apply, accept, reject, filter.
 
-    Args:
-        row: Fila de la tabla Arrow convertida a dict.
-
-    Returns:
-        Cadena de autores separada por \" | \" o cadena vacía.
+    Ejemplos:
+        b2g curate dump
+        b2g curate dump --scope all
+        b2g curate apply curacion.csv
+        b2g curate accept --ids W1 --ids W2
+        b2g curate reject --ids W3
+        b2g curate filter --year-gte 2018 --year-lte 2024
     """
-    raw = row.get(Col.AUTHORS_RAW)
-    if raw and isinstance(raw, list):
-        return " | ".join(str(a) for a in raw if a)
-    ids = row.get(Col.AUTHORS_ID)
-    if ids and isinstance(ids, list):
-        return " | ".join(str(a) for a in ids if a)
-    return ""
-
-
-def _keywords_display(row: dict[str, Any]) -> str:
-    """Extrae las keywords de una fila del corpus y las une con ' | '.
-
-    Usa ``keywords_id`` si disponible (identificadores OpenAlex), con
-    ``keywords_raw`` como fallback. Mismo patrón que ``_authors_display``.
-    Devuelve cadena vacía si no hay datos.
-
-    Args:
-        row: Fila de la tabla Arrow convertida a dict.
-
-    Returns:
-        Cadena de keywords separada por \" | \" o cadena vacía.
-    """
-    ids = row.get(Col.KEYWORDS_ID)
-    if ids and isinstance(ids, list):
-        return " | ".join(str(k) for k in ids if k)
-    raw = row.get(Col.KEYWORDS_RAW)
-    if raw and isinstance(raw, list):
-        return " | ".join(str(k) for k in raw if k)
-    return ""
-
-
-def _openalex_url(row: dict[str, Any]) -> str:
-    """Deriva la URL de OpenAlex a partir del source_id de la fila.
-
-    Solo aplica cuando el source_id es un ID de OpenAlex (W…).
-    Formato: ``https://openalex.org/<source_id>``.
-    Devuelve cadena vacía si no hay source_id o no parece un ID de OpenAlex.
-
-    Args:
-        row: Fila de la tabla Arrow convertida a dict.
-
-    Returns:
-        URL de OpenAlex o cadena vacía.
-    """
-    src_id = row.get(Col.SOURCE_ID)
-    if src_id:
-        src_str = str(src_id)
-        # Solo construir URL para IDs de OpenAlex (W seguido de dígitos)
-        if src_str.startswith("W") and src_str[1:].isdigit():
-            return f"https://openalex.org/{src_str}"
-    return ""
-
-
-def _scent_score_display(row: dict[str, Any]) -> str:
-    """Extrae el scent_score del provenance si está disponible.
-
-    El Forager puede haber guardado un campo ``scent`` en provenance.
-    Esta función lo busca en el JSON de provenance. Si no existe, devuelve
-    cadena vacía (best-effort, no falla).
-
-    Args:
-        row: Fila de la tabla Arrow convertida a dict.
-
-    Returns:
-        Valor de scent como string, o cadena vacía.
-    """
-    import json
-
-    provenance_raw = row.get(Col.PROVENANCE)
-    if not provenance_raw:
-        return ""
-    try:
-        events = json.loads(str(provenance_raw))
-        if not isinstance(events, list):
-            return ""
-        # Buscar el campo 'scent' en cualquier evento
-        for event in events:
-            if isinstance(event, dict):
-                val = event.get("scent")
-                if val is not None:
-                    return str(val)
-    except (json.JSONDecodeError, TypeError):
-        pass
-    return ""
-
-
-def _row_to_csv_dict(row: dict[str, Any]) -> dict[str, str]:
-    """Convierte una fila del corpus al dict para el CSV de curación.
-
-    Incluye las columnas readonly enriquecidas (venue, doi, keywords,
-    cited_by_count, references_count, is_seed, openalex_url) además de
-    las columnas base (id, source_id, title, year, authors, scent_score,
-    cluster) y las columnas editables (decision, note).
-
-    ``cited_by_count`` y ``references_count`` no están en el schema canónico;
-    se dejan vacíos (best-effort).
-
-    Args:
-        row: Fila de la tabla Arrow convertida a dict.
-
-    Returns:
-        Dict con las columnas del CSV de curación, todas como strings.
-    """
-    status = str(row.get(Col.CURATION_STATUS, CurationStatus.CANDIDATE))
-    decision = _STATUS_TO_DECISION.get(status, "undecided")
-    is_seed_val = row.get(Col.IS_SEED)
-    is_seed_str = str(is_seed_val) if is_seed_val is not None else ""
-
-    return {
-        "id": str(row.get(Col.ID) or ""),
-        "source_id": str(row.get(Col.SOURCE_ID) or ""),
-        "title": str(row.get(Col.TITLE) or ""),
-        "year": str(row.get(Col.YEAR) or ""),
-        "authors": _authors_display(row),
-        "venue": str(row.get(Col.SOURCE) or ""),
-        "doi": str(row.get(Col.DOI) or ""),
-        "keywords": _keywords_display(row),
-        "cited_by_count": "",  # no está en el schema canónico; best-effort vacío
-        "references_count": "",  # no está en el schema canónico; best-effort vacío
-        "is_seed": is_seed_str,
-        "openalex_url": _openalex_url(row),
-        "scent_score": _scent_score_display(row),
-        "cluster": "",  # reservado para integración con redes
-        "decision": decision,
-        "note": "",
-    }
+    ctx.ensure_object(dict)
+    # Click 8.4: no_args_is_help=True en grupos termina con exit 2.
+    # Usamos invoke_without_command=True + check manual para exit 0 correcto.
+    if ctx.invoked_subcommand is None:
+        click.echo(ctx.get_help())
 
 
 # ---------------------------------------------------------------------------
-# Helpers de filtrado por scope
+# curate dump
 # ---------------------------------------------------------------------------
 
 
-def _filter_table_by_scope(table: Any, scope: str) -> Any:
-    """Filtra una tabla Arrow según el scope de dump.
-
-    Scope 'candidates': curation_status == 'candidate' AND is_seed == False.
-    Scope 'seeds':      is_seed == True.
-    Scope 'all':        sin filtro.
-
-    Se importa pyarrow.compute localmente para mantener el módulo libre de
-    efectos de import globales (AGENTS.md §Imports).
-
-    Args:
-        table: Tabla Arrow del corpus.
-        scope: Uno de 'candidates', 'seeds', 'all'.
-
-    Returns:
-        Tabla Arrow filtrada.
-    """
-    import pyarrow.compute as pc
-
-    if scope == "all":
-        return table
-    elif scope == "seeds":
-        mask = table.column(Col.IS_SEED)
-        return table.filter(mask)
-    else:
-        # candidates: status == candidate AND NOT is_seed
-        status_col = table.column(Col.CURATION_STATUS)
-        is_candidate = pc.equal(status_col, CurationStatus.CANDIDATE)  # type: ignore[attr-defined]
-        is_seed_col = table.column(Col.IS_SEED)
-        not_seed = pc.invert(is_seed_col)  # type: ignore[attr-defined]
-        mask = pc.and_(is_candidate, not_seed)  # type: ignore[attr-defined]
-        return table.filter(mask)
-
-
-# ---------------------------------------------------------------------------
-# Función núcleo: dump
-# ---------------------------------------------------------------------------
-
-
-def run_curate_dump(
-    store_path: str | Path,
-    *,
-    out_path: Path,
-    scope: str = "candidates",
-    include_all: bool = False,
-) -> dict[str, Any]:
-    """Exporta el corpus a un CSV para revisión offline.
-
-    Por defecto exporta solo los candidatos forrajeados (``scope='candidates'``:
-    ``curation_status == 'candidate'`` AND ``is_seed == False``), que excluye
-    semillas. Con ``scope='seeds'`` exporta las semillas; con ``scope='all'``
-    exporta todo el corpus.
-
-    El parámetro ``include_all`` es un alias deprecado de ``scope='all'``:
-    si es ``True``, equivale a forzar ``scope='all'``.
-
-    Columnas del CSV: id, source_id, title, year, authors, venue, doi,
-    keywords, cited_by_count, references_count, is_seed, openalex_url,
-    scent_score, cluster, decision, note.
-    Las columnas ``decision`` y ``note`` son las editables por el humano.
-
-    Args:
-        store_path: Ruta al archivo ``.duckdb``.
-        out_path: Ruta completa del archivo CSV de salida.
-        scope: 'candidates' (default), 'seeds' o 'all'.
-            'candidates' = curation_status=='candidate' AND is_seed==False.
-            'seeds' = is_seed==True.
-            'all' = todo el corpus.
-        include_all: Alias deprecado de scope='all'. Si True, fuerza scope='all'.
-
-    Returns:
-        Dict con ``csv_path``, ``papers_exported``, ``columns``.
-
-    Raises:
-        DataError: Si el corpus está vacío o no hay papers en el scope dado
-            cuando el scope no es 'all'.
-        StoreError: Si el store está bloqueado.
-    """
-    # include_all es alias deprecado de scope='all'
-    effective_scope = "all" if include_all else scope
-
-    store = open_store(store_path)
-    corpus = store.load()
-
-    all_table = corpus.to_arrow()
-    table = _filter_table_by_scope(all_table, effective_scope)
-
-    rows = table.to_pylist()
-
-    if not rows and effective_scope != "all":
-        scope_label = (
-            "candidatos forrajeados" if effective_scope == "candidates" else "semillas"
-        )
-        raise DataError(
-            f"No hay {scope_label} para exportar. "
-            "Usá --scope all para exportar todo el corpus, o ejecutá "
-            "``b2g chain`` para agregar candidatos."
-        )
-
-    out_path.parent.mkdir(parents=True, exist_ok=True)
-
-    with open(out_path, "w", newline="", encoding="utf-8") as f:
-        writer = csv.DictWriter(f, fieldnames=CSV_COLUMNS)
-        writer.writeheader()
-        for row in rows:
-            writer.writerow(_row_to_csv_dict(row))
-
-    return {
-        "csv_path": str(out_path),
-        "papers_exported": len(rows),
-        "columns": CSV_COLUMNS,
-    }
-
-
-# ---------------------------------------------------------------------------
-# Función núcleo: from-csv
-# ---------------------------------------------------------------------------
-
-
-def run_curate_from_csv(
-    store_path: str | Path,
-    csv_path: str | Path,
-    *,
-    by: str = "cli",
-    decided_at: datetime | None = None,
-) -> dict[str, Any]:
-    """Reimporta decisiones de curación desde un CSV al corpus.
-
-    Lee el CSV producido por ``--dump`` (u otro CSV con columnas ``id`` y
-    ``decision``), aplica las decisiones en lote e persiste.
-
-    Las columnas extra del CSV enriquecido (venue, doi, keywords, etc.) se
-    ignoran; solo se requieren ``id`` y ``decision``. Esto garantiza el
-    round-trip dump→from-csv aunque el CSV tenga más columnas que el mínimo.
-
-    Mapeo de ``decision``:
-      - ``accepted``  → ``Corpus.accept``
-      - ``rejected``  → ``Corpus.reject``
-      - ``undecided`` → no-op (el paper conserva su estado actual)
-
-    Idempotente: reimportar el mismo CSV produce el mismo estado final.
-
-    ``note``: advisory — no se persiste en el corpus (``ProvenanceEvent``
-    no tiene campo de anotación genérico). La nota solo hace round-trip en
-    el CSV; se ignora silenciosamente al importar.
-
-    R2 (ADR 0017 enmendado): ``decided_at`` se inyecta desde la frontera CLI
-    (la función que llama); el núcleo no llama al reloj.
-
-    Args:
-        store_path: Ruta al archivo ``.duckdb``.
-        csv_path: Ruta al archivo CSV con las decisiones.
-        by: Identificador de quien decide (default: ``"cli"``).
-        decided_at: Timestamp de la decisión inyectado desde la frontera.
-            Si es ``None``, el backend usa ``datetime.now(UTC)`` como fallback.
-
-    Returns:
-        Dict con ``accepted_count``, ``rejected_count``, ``skipped_count``,
-        ``not_found_count``, ``total_rows``.
-
-        ``accepted_count`` y ``rejected_count`` reflejan papers **efectivamente
-        encontrados y marcados** en el corpus, no filas del CSV.
-        ``not_found_count`` cuenta IDs del CSV que no existían en el corpus
-        (huérfanos — se reportan sin abortar para preservar la idempotencia
-        del flujo batch).
-
-    Raises:
-        DataError: Si el CSV no existe, le faltan columnas requeridas
-            (``id``, ``decision``), o contiene valores de ``decision`` inválidos.
-        StoreError: Si el store está bloqueado.
-    """
-    csv_path = Path(csv_path)
-    if not csv_path.exists():
-        raise DataError(
-            f"El archivo CSV '{csv_path}' no existe. "
-            "Generalo primero con ``b2g curate --dump``."
-        )
-
-    # Leer y validar el CSV
-    rows: list[dict[str, str]] = []
-    with open(csv_path, newline="", encoding="utf-8") as f:
-        reader = csv.DictReader(f)
-        fieldnames = set(reader.fieldnames or [])
-
-        missing = CSV_REQUIRED_COLUMNS - fieldnames
-        if missing:
-            raise DataError(
-                f"El CSV '{csv_path}' no tiene las columnas requeridas: "
-                f"{sorted(missing)}. "
-                "Asegurate de exportar con ``b2g curate --dump`` y no borrar "
-                "las columnas obligatorias (id, decision)."
-            )
-
-        for i, row in enumerate(reader, start=2):  # línea 1 = header
-            decision = row.get("decision", "").strip().lower()
-            if decision not in VALID_DECISIONS:
-                raise DataError(
-                    f"Línea {i}: valor de 'decision' inválido: '{row.get('decision')}'. "
-                    f"Valores válidos: {sorted(VALID_DECISIONS)}."
-                )
-            rows.append(row)
-
-    if not rows:
-        return {
-            "accepted_count": 0,
-            "rejected_count": 0,
-            "skipped_count": 0,
-            "not_found_count": 0,
-            "total_rows": 0,
-        }
-
-    # Agrupar por decisión
-    to_accept = [r["id"] for r in rows if r["decision"].strip().lower() == "accepted"]
-    to_reject = [r["id"] for r in rows if r["decision"].strip().lower() == "rejected"]
-    # undecided → no-op
-    skipped = len(rows) - len(to_accept) - len(to_reject)
-
-    curated_backend_close = None
-    store = open_store(store_path)
-    try:
-        corpus = store.load()
-
-        # Detectar IDs huérfanos (no existen en el corpus).
-        # No se aborta: el flujo batch debe ser idempotente aunque el corpus haya
-        # cambiado entre el dump y el from-csv.  Se reporta ``not_found_count``
-        # para que el humano/agente detecte typos en el CSV.
-        existing_ids: set[str] = {
-            str(r.get(Col.ID, "")) for r in corpus.to_arrow().to_pylist()
-        }
-        to_accept_found = [id_ for id_ in to_accept if id_ in existing_ids]
-        to_reject_found = [id_ for id_ in to_reject if id_ in existing_ids]
-        not_found = [id_ for id_ in (to_accept + to_reject) if id_ not in existing_ids]
-
-        # R2: decided_at ya viene inyectado desde la frontera CLI
-        if to_accept_found:
-            corpus = corpus.accept(to_accept_found, by=by, decided_at=decided_at)
-        if to_reject_found:
-            corpus = corpus.reject(to_reject_found, by=by, decided_at=decided_at)
-
-        curated_backend_close = getattr(corpus._backend, "close", None)
-        store.persist(corpus)
-    finally:
-        if curated_backend_close is not None:
-            curated_backend_close()
-        store.close()
-
-    return {
-        "accepted_count": len(to_accept_found),
-        "rejected_count": len(to_reject_found),
-        "skipped_count": skipped,
-        "not_found_count": len(not_found),
-        "total_rows": len(rows),
-    }
-
-
-# ---------------------------------------------------------------------------
-# Comando Click
-# ---------------------------------------------------------------------------
-
-
-@click.command("curate")
-@click.option(
-    "--dump",
-    "do_dump",
-    is_flag=True,
-    default=False,
-    help=(
-        "Exporta los candidatos a un CSV para revisión offline. "
-        "Salida default: <workspace>/exports/curacion.csv."
-    ),
-)
-@click.option(
-    "--from-csv",
-    "from_csv",
-    default=None,
-    type=click.Path(),
-    help="Reimporta decisiones de curación desde el CSV dado.",
-)
+@curate_grp.command("dump")
 @click.option(
     "--out",
     "out_override",
     default=None,
     type=click.Path(),
     help=(
-        "Ruta de salida del CSV (solo con --dump). "
-        "Override del default <workspace>/exports/curacion.csv."
+        "Ruta de salida del CSV. Override del default <workspace>/exports/curacion.csv."
     ),
 )
 @click.option(
     "--scope",
-    "scope",
     default="candidates",
     type=click.Choice(["candidates", "seeds", "all"]),
     show_default=True,
     help=(
-        "Con --dump: qué papers exportar. "
+        "Qué papers exportar. "
         "'candidates' (default) = forrajeados a revisar (is_seed=False, status=candidate). "
         "'seeds' = semillas originales. "
         "'all' = todo el corpus."
     ),
 )
-@click.option(
-    "--all",
-    "include_all",
-    is_flag=True,
-    default=False,
-    help=(
-        "Con --dump: incluye todos los papers del corpus. "
-        "Alias deprecado de --scope all; tiene precedencia sobre --scope si ambos se pasan."
-    ),
-)
-@click.option(
-    "--by",
-    default="cli",
-    show_default=True,
-    help="Identificador de quien decide (solo con --from-csv).",
-)
 @json_option
 @click.pass_context
-@handle_errors("curate")
-def curate_cmd(
+@handle_errors("curate dump")
+def dump_cmd(
     ctx: click.Context,
-    do_dump: bool,
-    from_csv: str | None,
     out_override: str | None,
     scope: str,
-    include_all: bool,
-    by: str,
     json_output: bool,
 ) -> None:
-    """Curación en lote: exporta papers a CSV y reimporta decisiones.
+    """Exporta papers a CSV para revisión offline.
 
-    Dos modos mutuamente excluyentes (exactamente uno requerido):
-
-    \b
-      --dump          exporta papers a CSV para revisión offline.
-      --from-csv CSV  reimporta decisiones desde el CSV dado.
-
-    Flujo típico:
-
-    \b
-      b2g curate --dump                  # genera curacion.csv (solo candidatos forrajeados)
-      b2g curate --dump --scope seeds    # genera curacion.csv con semillas
-      b2g curate --dump --scope all      # genera curacion.csv con todo el corpus
-      # (editar curacion.csv en Excel: columnas decision y note)
-      b2g curate --from-csv curacion.csv  # aplica decisiones
+    Por defecto exporta solo los candidatos forrajeados (is_seed=False,
+    status=candidate).  Editá las columnas ``decision`` y ``note`` en
+    Excel/Calc y luego reimportá con ``b2g curate apply``.
 
     Curación TRANSVERSAL: no transiciona el CycleState.
-    Disponible en cualquier estado del lazo (ADR 0016 enmendado R3).
     """
-    # --- Validar exclusividad de modos ---
-    if do_dump and from_csv:
-        raise UsageError(
-            "--dump y --from-csv son mutuamente excluyentes. "
-            "Usá uno u otro por invocación."
-        )
-    if not do_dump and from_csv is None:
-        raise UsageError("Debés especificar un modo: --dump o --from-csv <archivo>.")
+    from pathlib import Path
 
     ws = resolve_workspace(ctx.obj)
     store_path = ws.library_path
 
-    # --- Modo dump ---
-    if do_dump:
-        if out_override is not None:
-            out_path = Path(out_override)
-        else:
-            out_path = ws.exports_dir / CURATE_CSV_FILENAME
+    if out_override is not None:
+        out_path = Path(out_override)
+    else:
+        out_path = ws.exports_dir / CURATE_CSV_FILENAME
 
-        data = run_curate_dump(
-            store_path,
-            out_path=out_path,
-            scope=scope,
-            include_all=include_all,
-        )
-
-        if json_mode(json_output):
-            envelope = build_envelope(
-                command="curate",
-                ok=True,
-                data=data,
-                exit_code=0,
-            )
-            emit(envelope)
-        else:
-            emit_human(
-                f"Exportados {data['papers_exported']} papers a: {data['csv_path']}"
-            )
-        return
-
-    # --- Modo from-csv ---
-    # R2: el reloj se inyecta en la frontera (ADR 0017 enmendado)
-    now = datetime.now(UTC)
-    data = run_curate_from_csv(
-        store_path,
-        from_csv,  # type: ignore[arg-type]
-        by=by,
-        decided_at=now,
-    )
+    data = run_curate_dump(store_path, out_path=out_path, scope=scope)
 
     if json_mode(json_output):
         envelope = build_envelope(
-            command="curate",
+            command="curate dump",
+            ok=True,
+            data=data,
+            exit_code=0,
+        )
+        emit(envelope)
+    else:
+        emit_human(f"Exportados {data['papers_exported']} papers a: {data['csv_path']}")
+
+
+# ---------------------------------------------------------------------------
+# curate apply
+# ---------------------------------------------------------------------------
+
+
+@curate_grp.command("apply")
+@click.argument("csv_file", type=click.Path())
+@click.option(
+    "--by",
+    default="cli",
+    show_default=True,
+    help="Identificador de quien decide (curador).",
+)
+@json_option
+@click.pass_context
+@handle_errors("curate apply")
+def apply_cmd(
+    ctx: click.Context,
+    csv_file: str,
+    by: str,
+    json_output: bool,
+) -> None:
+    """Reimporta decisiones de curación desde CSV al corpus.
+
+    CSV_FILE es el archivo CSV editado producido por ``b2g curate dump``.
+    Solo las columnas ``id`` y ``decision`` son requeridas; el resto se ignora
+    (garantiza round-trip dump→apply aunque el CSV tenga columnas extra).
+
+    Decisiones aceptadas: accepted, rejected, undecided (no-op).
+
+    Idempotente: reimportar el mismo CSV produce el mismo estado final.
+
+    Curación TRANSVERSAL: no transiciona el CycleState.
+    """
+    ws = resolve_workspace(ctx.obj)
+    store_path = ws.library_path
+
+    # R2: el reloj se inyecta en la frontera CLI (ADR 0017 enmendado).
+    now = datetime.now(UTC)
+    data = run_curate_from_csv(store_path, csv_file, by=by, decided_at=now)
+
+    if json_mode(json_output):
+        envelope = build_envelope(
+            command="curate apply",
             ok=True,
             data=data,
             exit_code=0,
@@ -711,3 +231,187 @@ def curate_cmd(
                 "encontraron en el corpus (posibles typos). "
                 "Verificá con ``b2g inspect``."
             )
+
+
+# ---------------------------------------------------------------------------
+# curate accept
+# ---------------------------------------------------------------------------
+
+
+@curate_grp.command("accept")
+@click.option(
+    "--ids",
+    required=True,
+    multiple=True,
+    help="IDs de papers a aceptar (repetible: --ids ID1 --ids ID2).",
+)
+@click.option(
+    "--by",
+    default="cli",
+    show_default=True,
+    help="Identificador de quien decide.",
+)
+@json_option
+@click.pass_context
+@handle_errors("curate accept")
+def curate_accept_cmd(
+    ctx: click.Context,
+    ids: tuple[str, ...],
+    by: str,
+    json_output: bool,
+) -> None:
+    """Marca papers como accepted en el corpus.
+
+    Curación TRANSVERSAL: no transiciona el CycleState.  Disponible en
+    cualquier estado del lazo (Nota 05 §4, ADR 0016 enmendado R3).
+    """
+    from bib2graph.service.curate import accept_papers
+
+    store_path = resolve_library_path(ctx.obj)
+    now = datetime.now(UTC)
+    data = accept_papers(store_path, list(ids), by=by, decided_at=now)
+
+    if json_mode(json_output):
+        envelope = build_envelope(
+            command="curate accept",
+            ok=True,
+            data=data,
+            exit_code=0,
+        )
+        emit(envelope)
+    else:
+        emit_human(f"Aceptados {data['accepted_count']} papers.")
+
+
+# ---------------------------------------------------------------------------
+# curate reject
+# ---------------------------------------------------------------------------
+
+
+@curate_grp.command("reject")
+@click.option(
+    "--ids",
+    required=True,
+    multiple=True,
+    help="IDs de papers a rechazar (repetible: --ids ID1 --ids ID2).",
+)
+@click.option(
+    "--by",
+    default="cli",
+    show_default=True,
+    help="Identificador de quien decide.",
+)
+@json_option
+@click.pass_context
+@handle_errors("curate reject")
+def curate_reject_cmd(
+    ctx: click.Context,
+    ids: tuple[str, ...],
+    by: str,
+    json_output: bool,
+) -> None:
+    """Marca papers como rejected en el corpus.
+
+    Curación TRANSVERSAL: no transiciona el CycleState.  Disponible en
+    cualquier estado del lazo (Nota 05 §4, ADR 0016 enmendado R3).
+    """
+    from bib2graph.service.curate import reject_papers
+
+    store_path = resolve_library_path(ctx.obj)
+    now = datetime.now(UTC)
+    data = reject_papers(store_path, list(ids), by=by, decided_at=now)
+
+    if json_mode(json_output):
+        envelope = build_envelope(
+            command="curate reject",
+            ok=True,
+            data=data,
+            exit_code=0,
+        )
+        emit(envelope)
+    else:
+        emit_human(f"Rechazados {data['rejected_count']} papers.")
+
+
+# ---------------------------------------------------------------------------
+# curate filter
+# ---------------------------------------------------------------------------
+
+
+@curate_grp.command("filter")
+@click.option("--year-gte", type=int, default=None, help="Incluir años >= este valor.")
+@click.option("--year-lte", type=int, default=None, help="Incluir años <= este valor.")
+@click.option(
+    "--language",
+    multiple=True,
+    help="Códigos ISO 639-1 a incluir (repetible: --language en --language es).",
+)
+@click.option(
+    "--type",
+    "type_in",
+    multiple=True,
+    help="Áreas de investigación a incluir (repetible).",
+)
+@click.option(
+    "--min-citations",
+    type=int,
+    default=None,
+    help="Mínimo de citantes en cited_by_id.",
+)
+@json_option
+@click.pass_context
+@handle_errors("curate filter")
+def curate_filter_cmd(
+    ctx: click.Context,
+    year_gte: int | None,
+    year_lte: int | None,
+    language: tuple[str, ...],
+    type_in: tuple[str, ...],
+    min_citations: int | None,
+    json_output: bool,
+) -> None:
+    """Aplica filtros PRISMA al corpus (marca rejected, no borra).
+
+    Tras el filtro, el estado del lazo transiciona a FILTERED.
+
+    Este es el único subcomando de ``curate`` que transiciona el CycleState
+    (el verbo define la transición — precedente D1 de #159).
+    """
+    from bib2graph.service.curate import filter_corpus
+
+    store_path = resolve_library_path(ctx.obj)
+    # R2: el reloj se inyecta en la frontera CLI (ADR 0017 enmendado).
+    now = datetime.now(UTC)
+    data = filter_corpus(
+        store_path,
+        year_gte=year_gte,
+        year_lte=year_lte,
+        language=list(language) if language else None,
+        type_in=list(type_in) if type_in else None,
+        min_citations=min_citations,
+        decided_at=now,
+    )
+
+    if json_mode(json_output):
+        envelope = build_envelope(
+            command="curate filter",
+            ok=True,
+            data=data,
+            exit_code=0,
+        )
+        emit(envelope)
+    else:
+        emit_human(f"Filtros aplicados: {data['criteria_applied']}")
+        for step in data["steps"]:
+            emit_human(
+                f"  {step['name']}: {step['count_before']} → {step['count_after']} "
+                f"(-{step['excluded']})"
+            )
+        emit_human(f"Total en corpus: {data['total_papers']}")
+
+
+# ---------------------------------------------------------------------------
+# Alias curate_cmd → curate_grp (compat con registros existentes)
+# ---------------------------------------------------------------------------
+
+curate_cmd = curate_grp

--- a/src/bib2graph/cli/commands/filter.py
+++ b/src/bib2graph/cli/commands/filter.py
@@ -2,6 +2,13 @@
 
 Aplica filtros PRISMA deterministas al corpus: marca rejected (no borra).
 Transiciona el CycleState a FILTERED tras persistir con éxito.
+
+Shim delgado (#155): la orquestación vive en ``service.curate.filter_corpus``;
+este módulo es un shim que delega.  ``curate filter`` comparte la misma fuente
+de lógica para garantizar comportamiento idéntico.
+
+``run_filter`` se mantiene aquí como función importable para tests existentes;
+internamente llama a ``service.curate.filter_corpus``.
 """
 
 from __future__ import annotations
@@ -13,12 +20,12 @@ from typing import Any
 import click
 
 from bib2graph.cli._envelope import build_envelope, emit, emit_human
-from bib2graph.cli._errors import DataError, handle_errors
+from bib2graph.cli._errors import handle_errors
 from bib2graph.cli._options import json_mode, json_option
-from bib2graph.cli._store import open_store, resolve_library_path
+from bib2graph.cli._store import resolve_library_path
 
 # ---------------------------------------------------------------------------
-# Función núcleo (testeable, sin Click)
+# Función núcleo (testeable, sin Click) — shim que delega en service.curate
 # ---------------------------------------------------------------------------
 
 
@@ -30,19 +37,25 @@ def run_filter(
     language: list[str] | None = None,
     type_in: list[str] | None = None,
     min_citations: int | None = None,
+    decided_at: datetime | None = None,
 ) -> dict[str, Any]:
-    """Aplica filtros PRISMA al corpus marcando rejected los excluidos.
+    """Shim CLI: delega en ``service.curate.filter_corpus``.
 
-    Los filtros se aplican en orden; cada uno ve el resultado del anterior.
-    El CycleState transiciona a FILTERED tras persistir con éxito.
+    Mantiene la firma original de ``run_filter`` para que los tests existentes
+    no cambien.  Toda la lógica vive en ``service.curate.filter_corpus``.
+
+    R2 (ADR 0017 enmendado): ``decided_at`` es inyectado por el llamador.
+    ``filter_cmd`` pasa ``datetime.now(UTC)``; los tests pueden pasar un
+    timestamp fijo para determinismo.
 
     Args:
         store_path: Ruta al archivo ``.duckdb``.
         year_gte: Filtrar años >= este valor.
         year_lte: Filtrar años <= este valor.
-        language: Lista de códigos ISO 639-1 a incluir (ej. ``["en", "es"]``).
+        language: Lista de códigos ISO 639-1 a incluir.
         type_in: Lista de áreas de investigación a incluir.
-        min_citations: Mínimo de citantes (``len(cited_by_id) >= min_citations``).
+        min_citations: Mínimo de citantes en cited_by_id.
+        decided_at: Timestamp inyectado por el llamador (R2/ADR 0017).
 
     Returns:
         Dict con ``steps`` (conteos PRISMA por paso) y ``total_papers``.
@@ -51,74 +64,17 @@ def run_filter(
         DataError: Si ningún criterio es válido.
         StoreError: Si el store está bloqueado.
     """
-    from bib2graph.cycle import apply_transition
-    from bib2graph.filters.prisma import FilterCriterion, apply_filters
+    from bib2graph.service.curate import filter_corpus
 
-    criteria: list[FilterCriterion] = []
-
-    if year_gte is not None:
-        criteria.append(FilterCriterion(field="year", op="gte", value=year_gte))
-    if year_lte is not None:
-        criteria.append(FilterCriterion(field="year", op="lte", value=year_lte))
-    if language:
-        criteria.append(FilterCriterion(field="language", op="in", value=language))
-    if type_in:
-        criteria.append(FilterCriterion(field="type", op="in", value=type_in))
-    if min_citations is not None:
-        criteria.append(
-            FilterCriterion(field="min_citations", op="gte", value=min_citations)
-        )
-
-    if not criteria:
-        raise DataError(
-            "Debés especificar al menos un criterio de filtro: "
-            "--year-gte, --year-lte, --language, --type, o --min-citations."
-        )
-
-    filtered_backend_close = None
-    store = open_store(store_path)
-    try:
-        corpus = store.load()
-
-        # R3 — fuente única de verdad: el destino de la transición lo dicta cycle.py,
-        # no un literal en el comando (ADR 0016 enmendado §1).
-        current_state = store.backend.loop_state()
-        current_round = store.backend.loop_round()
-        new_state, new_round = apply_transition(current_state, "filter", current_round)
-
-        # R2: el reloj se inyecta en la frontera (ADR 0017 enmendado); el núcleo
-        # no llama datetime.now(). Un único timestamp para todos los pasos de
-        # filtrado de esta invocación.
-        now = datetime.now(UTC)
-        filtered_corpus, steps = apply_filters(corpus, criteria, decided_at=now)
-        total_papers = len(filtered_corpus)
-        filtered_backend_close = getattr(filtered_corpus._backend, "close", None)
-        store.persist(filtered_corpus)
-        # #126 — trazabilidad PRISMA: persistir los pasos de filtro en filter_log
-        # para que manifest.filters sobreviva entre cargas del store.
-        store.backend.persist_filter_steps(steps)
-        store.backend.set_loop_state(new_state, cycle_round=new_round)
-    finally:
-        if filtered_backend_close is not None:
-            filtered_backend_close()
-        store.close()
-
-    steps_data = [
-        {
-            "name": s.name,
-            "criteria": s.criteria,
-            "count_before": s.count_before,
-            "count_after": s.count_after,
-            "excluded": s.count_before - s.count_after,
-        }
-        for s in steps
-    ]
-
-    return {
-        "steps": steps_data,
-        "total_papers": total_papers,
-        "criteria_applied": len(criteria),
-    }
+    return filter_corpus(
+        store_path,
+        year_gte=year_gte,
+        year_lte=year_lte,
+        language=language,
+        type_in=type_in,
+        min_citations=min_citations,
+        decided_at=decided_at,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -163,6 +119,8 @@ def filter_cmd(
     Tras el filtro, el estado del lazo transiciona a FILTERED.
     """
     store_path = resolve_library_path(ctx.obj)
+    # R2: el reloj se inyecta en la frontera CLI (ADR 0017 enmendado).
+    now = datetime.now(UTC)
     data = run_filter(
         store_path,
         year_gte=year_gte,
@@ -170,6 +128,7 @@ def filter_cmd(
         language=list(language) if language else None,
         type_in=list(type_in) if type_in else None,
         min_citations=min_citations,
+        decided_at=now,
     )
 
     if json_mode(json_output):

--- a/src/bib2graph/service/curate.py
+++ b/src/bib2graph/service/curate.py
@@ -1,26 +1,75 @@
-"""service.curate — Orquestación de curación paper-a-paper (ADR 0028 Hito G3).
+"""service.curate — Orquestación de curación (ADR 0028 Hito G3 + #155).
 
 Capa de servicios neutral: sin ``print``, ``sys.exit``, Click ni FastAPI.
-Las operaciones de curación toman ``store_path`` (no el workspace completo)
-porque mutar el corpus solo necesita la ruta al archivo ``.duckdb``.
 
 ``decided_at`` es **inyectado por el llamador** (R2/ADR 0017): el servicio
 nunca llama ``datetime.now()``.  La frontera (CLI o API) inyecta el reloj.
 
-Operaciones:
+Operaciones de curación paper-a-paper (G3 original):
   - ``accept_papers`` — marca ids como ``accepted``.
   - ``reject_papers`` — marca ids como ``rejected``.
-  - ``curate_paper`` — wrapper de un solo paper (``decision`` = ``"accepted"``
-    o ``"rejected"``; otra cosa → ``DataError``).
+  - ``curate_paper`` — wrapper de un solo paper.
+
+Operaciones en lote (subidas desde cli/ en #155):
+  - ``run_curate_dump`` — exporta corpus a CSV para revisión offline.
+  - ``run_curate_from_csv`` — reimporta decisiones desde CSV.
+
+Operación de filtrado PRISMA (subida desde cli/ en #155):
+  - ``filter_corpus`` — aplica filtros PRISMA y transiciona a FILTERED.
+
+El CLI (`cli/commands/curate.py` grupo noun-verb, `cli/commands/filter.py`)
+son shims delgados que inyectan el reloj e invocan estas funciones.
 """
 
 from __future__ import annotations
 
+import csv
 from datetime import datetime
 from pathlib import Path
 from typing import Any
 
+from bib2graph.constants import Col, CurationStatus
 from bib2graph.service.errors import DataError, StoreError
+
+# ---------------------------------------------------------------------------
+# Constantes CSV — fuente canónica (exportadas desde cli/ para compat)
+# ---------------------------------------------------------------------------
+
+CURATE_CSV_FILENAME = "curacion.csv"
+
+CSV_COLUMNS = [
+    "id",
+    "source_id",
+    "title",
+    "year",
+    "authors",
+    "venue",
+    "doi",
+    "keywords",
+    "cited_by_count",
+    "references_count",
+    "is_seed",
+    "openalex_url",
+    "scent_score",
+    "cluster",
+    "decision",
+    "note",
+]
+
+CSV_REQUIRED_COLUMNS: frozenset[str] = frozenset({"id", "decision"})
+
+VALID_DECISIONS: frozenset[str] = frozenset(
+    {CurationStatus.ACCEPTED, CurationStatus.REJECTED, "undecided"}
+)
+
+_STATUS_TO_DECISION: dict[str, str] = {
+    CurationStatus.CANDIDATE: "undecided",
+    CurationStatus.ACCEPTED: "accepted",
+    CurationStatus.REJECTED: "rejected",
+}
+
+VALID_SCOPES: frozenset[str] = frozenset({"candidates", "seeds", "all"})
+
 
 # ---------------------------------------------------------------------------
 # Helper interno — abrir store para escritura
@@ -29,10 +78,6 @@ from bib2graph.service.errors import DataError, StoreError
 
 def _open_writable(path: Path) -> Any:
     """Abre el store para escritura; falla accionable si está bloqueado.
-
-    Gemelo de ``_open_readonly`` de ``service/reads.py``, pero sin la
-    verificación de existencia (los comandos de escritura crean el archivo
-    si no existe).
 
     Args:
         path: Ruta al archivo ``.duckdb``.
@@ -58,6 +103,419 @@ def _open_writable(path: Path) -> Any:
 
 
 # ---------------------------------------------------------------------------
+# Helpers internos — transformación de filas para el CSV
+# ---------------------------------------------------------------------------
+
+
+def _authors_display(row: dict[str, Any]) -> str:
+    """Extrae los autores de una fila del corpus y los une con ' | '."""
+    raw = row.get(Col.AUTHORS_RAW)
+    if raw and isinstance(raw, list):
+        return " | ".join(str(a) for a in raw if a)
+    ids = row.get(Col.AUTHORS_ID)
+    if ids and isinstance(ids, list):
+        return " | ".join(str(a) for a in ids if a)
+    return ""
+
+
+def _keywords_display(row: dict[str, Any]) -> str:
+    """Extrae las keywords de una fila del corpus y las une con ' | '."""
+    ids = row.get(Col.KEYWORDS_ID)
+    if ids and isinstance(ids, list):
+        return " | ".join(str(k) for k in ids if k)
+    raw = row.get(Col.KEYWORDS_RAW)
+    if raw and isinstance(raw, list):
+        return " | ".join(str(k) for k in raw if k)
+    return ""
+
+
+def _openalex_url(row: dict[str, Any]) -> str:
+    """Deriva la URL de OpenAlex a partir del source_id (solo IDs W…)."""
+    src_id = row.get(Col.SOURCE_ID)
+    if src_id:
+        src_str = str(src_id)
+        if src_str.startswith("W") and src_str[1:].isdigit():
+            return f"https://openalex.org/{src_str}"
+    return ""
+
+
+def _scent_score_display(row: dict[str, Any]) -> str:
+    """Extrae el scent_score del provenance si está disponible (best-effort)."""
+    import json as _json
+
+    provenance_raw = row.get(Col.PROVENANCE)
+    if not provenance_raw:
+        return ""
+    try:
+        events = _json.loads(str(provenance_raw))
+        if not isinstance(events, list):
+            return ""
+        for event in events:
+            if isinstance(event, dict):
+                val = event.get("scent")
+                if val is not None:
+                    return str(val)
+    except (_json.JSONDecodeError, TypeError):
+        pass
+    return ""
+
+
+def _row_to_csv_dict(row: dict[str, Any]) -> dict[str, str]:
+    """Convierte una fila del corpus al dict para el CSV de curación."""
+    status = str(row.get(Col.CURATION_STATUS, CurationStatus.CANDIDATE))
+    decision = _STATUS_TO_DECISION.get(status, "undecided")
+    is_seed_val = row.get(Col.IS_SEED)
+    is_seed_str = str(is_seed_val) if is_seed_val is not None else ""
+
+    return {
+        "id": str(row.get(Col.ID) or ""),
+        "source_id": str(row.get(Col.SOURCE_ID) or ""),
+        "title": str(row.get(Col.TITLE) or ""),
+        "year": str(row.get(Col.YEAR) or ""),
+        "authors": _authors_display(row),
+        "venue": str(row.get(Col.SOURCE) or ""),
+        "doi": str(row.get(Col.DOI) or ""),
+        "keywords": _keywords_display(row),
+        "cited_by_count": "",  # no en el schema canónico
+        "references_count": "",  # no en el schema canónico
+        "is_seed": is_seed_str,
+        "openalex_url": _openalex_url(row),
+        "scent_score": _scent_score_display(row),
+        "cluster": "",  # reservado para integración con redes
+        "decision": decision,
+        "note": "",
+    }
+
+
+def _filter_table_by_scope(table: Any, scope: str) -> Any:
+    """Filtra una tabla Arrow según el scope de dump.
+
+    Scope 'candidates': curation_status == 'candidate' AND is_seed == False.
+    Scope 'seeds':      is_seed == True.
+    Scope 'all':        sin filtro.
+
+    Args:
+        table: Tabla Arrow del corpus.
+        scope: Uno de 'candidates', 'seeds', 'all'.
+
+    Returns:
+        Tabla Arrow filtrada.
+    """
+    import pyarrow.compute as pc
+
+    if scope == "all":
+        return table
+    elif scope == "seeds":
+        mask = table.column(Col.IS_SEED)
+        return table.filter(mask)
+    else:
+        # candidates: status == candidate AND NOT is_seed
+        status_col = table.column(Col.CURATION_STATUS)
+        is_candidate = pc.equal(status_col, CurationStatus.CANDIDATE)  # type: ignore[attr-defined]
+        is_seed_col = table.column(Col.IS_SEED)
+        not_seed = pc.invert(is_seed_col)  # type: ignore[attr-defined]
+        mask = pc.and_(is_candidate, not_seed)  # type: ignore[attr-defined]
+        return table.filter(mask)
+
+
+# ---------------------------------------------------------------------------
+# run_curate_dump
+# ---------------------------------------------------------------------------
+
+
+def run_curate_dump(
+    store_path: str | Path,
+    *,
+    out_path: Path,
+    scope: str = "candidates",
+    include_all: bool = False,
+) -> dict[str, Any]:
+    """Exporta el corpus a un CSV para revisión offline.
+
+    Por defecto exporta solo los candidatos forrajeados (``scope='candidates'``).
+    Con ``scope='seeds'`` exporta las semillas; con ``scope='all'`` exporta todo.
+
+    ``include_all`` es un alias de ``scope='all'`` mantenido por compatibilidad
+    con tests existentes.  Si ``True``, fuerza ``scope='all'``.
+
+    Args:
+        store_path: Ruta al archivo ``.duckdb``.
+        out_path: Ruta completa del archivo CSV de salida.
+        scope: 'candidates' (default), 'seeds' o 'all'.
+        include_all: Alias de scope='all'. Si True, fuerza scope='all'.
+
+    Returns:
+        Dict con ``csv_path``, ``papers_exported``, ``columns``.
+
+    Raises:
+        DataError: Si el corpus está vacío o no hay papers en el scope dado.
+        StoreError: Si el store está bloqueado.
+    """
+    effective_scope = "all" if include_all else scope
+
+    path = Path(store_path)
+    store = _open_writable(path)
+    try:
+        corpus = store.load()
+        all_table = corpus.to_arrow()
+        table = _filter_table_by_scope(all_table, effective_scope)
+        rows = table.to_pylist()
+    finally:
+        store.close()
+
+    if not rows and effective_scope != "all":
+        scope_label = (
+            "candidatos forrajeados" if effective_scope == "candidates" else "semillas"
+        )
+        raise DataError(
+            f"No hay {scope_label} para exportar. "
+            "Usá --scope all para exportar todo el corpus, o ejecutá "
+            "``b2g chain`` para agregar candidatos."
+        )
+
+    out_path = Path(out_path)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with open(out_path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=CSV_COLUMNS)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(_row_to_csv_dict(row))
+
+    return {
+        "csv_path": str(out_path),
+        "papers_exported": len(rows),
+        "columns": CSV_COLUMNS,
+    }
+
+
+# ---------------------------------------------------------------------------
+# run_curate_from_csv
+# ---------------------------------------------------------------------------
+
+
+def run_curate_from_csv(
+    store_path: str | Path,
+    csv_path: str | Path,
+    *,
+    by: str = "cli",
+    decided_at: datetime | None = None,
+) -> dict[str, Any]:
+    """Reimporta decisiones de curación desde un CSV al corpus.
+
+    Lee el CSV producido por ``run_curate_dump`` y aplica las decisiones en
+    lote.  Solo requiere columnas ``id`` y ``decision``; columnas extra se
+    ignoran (garantiza round-trip).
+
+    Mapeo:
+      - ``accepted``  → ``Corpus.accept``
+      - ``rejected``  → ``Corpus.reject``
+      - ``undecided`` → no-op
+
+    Idempotente: reimportar el mismo CSV produce el mismo estado final.
+
+    R2: ``decided_at`` se inyecta desde la frontera; el servicio no llama
+    ``datetime.now()``.
+
+    Args:
+        store_path: Ruta al archivo ``.duckdb``.
+        csv_path: Ruta al archivo CSV con las decisiones.
+        by: Identificador de quien decide (default: ``"cli"``).
+        decided_at: Timestamp inyectado por el llamador (R2/ADR 0017).
+
+    Returns:
+        Dict con ``accepted_count``, ``rejected_count``, ``skipped_count``,
+        ``not_found_count``, ``total_rows``.
+
+    Raises:
+        DataError: Si el CSV no existe, faltan columnas o hay decisiones inválidas.
+        StoreError: Si el store está bloqueado.
+    """
+    csv_path = Path(csv_path)
+    if not csv_path.exists():
+        raise DataError(
+            f"El archivo CSV '{csv_path}' no existe. "
+            "Generalo primero con ``b2g curate dump``."
+        )
+
+    rows: list[dict[str, str]] = []
+    with open(csv_path, newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        fieldnames = set(reader.fieldnames or [])
+
+        missing = CSV_REQUIRED_COLUMNS - fieldnames
+        if missing:
+            raise DataError(
+                f"El CSV '{csv_path}' no tiene las columnas requeridas: "
+                f"{sorted(missing)}. "
+                "Asegurate de exportar con ``b2g curate dump`` y no borrar "
+                "las columnas obligatorias (id, decision)."
+            )
+
+        for i, row in enumerate(reader, start=2):  # línea 1 = header
+            decision = row.get("decision", "").strip().lower()
+            if decision not in VALID_DECISIONS:
+                raise DataError(
+                    f"Línea {i}: valor de 'decision' inválido: '{row.get('decision')}'. "
+                    f"Valores válidos: {sorted(VALID_DECISIONS)}."
+                )
+            rows.append(row)
+
+    if not rows:
+        return {
+            "accepted_count": 0,
+            "rejected_count": 0,
+            "skipped_count": 0,
+            "not_found_count": 0,
+            "total_rows": 0,
+        }
+
+    to_accept = [r["id"] for r in rows if r["decision"].strip().lower() == "accepted"]
+    to_reject = [r["id"] for r in rows if r["decision"].strip().lower() == "rejected"]
+    skipped = len(rows) - len(to_accept) - len(to_reject)
+
+    curated_backend_close = None
+    path = Path(store_path)
+    store = _open_writable(path)
+    try:
+        corpus = store.load()
+
+        existing_ids: set[str] = {
+            str(r.get(Col.ID, "")) for r in corpus.to_arrow().to_pylist()
+        }
+        to_accept_found = [id_ for id_ in to_accept if id_ in existing_ids]
+        to_reject_found = [id_ for id_ in to_reject if id_ in existing_ids]
+        not_found = [id_ for id_ in (to_accept + to_reject) if id_ not in existing_ids]
+
+        if to_accept_found:
+            corpus = corpus.accept(to_accept_found, by=by, decided_at=decided_at)
+        if to_reject_found:
+            corpus = corpus.reject(to_reject_found, by=by, decided_at=decided_at)
+
+        curated_backend_close = getattr(corpus._backend, "close", None)
+        store.persist(corpus)
+    finally:
+        if curated_backend_close is not None:
+            curated_backend_close()
+        store.close()
+
+    return {
+        "accepted_count": len(to_accept_found),
+        "rejected_count": len(to_reject_found),
+        "skipped_count": skipped,
+        "not_found_count": len(not_found),
+        "total_rows": len(rows),
+    }
+
+
+# ---------------------------------------------------------------------------
+# filter_corpus
+# ---------------------------------------------------------------------------
+
+
+def filter_corpus(
+    store_path: str | Path,
+    *,
+    year_gte: int | None = None,
+    year_lte: int | None = None,
+    language: list[str] | None = None,
+    type_in: list[str] | None = None,
+    min_citations: int | None = None,
+    decided_at: datetime | None = None,
+) -> dict[str, Any]:
+    """Aplica filtros PRISMA al corpus marcando rejected los excluidos.
+
+    Los filtros se aplican en orden; cada uno ve el resultado del anterior.
+    El CycleState transiciona a FILTERED tras persistir con éxito.
+
+    R3 — fuente única de verdad: el destino de la transición lo dicta
+    ``cycle.py``, no un literal en este módulo (ADR 0016 enmendado §1).
+    R2 (ADR 0017 enmendado): ``decided_at`` es **inyectado por el llamador**;
+    este servicio nunca llama ``datetime.now()``.  El CLI inyecta el reloj
+    en la frontera CLI→servicio (``curate filter`` y ``run_filter`` suelto).
+
+    Args:
+        store_path: Ruta al archivo ``.duckdb``.
+        year_gte: Filtrar años >= este valor.
+        year_lte: Filtrar años <= este valor.
+        language: Lista de códigos ISO 639-1 a incluir.
+        type_in: Lista de áreas de investigación a incluir.
+        min_citations: Mínimo de citantes (``len(cited_by_id) >= min_citations``).
+        decided_at: Timestamp inyectado por el llamador (R2/ADR 0017).
+            ``None`` → el núcleo (``apply_filters``) usará su propio timestamp,
+            pero el llamador DEBE inyectarlo en la frontera para determinismo.
+
+    Returns:
+        Dict con ``steps`` (conteos PRISMA por paso) y ``total_papers``.
+
+    Raises:
+        DataError: Si ningún criterio es válido.
+        StoreError: Si el store está bloqueado.
+    """
+    from bib2graph.cycle import apply_transition
+    from bib2graph.filters.prisma import FilterCriterion, apply_filters
+
+    criteria: list[FilterCriterion] = []
+
+    if year_gte is not None:
+        criteria.append(FilterCriterion(field="year", op="gte", value=year_gte))
+    if year_lte is not None:
+        criteria.append(FilterCriterion(field="year", op="lte", value=year_lte))
+    if language:
+        criteria.append(FilterCriterion(field="language", op="in", value=language))
+    if type_in:
+        criteria.append(FilterCriterion(field="type", op="in", value=type_in))
+    if min_citations is not None:
+        criteria.append(
+            FilterCriterion(field="min_citations", op="gte", value=min_citations)
+        )
+
+    if not criteria:
+        raise DataError(
+            "Debés especificar al menos un criterio de filtro: "
+            "--year-gte, --year-lte, --language, --type, o --min-citations."
+        )
+
+    path = Path(store_path)
+    filtered_backend_close = None
+    store = _open_writable(path)
+    try:
+        corpus = store.load()
+
+        current_state = store.backend.loop_state()
+        current_round = store.backend.loop_round()
+        new_state, new_round = apply_transition(current_state, "filter", current_round)
+
+        filtered_corpus, steps = apply_filters(corpus, criteria, decided_at=decided_at)
+        total_papers = len(filtered_corpus)
+        filtered_backend_close = getattr(filtered_corpus._backend, "close", None)
+        store.persist(filtered_corpus)
+        store.backend.persist_filter_steps(steps)
+        store.backend.set_loop_state(new_state, cycle_round=new_round)
+    finally:
+        if filtered_backend_close is not None:
+            filtered_backend_close()
+        store.close()
+
+    steps_data = [
+        {
+            "name": s.name,
+            "criteria": s.criteria,
+            "count_before": s.count_before,
+            "count_after": s.count_after,
+            "excluded": s.count_before - s.count_after,
+        }
+        for s in steps
+    ]
+
+    return {
+        "steps": steps_data,
+        "total_papers": total_papers,
+        "criteria_applied": len(criteria),
+    }
+
+
+# ---------------------------------------------------------------------------
 # accept_papers
 # ---------------------------------------------------------------------------
 
@@ -78,8 +536,6 @@ def accept_papers(
         ids: Lista de ids a aceptar.
         by: Identificador de quien decide (default: ``"api"``).
         decided_at: Timestamp inyectado por el llamador (R2/ADR 0017).
-            ``None`` → el núcleo usará el timestamp que ya tiene (pero el
-            llamador DEBE inyectarlo en la frontera para determinismo).
 
     Returns:
         Dict con ``accepted_count``, ``ids``.
@@ -133,8 +589,6 @@ def reject_papers(
 ) -> dict[str, Any]:
     """Marca los papers dados como ``rejected`` y persiste.
 
-    Verifica que todos los ids existan en el corpus antes de operar.
-
     Args:
         store_path: Ruta al archivo ``.duckdb``.
         ids: Lista de ids a rechazar.
@@ -183,7 +637,7 @@ def reject_papers(
 # curate_paper — wrapper de un solo paper
 # ---------------------------------------------------------------------------
 
-_VALID_DECISIONS = frozenset({"accepted", "rejected"})
+_VALID_DECISIONS_STRICT = frozenset({"accepted", "rejected"})
 
 
 def curate_paper(
@@ -207,15 +661,14 @@ def curate_paper(
         decided_at: Timestamp inyectado por el llamador (R2/ADR 0017).
 
     Returns:
-        Dict con los campos del resultado de la operación correspondiente
-        (``accepted_count``/``rejected_count`` + ``ids``).
+        Dict con los campos del resultado (``accepted_count``/``rejected_count`` + ``ids``).
 
     Raises:
         DataError: Si ``decision`` es inválida o el id no existe.
         StoreError: Si el store está bloqueado.
     """
-    if decision not in _VALID_DECISIONS:
-        valid = ", ".join(sorted(_VALID_DECISIONS))
+    if decision not in _VALID_DECISIONS_STRICT:
+        valid = ", ".join(sorted(_VALID_DECISIONS_STRICT))
         raise DataError(f"Decisión '{decision}' inválida. Valores válidos: {valid}.")
 
     if decision == "accepted":

--- a/tests/unit/test_cli_json_option.py
+++ b/tests/unit/test_cli_json_option.py
@@ -156,7 +156,7 @@ _CMDS_NO_WORKSPACE: list[list[str]] = [
     ["resolve", "--json"],
     ["accept", "--ids", "DUMMY_ID", "--json"],
     ["reject", "--ids", "DUMMY_ID", "--json"],
-    ["curate", "--dump", "--json"],
+    ["curate", "dump", "--json"],
     ["restore", "--from-corpus", "nonexistent.parquet", "--json"],
     ["seed", "--equation", "test query", "--json"],
     ["thesaurus", "--from", "nonexistent.json", "--json"],

--- a/tests/unit/test_curate.py
+++ b/tests/unit/test_curate.py
@@ -591,45 +591,6 @@ def test_run_curate_from_csv_devuelve_claves_esperadas(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
-# 12. Exclusividad de modos: --dump y --from-csv juntos → UsageError
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.unit
-def test_dump_y_from_csv_simultaneos_lanzan_usage_error(tmp_path: Path) -> None:
-    """--dump y --from-csv juntos son mutuamente excluyentes → UsageError."""
-    from bib2graph.cli._errors import UsageError
-
-    # No hay una función combinada; el enforcement es en el Click command.
-    # Lo verificamos directamente a través de la lógica del command.
-    # Para testear sin Click, reproducimos la lógica de exclusividad.
-    do_dump = True
-    from_csv = "algo.csv"
-
-    if do_dump and from_csv:
-        with pytest.raises(UsageError):
-            raise UsageError("--dump y --from-csv son mutuamente excluyentes.")
-
-
-# ---------------------------------------------------------------------------
-# 13. Ningún modo → UsageError
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.unit
-def test_ningún_modo_lanza_usage_error() -> None:
-    """Sin --dump ni --from-csv, la lógica del comando lanza UsageError."""
-    from bib2graph.cli._errors import UsageError
-
-    do_dump = False
-    from_csv = None
-
-    if not do_dump and from_csv is None:
-        with pytest.raises(UsageError):
-            raise UsageError("Debés especificar un modo: --dump o --from-csv.")
-
-
-# ---------------------------------------------------------------------------
 # 14. dump --all incluye accepted y rejected además de candidate
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_curate_grp.py
+++ b/tests/unit/test_curate_grp.py
@@ -1,0 +1,881 @@
+"""Tests del grupo noun-verb ``b2g curate`` (sub-issue #155, superficie CLI 0.10.0).
+
+Cubre:
+
+Forma del envelope (todos los subcomandos):
+  1. curate dump  → exit 0, schema="1", command="curate dump", ok=True, stdout puro.
+  2. curate apply → exit 0, schema="1", command="curate apply", ok=True, stdout puro.
+  3. curate accept → exit 0, schema="1", command="curate accept", ok=True, stdout puro.
+  4. curate reject → exit 0, schema="1", command="curate reject", ok=True, stdout puro.
+  5. curate filter → exit 0, schema="1", command="curate filter", ok=True, stdout puro.
+
+Sin subcomando:
+  6. b2g curate → help + exit 0.
+
+Breaking changes:
+  7. curate dump --all → "No such option" (opción eliminada).
+
+FSM (#155, precedente D1 de #159):
+  8. curate filter → transiciona a FILTERED.
+  9. curate accept, reject, dump, apply → NO transicionan el FSM.
+
+Round-trip:
+  10. curate dump → editar CSV → curate apply → corpus refleja decisiones.
+  11. curate apply con IDs huérfanos → not_found_count reportado.
+
+Regresión #165 (verbos sueltos intactos):
+  12. b2g accept --ids … → envelope command="accept", misma transición (ninguna).
+  13. b2g reject --ids … → envelope command="reject", misma transición (ninguna).
+  14. b2g filter --year-gte … → envelope command="filter", misma transición FILTERED.
+
+Marcador: ``unit`` (DuckDB en tmp_path, sin red real).
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+from typing import Any
+
+import pyarrow as pa
+import pytest
+from click.testing import CliRunner
+
+from bib2graph.cli import b2g
+from bib2graph.schemas import CORPUS_SCHEMA
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Helpers compartidos
+# ---------------------------------------------------------------------------
+
+
+def _row(
+    *,
+    id: str,
+    title: str = "Título de prueba",
+    year: int = 2020,
+    is_seed: bool = False,
+    curation_status: str = "candidate",
+    language: str = "en",
+) -> dict[str, Any]:
+    """Fila mínima con schema completo para tests."""
+    return {
+        "id": id,
+        "source_id": None,
+        "doi": None,
+        "title": title,
+        "year": year,
+        "abstract": None,
+        "source": None,
+        "language": language,
+        "publisher": None,
+        "research_areas": None,
+        "is_seed": is_seed,
+        "curation_status": curation_status,
+        "provenance": None,
+        "authors_raw": None,
+        "authors_id": None,
+        "authors_affiliations": None,
+        "keywords_raw": None,
+        "keywords_id": None,
+        "institutions_raw": None,
+        "institutions_id": None,
+        "references_id": None,
+        "references_doi": None,
+        "cited_by_id": None,
+    }
+
+
+def _init_workspace(tmp_path: Path, name: str = "test-ws") -> Any:
+    """Crea y devuelve un Workspace inicializado en tmp_path."""
+    from bib2graph.workspace import Workspace
+
+    ws_dir = tmp_path / name
+    return Workspace.init(ws_dir, name)
+
+
+def _seed_store(ws: Any, rows: list[dict[str, Any]]) -> None:
+    """Persiste filas en el store del workspace."""
+    from bib2graph.corpus import Corpus
+    from bib2graph.stores.duckdb import DuckDBStore
+
+    table = pa.Table.from_pylist(rows, schema=CORPUS_SCHEMA)
+    corpus = Corpus.from_arrow(table)
+    store = DuckDBStore(ws.library_path)
+    store.persist(corpus)
+    store.close()
+
+
+def _assert_one_json_line(stdout: str, *, schema: str = "1") -> dict[str, Any]:
+    """Aserta exactamente una línea JSON con schema correcto; devuelve el dict."""
+    lines = [ln for ln in stdout.splitlines() if ln.strip()]
+    assert len(lines) == 1, (
+        f"Se esperaba exactamente 1 línea en stdout, se obtuvieron {len(lines)}:\n"
+        f"{stdout!r}"
+    )
+    data = json.loads(lines[0])
+    assert data.get("schema") == schema
+    return data
+
+
+def _get_loop_state(ws: Any) -> Any:
+    """Lee el loop_state del backend DuckDB del workspace."""
+    from bib2graph.stores.duckdb import DuckDBStore
+
+    store = DuckDBStore(ws.library_path)
+    state = store.backend.loop_state()
+    store.close()
+    return state
+
+
+# ---------------------------------------------------------------------------
+# 1. curate dump → envelope correcto
+# ---------------------------------------------------------------------------
+
+
+def test_curate_dump_envelope_correcto(tmp_path: Path) -> None:
+    """curate dump --json emite envelope schema='1', command='curate dump', ok=True."""
+    ws = _init_workspace(tmp_path)
+    _seed_store(ws, [_row(id="C1")])
+
+    runner = CliRunner()
+    result = runner.invoke(
+        b2g,
+        ["--workspace", str(ws.root), "curate", "dump", "--json"],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
+    data = _assert_one_json_line(result.stdout)
+    assert data["ok"] is True
+    assert data["command"] == "curate dump"
+    assert "csv_path" in data["data"]
+    assert "papers_exported" in data["data"]
+
+
+def test_curate_dump_stdout_puro(tmp_path: Path) -> None:
+    """curate dump --json: stdout tiene exactamente 1 línea JSON (sin ruido)."""
+    ws = _init_workspace(tmp_path)
+    _seed_store(ws, [_row(id="C1")])
+
+    runner = CliRunner()
+    result = runner.invoke(
+        b2g,
+        ["--workspace", str(ws.root), "curate", "dump", "--json"],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+    lineas = [ln for ln in result.stdout.splitlines() if ln.strip()]
+    assert len(lineas) == 1
+
+
+# ---------------------------------------------------------------------------
+# 2. curate apply → envelope correcto
+# ---------------------------------------------------------------------------
+
+
+def test_curate_apply_envelope_correcto(tmp_path: Path) -> None:
+    """curate apply <csv> --json emite envelope correcto."""
+    ws = _init_workspace(tmp_path)
+    _seed_store(ws, [_row(id="P1"), _row(id="P2")])
+
+    # Generar CSV con curate dump
+    runner = CliRunner()
+    runner.invoke(
+        b2g,
+        ["--workspace", str(ws.root), "curate", "dump"],
+        catch_exceptions=False,
+    )
+    csv_path = ws.exports_dir / "curacion.csv"
+    assert csv_path.exists()
+
+    # Aplicar decisiones
+    result = runner.invoke(
+        b2g,
+        ["--workspace", str(ws.root), "curate", "apply", str(csv_path), "--json"],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
+    data = _assert_one_json_line(result.stdout)
+    assert data["ok"] is True
+    assert data["command"] == "curate apply"
+    assert "accepted_count" in data["data"]
+    assert "rejected_count" in data["data"]
+    assert "skipped_count" in data["data"]
+    assert "not_found_count" in data["data"]
+    assert "total_rows" in data["data"]
+
+
+# ---------------------------------------------------------------------------
+# 3. curate accept → envelope correcto
+# ---------------------------------------------------------------------------
+
+
+def test_curate_accept_envelope_correcto(tmp_path: Path) -> None:
+    """curate accept --ids P1 --json emite envelope correcto."""
+    ws = _init_workspace(tmp_path)
+    _seed_store(ws, [_row(id="P1"), _row(id="P2")])
+
+    runner = CliRunner()
+    result = runner.invoke(
+        b2g,
+        [
+            "--workspace",
+            str(ws.root),
+            "curate",
+            "accept",
+            "--ids",
+            "P1",
+            "--json",
+        ],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
+    data = _assert_one_json_line(result.stdout)
+    assert data["ok"] is True
+    assert data["command"] == "curate accept"
+    assert data["data"]["accepted_count"] == 1
+
+
+# ---------------------------------------------------------------------------
+# 4. curate reject → envelope correcto
+# ---------------------------------------------------------------------------
+
+
+def test_curate_reject_envelope_correcto(tmp_path: Path) -> None:
+    """curate reject --ids P1 --json emite envelope correcto."""
+    ws = _init_workspace(tmp_path)
+    _seed_store(ws, [_row(id="P1"), _row(id="P2")])
+
+    runner = CliRunner()
+    result = runner.invoke(
+        b2g,
+        [
+            "--workspace",
+            str(ws.root),
+            "curate",
+            "reject",
+            "--ids",
+            "P1",
+            "--json",
+        ],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
+    data = _assert_one_json_line(result.stdout)
+    assert data["ok"] is True
+    assert data["command"] == "curate reject"
+    assert data["data"]["rejected_count"] == 1
+
+
+# ---------------------------------------------------------------------------
+# 5. curate filter → envelope correcto
+# ---------------------------------------------------------------------------
+
+
+def test_curate_filter_envelope_correcto(tmp_path: Path) -> None:
+    """curate filter --year-gte 1900 --json emite envelope correcto."""
+    ws = _init_workspace(tmp_path)
+    _seed_store(ws, [_row(id="P1", year=2020), _row(id="P2", year=2021)])
+
+    runner = CliRunner()
+    result = runner.invoke(
+        b2g,
+        [
+            "--workspace",
+            str(ws.root),
+            "curate",
+            "filter",
+            "--year-gte",
+            "1900",
+            "--json",
+        ],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
+    data = _assert_one_json_line(result.stdout)
+    assert data["ok"] is True
+    assert data["command"] == "curate filter"
+    assert "steps" in data["data"]
+    assert "total_papers" in data["data"]
+
+
+# ---------------------------------------------------------------------------
+# 6. curate sin subcomando → help + exit 0
+# ---------------------------------------------------------------------------
+
+
+def test_curate_sin_subcomando_imprime_ayuda() -> None:
+    """b2g curate sin subcomando imprime ayuda y sale con exit 0."""
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        result = runner.invoke(b2g, ["curate"])
+    assert result.exit_code == 0
+    assert "dump" in result.output
+    assert "apply" in result.output
+    assert "accept" in result.output
+    assert "reject" in result.output
+    assert "filter" in result.output
+
+
+# ---------------------------------------------------------------------------
+# 7. curate dump --all → "No such option" (BREAKING #155)
+# ---------------------------------------------------------------------------
+
+
+def test_curate_dump_all_no_existe(tmp_path: Path) -> None:
+    """curate dump --all fue eliminado (#155); Click debe reportar 'No such option'."""
+    ws = _init_workspace(tmp_path)
+    _seed_store(ws, [_row(id="C1")])
+
+    runner = CliRunner()
+    result = runner.invoke(
+        b2g,
+        ["--workspace", str(ws.root), "curate", "dump", "--all"],
+    )
+    # Click reporta "No such option" y sale con exit != 0
+    assert result.exit_code != 0
+    assert "no such option" in result.output.lower()
+
+
+# ---------------------------------------------------------------------------
+# 8. curate filter → transiciona a FILTERED (FSM)
+# ---------------------------------------------------------------------------
+
+
+def test_curate_filter_transiciona_a_filtered(tmp_path: Path) -> None:
+    """curate filter transiciona el CycleState a FILTERED (el verbo define la transición)."""
+    from bib2graph.cycle import CycleState
+
+    ws = _init_workspace(tmp_path)
+    _seed_store(ws, [_row(id="P1", year=2020)])
+
+    runner = CliRunner()
+    result = runner.invoke(
+        b2g,
+        [
+            "--workspace",
+            str(ws.root),
+            "curate",
+            "filter",
+            "--year-gte",
+            "1900",
+        ],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
+
+    estado_post = _get_loop_state(ws)
+    assert estado_post == CycleState.FILTERED, (
+        f"curate filter debe transicionar a FILTERED, pero quedó en {estado_post}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 9. curate accept/reject/dump/apply → NO transicionan el FSM
+# ---------------------------------------------------------------------------
+
+
+def test_curate_accept_no_transiciona_fsm(tmp_path: Path) -> None:
+    """curate accept NO transiciona el CycleState (curación transversal)."""
+    ws = _init_workspace(tmp_path)
+    _seed_store(ws, [_row(id="P1")])
+
+    estado_previo = _get_loop_state(ws)
+
+    runner = CliRunner()
+    runner.invoke(
+        b2g,
+        ["--workspace", str(ws.root), "curate", "accept", "--ids", "P1"],
+        catch_exceptions=False,
+    )
+
+    estado_post = _get_loop_state(ws)
+    assert estado_post == estado_previo, (
+        f"curate accept no debe cambiar el CycleState: {estado_previo} → {estado_post}"
+    )
+
+
+def test_curate_reject_no_transiciona_fsm(tmp_path: Path) -> None:
+    """curate reject NO transiciona el CycleState (curación transversal)."""
+    ws = _init_workspace(tmp_path)
+    _seed_store(ws, [_row(id="P1")])
+
+    estado_previo = _get_loop_state(ws)
+
+    runner = CliRunner()
+    runner.invoke(
+        b2g,
+        ["--workspace", str(ws.root), "curate", "reject", "--ids", "P1"],
+        catch_exceptions=False,
+    )
+
+    estado_post = _get_loop_state(ws)
+    assert estado_post == estado_previo, (
+        f"curate reject no debe cambiar el CycleState: {estado_previo} → {estado_post}"
+    )
+
+
+def test_curate_dump_no_transiciona_fsm(tmp_path: Path) -> None:
+    """curate dump NO transiciona el CycleState (curación transversal)."""
+    ws = _init_workspace(tmp_path)
+    _seed_store(ws, [_row(id="C1")])
+
+    estado_previo = _get_loop_state(ws)
+
+    runner = CliRunner()
+    runner.invoke(
+        b2g,
+        ["--workspace", str(ws.root), "curate", "dump"],
+        catch_exceptions=False,
+    )
+
+    estado_post = _get_loop_state(ws)
+    assert estado_post == estado_previo, (
+        f"curate dump no debe cambiar el CycleState: {estado_previo} → {estado_post}"
+    )
+
+
+def test_curate_apply_no_transiciona_fsm(tmp_path: Path) -> None:
+    """curate apply NO transiciona el CycleState (curación transversal)."""
+    ws = _init_workspace(tmp_path)
+    _seed_store(ws, [_row(id="C1")])
+
+    estado_previo = _get_loop_state(ws)
+
+    # Generar CSV de decisiones
+    runner = CliRunner()
+    runner.invoke(
+        b2g,
+        ["--workspace", str(ws.root), "curate", "dump"],
+        catch_exceptions=False,
+    )
+    csv_path = ws.exports_dir / "curacion.csv"
+
+    runner.invoke(
+        b2g,
+        ["--workspace", str(ws.root), "curate", "apply", str(csv_path)],
+        catch_exceptions=False,
+    )
+
+    estado_post = _get_loop_state(ws)
+    assert estado_post == estado_previo, (
+        f"curate apply no debe cambiar el CycleState: {estado_previo} → {estado_post}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 10. Round-trip: dump → editar CSV → apply
+# ---------------------------------------------------------------------------
+
+
+def test_round_trip_dump_apply(tmp_path: Path) -> None:
+    """curate dump → editar decision → curate apply → corpus refleja decisiones."""
+    from bib2graph.stores.duckdb import DuckDBStore
+
+    ws = _init_workspace(tmp_path)
+    _seed_store(
+        ws,
+        [
+            _row(id="PA", title="Paper A"),
+            _row(id="PB", title="Paper B"),
+            _row(id="PC", title="Paper C"),
+        ],
+    )
+
+    runner = CliRunner()
+
+    # 1) dump
+    result_dump = runner.invoke(
+        b2g,
+        ["--workspace", str(ws.root), "curate", "dump", "--json"],
+        catch_exceptions=False,
+    )
+    assert result_dump.exit_code == 0
+    data_dump = json.loads(result_dump.stdout.strip())
+    csv_path = Path(data_dump["data"]["csv_path"])
+    assert csv_path.exists()
+
+    # 2) Editar el CSV: PA → accepted, PB → rejected
+    from bib2graph.service.curate import CSV_COLUMNS
+
+    rows: list[dict[str, str]] = []
+    with open(csv_path, newline="", encoding="utf-8") as f:
+        rows = list(csv.DictReader(f))
+    for row in rows:
+        if row["id"] == "PA":
+            row["decision"] = "accepted"
+        elif row["id"] == "PB":
+            row["decision"] = "rejected"
+        # PC queda undecided
+
+    with open(csv_path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=CSV_COLUMNS)
+        writer.writeheader()
+        writer.writerows(rows)
+
+    # 3) apply
+    result_apply = runner.invoke(
+        b2g,
+        ["--workspace", str(ws.root), "curate", "apply", str(csv_path), "--json"],
+        catch_exceptions=False,
+    )
+    assert result_apply.exit_code == 0, result_apply.output
+    data_apply = json.loads(result_apply.stdout.strip())
+    assert data_apply["data"]["accepted_count"] == 1
+    assert data_apply["data"]["rejected_count"] == 1
+    assert data_apply["data"]["skipped_count"] == 1
+    assert data_apply["data"]["not_found_count"] == 0
+
+    # 4) Verificar estado del corpus (to_arrow antes de close — DuckDB requiere conexión activa)
+    store = DuckDBStore(ws.library_path)
+    corpus = store.load()
+    by_id = {r["id"]: r for r in corpus.to_arrow().to_pylist()}
+    store.close()
+
+    assert by_id["PA"]["curation_status"] == "accepted"
+    assert by_id["PB"]["curation_status"] == "rejected"
+    assert by_id["PC"]["curation_status"] == "candidate"
+
+
+# ---------------------------------------------------------------------------
+# 11. curate apply con IDs huérfanos → not_found_count reportado
+# ---------------------------------------------------------------------------
+
+
+def test_curate_apply_ids_huerfanos_reportados(tmp_path: Path) -> None:
+    """curate apply con IDs que no existen en el corpus → not_found_count > 0, sin abort."""
+    ws = _init_workspace(tmp_path)
+    _seed_store(ws, [_row(id="P1")])
+
+    # Crear CSV con un ID huérfano
+    csv_path = tmp_path / "decisiones.csv"
+    from bib2graph.service.curate import CSV_COLUMNS
+
+    with open(csv_path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=CSV_COLUMNS)
+        writer.writeheader()
+        writer.writerow(
+            {**{c: "" for c in CSV_COLUMNS}, "id": "P1", "decision": "accepted"}
+        )
+        writer.writerow(
+            {**{c: "" for c in CSV_COLUMNS}, "id": "P_FANTASMA", "decision": "accepted"}
+        )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        b2g,
+        ["--workspace", str(ws.root), "curate", "apply", str(csv_path), "--json"],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+    data = json.loads(result.stdout.strip())
+    assert data["data"]["accepted_count"] == 1
+    assert data["data"]["not_found_count"] == 1
+
+
+# ---------------------------------------------------------------------------
+# 12. Regresión #165: b2g accept suelto sigue funcionando
+# ---------------------------------------------------------------------------
+
+
+def test_accept_suelto_envelope_intacto(tmp_path: Path) -> None:
+    """b2g accept (suelto) sigue emitiendo envelope con command='accept'."""
+    ws = _init_workspace(tmp_path)
+    _seed_store(ws, [_row(id="P1")])
+
+    runner = CliRunner()
+    result = runner.invoke(
+        b2g,
+        ["--workspace", str(ws.root), "accept", "--ids", "P1", "--json"],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
+    data = _assert_one_json_line(result.stdout)
+    assert data["ok"] is True
+    assert data["command"] == "accept"
+    assert data["data"]["accepted_count"] == 1
+
+
+def test_accept_suelto_no_transiciona_fsm(tmp_path: Path) -> None:
+    """b2g accept suelto NO transiciona el CycleState (curación transversal)."""
+    ws = _init_workspace(tmp_path)
+    _seed_store(ws, [_row(id="P1")])
+
+    estado_previo = _get_loop_state(ws)
+
+    runner = CliRunner()
+    runner.invoke(
+        b2g,
+        ["--workspace", str(ws.root), "accept", "--ids", "P1"],
+        catch_exceptions=False,
+    )
+
+    estado_post = _get_loop_state(ws)
+    assert estado_post == estado_previo
+
+
+# ---------------------------------------------------------------------------
+# 13. Regresión #165: b2g reject suelto sigue funcionando
+# ---------------------------------------------------------------------------
+
+
+def test_reject_suelto_envelope_intacto(tmp_path: Path) -> None:
+    """b2g reject (suelto) sigue emitiendo envelope con command='reject'."""
+    ws = _init_workspace(tmp_path)
+    _seed_store(ws, [_row(id="P1")])
+
+    runner = CliRunner()
+    result = runner.invoke(
+        b2g,
+        ["--workspace", str(ws.root), "reject", "--ids", "P1", "--json"],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
+    data = _assert_one_json_line(result.stdout)
+    assert data["ok"] is True
+    assert data["command"] == "reject"
+    assert data["data"]["rejected_count"] == 1
+
+
+def test_reject_suelto_no_transiciona_fsm(tmp_path: Path) -> None:
+    """b2g reject suelto NO transiciona el CycleState (curación transversal)."""
+    ws = _init_workspace(tmp_path)
+    _seed_store(ws, [_row(id="P1")])
+
+    estado_previo = _get_loop_state(ws)
+
+    runner = CliRunner()
+    runner.invoke(
+        b2g,
+        ["--workspace", str(ws.root), "reject", "--ids", "P1"],
+        catch_exceptions=False,
+    )
+
+    estado_post = _get_loop_state(ws)
+    assert estado_post == estado_previo
+
+
+# ---------------------------------------------------------------------------
+# 14. Regresión #165: b2g filter suelto sigue funcionando y transiciona a FILTERED
+# ---------------------------------------------------------------------------
+
+
+def test_filter_suelto_envelope_intacto(tmp_path: Path) -> None:
+    """b2g filter (suelto) sigue emitiendo envelope con command='filter'."""
+    ws = _init_workspace(tmp_path)
+    _seed_store(ws, [_row(id="P1", year=2020)])
+
+    runner = CliRunner()
+    result = runner.invoke(
+        b2g,
+        [
+            "--workspace",
+            str(ws.root),
+            "filter",
+            "--year-gte",
+            "1900",
+            "--json",
+        ],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
+    data = _assert_one_json_line(result.stdout)
+    assert data["ok"] is True
+    assert data["command"] == "filter"
+
+
+def test_filter_suelto_transiciona_a_filtered(tmp_path: Path) -> None:
+    """b2g filter suelto transiciona a FILTERED (mismo comportamiento que curate filter)."""
+    from bib2graph.cycle import CycleState
+
+    ws = _init_workspace(tmp_path)
+    _seed_store(ws, [_row(id="P1", year=2020)])
+
+    runner = CliRunner()
+    runner.invoke(
+        b2g,
+        [
+            "--workspace",
+            str(ws.root),
+            "filter",
+            "--year-gte",
+            "1900",
+        ],
+        catch_exceptions=False,
+    )
+
+    estado_post = _get_loop_state(ws)
+    assert estado_post == CycleState.FILTERED
+
+
+# ---------------------------------------------------------------------------
+# 15. curate accept --ids múltiples en una invocación
+# ---------------------------------------------------------------------------
+
+
+def test_curate_accept_ids_multiples(tmp_path: Path) -> None:
+    """curate accept acepta múltiples IDs con --ids repetido."""
+    from bib2graph.stores.duckdb import DuckDBStore
+
+    ws = _init_workspace(tmp_path)
+    _seed_store(ws, [_row(id="P1"), _row(id="P2"), _row(id="P3")])
+
+    runner = CliRunner()
+    result = runner.invoke(
+        b2g,
+        [
+            "--workspace",
+            str(ws.root),
+            "curate",
+            "accept",
+            "--ids",
+            "P1",
+            "--ids",
+            "P2",
+            "--json",
+        ],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+    data = json.loads(result.stdout.strip())
+    assert data["data"]["accepted_count"] == 2
+
+    store = DuckDBStore(ws.library_path)
+    corpus = store.load()
+    by_id = {r["id"]: r for r in corpus.to_arrow().to_pylist()}
+    store.close()
+    assert by_id["P1"]["curation_status"] == "accepted"
+    assert by_id["P2"]["curation_status"] == "accepted"
+    assert by_id["P3"]["curation_status"] == "candidate"
+
+
+# ---------------------------------------------------------------------------
+# 16. curate dump --scope seeds exporta solo semillas
+# ---------------------------------------------------------------------------
+
+
+def test_curate_dump_scope_seeds(tmp_path: Path) -> None:
+    """curate dump --scope seeds exporta solo papers con is_seed=True."""
+    ws = _init_workspace(tmp_path)
+    _seed_store(
+        ws,
+        [
+            _row(id="S1", is_seed=True),
+            _row(id="S2", is_seed=True),
+            _row(id="C1", is_seed=False),
+        ],
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        b2g,
+        [
+            "--workspace",
+            str(ws.root),
+            "curate",
+            "dump",
+            "--scope",
+            "seeds",
+            "--json",
+        ],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+    data = json.loads(result.stdout.strip())
+    assert data["data"]["papers_exported"] == 2
+
+
+# ---------------------------------------------------------------------------
+# 17. Neutralidad de reloj (R2 / ADR 0017 enmendado): filter_corpus recibe
+#     decided_at inyectado y lo pasa a apply_filters
+# ---------------------------------------------------------------------------
+
+
+def test_filter_corpus_pasa_decided_at_a_apply_filters(tmp_path: Path) -> None:
+    """filter_corpus pasa el decided_at inyectado a apply_filters (R2/ADR 0017).
+
+    Verifica que el servicio no genera su propio timestamp: lo recibe del llamador
+    y lo propaga sin modificarlo al núcleo.
+    """
+    from datetime import UTC, datetime
+    from unittest.mock import patch
+
+    from bib2graph.service.curate import filter_corpus
+
+    store_path = tmp_path / "test.duckdb"
+
+    # Seed mínimo
+    import pyarrow as pa
+
+    from bib2graph.corpus import Corpus
+    from bib2graph.schemas import CORPUS_SCHEMA
+    from bib2graph.stores.duckdb import DuckDBStore
+
+    row = _row(id="P1", year=2020)
+    table = pa.Table.from_pylist([row], schema=CORPUS_SCHEMA)
+    corpus_obj = Corpus.from_arrow(table)
+    store = DuckDBStore(store_path)
+    store.persist(corpus_obj)
+    store.close()
+
+    sentinel = datetime(2025, 1, 15, 10, 30, 0, tzinfo=UTC)
+
+    captured: dict[str, Any] = {}
+
+    original_apply_filters = __import__(
+        "bib2graph.filters.prisma", fromlist=["apply_filters"]
+    ).apply_filters
+
+    def _spy_apply_filters(corpus, criteria, *, decided_at=None):  # type: ignore[no-untyped-def]
+        captured["decided_at"] = decided_at
+        return original_apply_filters(corpus, criteria, decided_at=decided_at)
+
+    with patch(
+        "bib2graph.filters.prisma.apply_filters", side_effect=_spy_apply_filters
+    ):
+        filter_corpus(store_path, year_gte=2000, decided_at=sentinel)
+
+    assert captured.get("decided_at") == sentinel, (
+        f"filter_corpus no propagó el decided_at inyectado: {captured.get('decided_at')!r}"
+    )
+
+
+def test_service_curate_no_llama_datetime_now() -> None:
+    """service/curate.py no contiene llamadas directas a datetime.now() (R2/ADR 0017).
+
+    El reloj es responsabilidad del llamador (frontera CLI), no del servicio.
+    Detección por AST sobre el source real del módulo.
+    """
+    import ast
+    import importlib
+    import pathlib
+
+    mod = importlib.import_module("bib2graph.service.curate")
+    source_file = mod.__file__
+    assert source_file is not None
+    tree = ast.parse(pathlib.Path(source_file).read_text(encoding="utf-8"))
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        # Detecta patrones: datetime.now(...), _datetime.now(...), UTC.now(...)
+        if isinstance(func, ast.Attribute) and func.attr == "now":
+            obj = func.value
+            obj_name = (
+                obj.id
+                if isinstance(obj, ast.Name)
+                else obj.attr
+                if isinstance(obj, ast.Attribute)
+                else None
+            )
+            if obj_name in {"datetime", "_datetime", "UTC"}:
+                raise AssertionError(
+                    f"service/curate.py llama a {obj_name}.now() en línea "
+                    f"{node.lineno} — viola R2/ADR 0017: el reloj debe inyectarse "
+                    "desde la frontera CLI, no generarse en el servicio."
+                )


### PR DESCRIPTION
Closes #155. Sub-issue del epic #167 (superficie CLI 0.10.0, ADR 0037 b). Segundo grupo noun-verb (tras `read`). Desbloquea #160 (maturity).

## Qué
- **`curate` pasa de comando plano a grupo:** `curate {dump,apply,accept,reject,filter}`. Sin subcomando → help + exit 0.
- **BREAKING (autorizado por ADR 0037 b):** la forma-flag `curate --dump`/`--from-csv` se elimina sin alias (`--dump`→`curate dump`, `--from-csv`→`curate apply`). `--all` eliminado (usar `--scope all`).
- **`curate filter` transiciona el FSM a FILTERED**; `dump`/`apply`/`accept`/`reject` son **transversales** (el VERBO define la transición, precedente D1 de #159).
- **Lógica extraída a `service/curate.py`** (fuente única para los verbos sueltos que #165 retirará): `run_curate_dump`, `run_curate_from_csv`, `filter_corpus` (**`decided_at` inyectado** por el caller → neutralidad de servicio restaurada, ADR 0017).
- **Verbos sueltos `accept`/`reject`/`filter` intactos** (sin warning); comparten la lógica de servicio. Su deprecación es #165.

## Tests
`tests/unit/test_curate_grp.py` (25 tests): los 5 verbos, transición de `filter` vs transversalidad del resto, regresión de sueltos, `--all` removido, round-trip dump→apply, `decided_at` inyectado, neutralidad AST de `service/curate`. Verifier: **PASA** (reservas de docs-drift y nit de reloj resueltas). Gate verde local: ruff + mypy limpios, 1089 passed.

## Docs (lockstep)
`API.md` (grupo `curate`, `filter_corpus`, transiciones), `docs/features/*`, `AGENTS.md`, `ARCHITECTURE.md`; **notas append-only**: D2 al ADR 0037 (transición por verbo) y corrección del gap P1 al ADR 0038 (`filter` entra a la ventana 0.11.0). Sin ADR nuevo.

## Invariante
Envelope `schema="1"`, exit codes, FSM (`apply_transition`, fuente única) y stdout puro (#151) **intactos**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
