### PR TITLE
feat(cli): maturity-stamp en artefactos one-shot (build/snapshot/read top) (#160)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,10 @@
   `read stats --group-by {status,year,is_seed}`, `read show --id` (resuelve id/doi/source_id, ADR 0036),
   `read top --top N --kind {…}` (la salida de investigación: nodos centrales + co-citación con título;
   default `bibliographic_coupling`, robusto en one-shot; co-citación vacía → honest-empty exit 0 +
-  reason/fix_command). `read` sin subcomando → ayuda + exit 0 (`invoke_without_command=True`, workaround Click 8.4); el
+  reason/fix_command). **Artefactos one-shot honestos (#160, ADR 0037 §f):** el `--json` de `build`,
+  `snapshot` y `read top` suma un bloque aditivo **`maturity`** (`{curated, scope, saturated,
+  empty_networks}`, `schema="1"` intacto) que autodeclara que el resultado es un borrador sin pulir;
+  forma estable en `docs/API.md` §Apéndice `maturity`. `read` sin subcomando → ayuda + exit 0 (`invoke_without_command=True`, workaround Click 8.4); el
   `command` del envelope usa la ruta completa (`"read list"`). `inspect` queda **en deprecación** (#165,
   lo absorben `read show` + `status`) pero **sigue vivo**. Ver `docs/API.md` §Convenciones CLI.
   **Grupo noun-verb `curate {dump,apply,accept,reject,filter}` (#155, ADR 0037 §b):** SEGUNDO grupo del

--- a/docs/API.md
+++ b/docs/API.md
@@ -576,8 +576,12 @@ Si una red sale vacía por el `min_weight` del YAML (modo spec), el `reason` **c
 **Esquema de respuesta `--json` (`data`):** `networks_built`, `artifacts_dir`, `corpus_hash`,
 **`scope`** = **token CLI** (`seeds`/`accepted`/`all`, gancho estable para #160 maturity),
 **`corpus_scope`** = vocab interno (`seeds_only`/…, backward-compat), `networks` (lista, con
-`clusters_csv` condicional), `warnings` (corpus-level) y `empty_networks` (diagnóstico por-red).
-Invariante: envelope `schema="1"`, exit codes y FSM intactos; todo lo de #159 es **aditivo**.
+`clusters_csv` condicional), `warnings` (corpus-level), `empty_networks` (diagnóstico por-red) y
+**`maturity`** (bloque aditivo del one-shot, AS-BUILT #160 — ver Apéndice `maturity`; `curated`
+deriva del **corpus completo** pre-scope, `scope` reusa este `data["scope"]`, `empty_networks` es la
+lista de `kind` extraída de `data["empty_networks"]` sin duplicar `reason`/`fix_command`; presente
+también en el early-return de corpus vacío).
+Invariante: envelope `schema="1"`, exit codes y FSM intactos; todo lo de #159/#160 es **aditivo**.
 
 > **No-divergencia es por-corpus.** La garantía de no-divergencia entre el diagnóstico de red-vacía de
 > `build` y el de `status` (ADR 0037 §(e)) es **sobre el mismo corpus de entrada**. Con `--scope != all`,
@@ -588,7 +592,9 @@ Invariante: envelope `schema="1"`, exit codes y FSM intactos; todo lo de #159 es
 **`snapshot` (AS-BUILT #32, 2026-06-17):** `b2g snapshot` sella una foto reproducible del estado vivo
 (parquet + `manifest.json`, ADR 0017). **`--out-dir` pasó a override OPCIONAL** — sin él, escribe en
 **`<workspace>/snapshots/`** (resolución ambiente vía `resolve_workspace`, igual que `build`). No
-transiciona el `CycleState`.
+transiciona el `CycleState`. Su `--json.data` —`snapshot_dir`, `corpus_hash`, `total_papers`,
+`schema_version`— suma el bloque aditivo **`maturity`** (AS-BUILT #160, ver Apéndice `maturity`):
+`scope="all"`, `empty_networks=[]` (snapshot no proyecta redes), `curated` desde el corpus vivo.
 
 **Staleness de la cache de redes (AS-BUILT #32, 2026-06-17):** `b2g status` suma el campo aditivo
 `data["networks_cache_stale"]: bool` (`schema="1"` intacto) y, cuando es `true`, un `warnings`
@@ -639,7 +645,11 @@ materializó en #157 (antes diferido). La lógica vive en `service/reads.py` (`l
   Flags: `--top N` / `-n` (default 10), `--kind` (`Choice` sobre los 5 `NetworkKind`, **default
   `bibliographic_coupling`**), `--json`. Envelope:
   `data = {kind, top, central: [{id, title, degree_centrality, community?}],
-  cocitation: [{source, source_title, target, target_title, weight}], reason?, fix_command?}`.
+  cocitation: [{source, source_title, target, target_title, weight}], reason?, fix_command?,
+  maturity}`. El bloque **`maturity`** (aditivo del one-shot, AS-BUILT #160 — ver Apéndice `maturity`)
+  está **SIEMPRE presente**: `scope="all"`, `empty_networks=["cocitation"]` cuando la co-citación
+  quedó vacía (si no, `[]`), `curated` desde el corpus. **No** duplica `reason`/`fix_command` (esos
+  viven en el bloque honest-empty de abajo).
   - **`central`** — top `N` nodos de la red `--kind` por `degree_centrality` desc. En redes de paper
     (`bibliographic_coupling`/`cocitation`) `title` es el **título completo** (join id→title); en
     redes de autor/institución/keyword cae al `label` (nombre de la entidad).
@@ -726,6 +736,32 @@ se activa con la variable de entorno **`B2G_JSON`**:
 Aditivo y retrocompatible: el envelope `schema="1"`, los exit codes y la FSM **no cambian** (ver
 ADR [0021](decisiones/0021-cli-agente-native-contrato.md) §C, enmienda 2026-06-27).
 
+**Apéndice — bloque `maturity` del one-shot (AS-BUILT #160, ADR [0037](decisiones/0037-superficie-cli-10-verbos-ciclo.md) §f; FORMA fijada aquí por delegación de ADR [0038](decisiones/0038-destino-verbos-huerfanos-0037.md) P3).**
+Los artefactos del camino **one-shot** llevan un bloque **aditivo** `data["maturity"]` que **se
+autodeclara borrador sin pulir**: honestidad **por construcción** (vom Brocke/PRISMA hecho
+self-description), para que ni un agente que optimiza por `exit 0` ni un humano apurado confundan un
+one-shot con un resultado terminado. **Aditivo: `schema="1"` intacto.**
+
+```json
+"maturity": {"curated": false, "scope": "all", "saturated": false, "empty_networks": []}
+```
+
+- **Forma estable: SIEMPRE 4 claves** (orden y tipos fijos). El bloque no muta de forma según el caso.
+
+| clave | tipo | valores | regla de derivación |
+|---|---|---|---|
+| `curated` | `bool` | `true`/`false` | `true` si el corpus **completo** (`corpus_full`, **antes** del filtro de `--corpus-scope`) tiene **≥1 paper** con `curation_status` ∈ {`accepted`, `rejected`}. Refleja si hay decisiones de curación aplicadas, **independiente** del scope y del FSM. |
+| `scope` | `str` \| `null` | token CLI (`all`/`accepted`/`seeds`…) \| `null` | En `build` reusa `data["scope"]` (el **token CLI** tal como se tipeó, no el vocab interno `seeds_only`). En `snapshot` y `read top` es `"all"`. `null` si no aplica. |
+| `saturated` | `bool` | **`false` constante** | **Siempre `false`** en one-shot: el PO decidió **no sobre-afirmar**. Gancho futuro (documentado en el código): comparar `referenced_refs_count()` entre rondas de `enrich` para detectar convergencia de referencias. |
+| `empty_networks` | `list[str]` | lista de `kind` (puede ser `[]`) | **Solo los tokens `kind`** de las redes vacías. `reason`/`fix_command` **NO se duplican** acá — siguen viviendo en `data["empty_networks"]` (lista de dicts `{kind, reason, fix_command}`) de `build`. En `build` se extraen de ahí; en `read top` es `["cocitation"]` si la co-citación quedó vacía; en `snapshot` es `[]`. |
+
+- **Dónde aparece (PRESENTE SIEMPRE):** `build` (incluido el early-return de corpus vacío),
+  `snapshot` y `read top`. **AUSENTE** en `read list`, `read stats` y `read show` (lecturas tabulares,
+  no artefactos one-shot) — no llevan `maturity`.
+- **Función pura:** lo calcula `service.maturity.compute_maturity(corpus, *, scope, empty_network_kinds)`
+  (sin I/O, re-exportada desde `bib2graph.service`), invariante de neutralidad de transporte intacta
+  (§0).
+
 ---
 
 ## 0. Capa de servicios `service/` — contrato neutral compartido (AS-BUILT G1, ADR 0028)
@@ -787,6 +823,18 @@ def code_for(exc: BaseException) -> int:
     httpx.HTTPError → 4. Excepción no mapeada → TypeError (el llamador decide).
     Lo usan la capa de servicio y los adaptadores para derivar exit code / HTTP status
     sin duplicar la política."""
+
+
+# service/maturity.py — bloque maturity del one-shot (#160, ADR 0037 §f / 0038 P3)
+def compute_maturity(
+    corpus: Corpus, *, scope: str | None, empty_network_kinds: list[str]
+) -> dict[str, Any]:
+    """Bloque maturity para el --json de build/snapshot/read top (ver Apéndice maturity).
+    Función PURA, sin I/O. Devuelve EXACTAMENTE 4 claves:
+    {curated: bool, scope: str|None, saturated: bool, empty_networks: list[str]}.
+    curated = corpus tiene ≥1 paper con curation_status ∈ {accepted, rejected};
+    saturated = False constante (one-shot never over-claims; gancho futuro referenced_refs_count);
+    empty_networks = solo los kind (reason/fix_command NO se duplican)."""
 ```
 
 **Adaptadores (el contrato se re-exporta, no se duplica).** `cli/_envelope.py` y `cli/_errors.py`
@@ -891,12 +939,15 @@ def get_top(ws: Workspace, *, n=10, kind="bibliographic_coupling") -> dict[str, 
     """Salida de investigación (#157): nodos centrales + pares de co-citación con título,
     sobre redes recomputadas (NO requiere `build`; mismo camino que get_network). Devuelve:
     {kind, top, central: [{id, title, degree_centrality, community?}],
-     cocitation: [{source, source_title, target, target_title, weight}], reason?, fix_command?}.
+     cocitation: [{source, source_title, target, target_title, weight}], reason?, fix_command?,
+     maturity}.
     `central` = top n nodos de la red `kind` por degree_centrality desc (título completo en redes
     de paper; label de entidad en author/institution/keyword). `cocitation` = SIEMPRE la red
     cocitation, top n aristas por weight desc.
     Honest-empty: co-citación vacía (sin cited_by_id) → bloque [] + reason/fix_command
-    (de predict_build_preview), NO error. Raises DataError si kind inválido, n <= 0, o la red
+    (de predict_build_preview), NO error. `maturity` (aditivo, #160, ver Apéndice `maturity`):
+    SIEMPRE presente, scope="all", empty_networks=["cocitation"] si la co-citación quedó vacía.
+    Raises DataError si kind inválido, n <= 0, o la red
     falla genuinamente; StoreError si el store falla. (Detrás de `read top`.)"""
 ```
 

--- a/src/bib2graph/cli/commands/build.py
+++ b/src/bib2graph/cli/commands/build.py
@@ -331,15 +331,28 @@ def run_build(
             artifacts_dir.mkdir(parents=True, exist_ok=True)
             (artifacts_dir / ".corpus_hash").write_text("", encoding="utf-8")
             store.backend.set_loop_state(new_state, cycle_round=new_round)
+            # scope_display para early-return (corpus vacío): mismo cálculo que el path normal.
+            _scope_display_empty = (
+                scope_cli_token if scope_cli_token is not None else corpus_scope
+            )
+            # Maturity en early-return: curated desde corpus_full (el filtrado está vacío).
+            from bib2graph.service.maturity import compute_maturity as _compute_maturity
+
+            _maturity_empty = _compute_maturity(
+                corpus_full,
+                scope=_scope_display_empty,
+                empty_network_kinds=[],
+            )
             return {
                 "networks_built": 0,
                 "artifacts_dir": str(artifacts_dir),
                 "corpus_hash": "",
                 "corpus_scope": corpus_scope,
-                "scope": corpus_scope,
+                "scope": _scope_display_empty,
                 "networks": [],
                 "warnings": build_warnings,
                 "empty_networks": [],
+                "maturity": _maturity_empty,
             }
 
         # Diagnóstico pre-build (ADR 0037 §(e), fuente única con status-time).
@@ -423,15 +436,28 @@ def run_build(
         hash_file.write_text(corpus_hash, encoding="utf-8")
 
         store.backend.set_loop_state(new_state, cycle_round=new_round)
+
+        # FIX 2 — gancho para #160 (maturity): "scope" expone el token CLI tal como
+        # lo tipió el usuario ("seeds"/"accepted"/"all"), NO el vocab interno
+        # ("seeds_only"). Esto hace que la superficie de agents-first sea consistente.
+        # Cuando se llama sin CLI (tests unitarios directos), scope_cli_token=None
+        # y se usa corpus_scope como fallback (preserva compat pre-0.10.0).
+        scope_display = scope_cli_token if scope_cli_token is not None else corpus_scope
+
+        # Maturity (#160): computar DENTRO del try para acceder a corpus_full
+        # antes del store.close() en finally.  Extrae los kinds de empty_networks
+        # (lista de dicts {kind, reason, fix_command}) sin duplicar reason/fix_command.
+        from bib2graph.service.maturity import compute_maturity as _compute_maturity
+
+        empty_network_kinds = [str(en["kind"]) for en in empty_networks]
+        maturity = _compute_maturity(
+            corpus_full,
+            scope=scope_display,
+            empty_network_kinds=empty_network_kinds,
+        )
     finally:
         store.close()
 
-    # FIX 2 — gancho para #160 (maturity): "scope" expone el token CLI tal como
-    # lo tipió el usuario ("seeds"/"accepted"/"all"), NO el vocab interno
-    # ("seeds_only"). Esto hace que la superficie de agents-first sea consistente.
-    # Cuando se llama sin CLI (tests unitarios directos), scope_cli_token=None
-    # y se usa corpus_scope como fallback (preserva compat pre-0.10.0).
-    scope_display = scope_cli_token if scope_cli_token is not None else corpus_scope
     return {
         "networks_built": len(artifacts),
         "artifacts_dir": str(artifacts_dir),
@@ -441,6 +467,7 @@ def run_build(
         "networks": networks_info,
         "warnings": build_warnings,
         "empty_networks": empty_networks,
+        "maturity": maturity,
     }
 
 

--- a/src/bib2graph/cli/commands/snapshot.py
+++ b/src/bib2graph/cli/commands/snapshot.py
@@ -50,11 +50,20 @@ def run_snapshot(
 
     snap = corpus.snapshot(Path(out_dir))
 
+    from bib2graph.service.maturity import compute_maturity
+
+    maturity = compute_maturity(
+        corpus,
+        scope="all",
+        empty_network_kinds=[],
+    )
+
     return {
         "snapshot_dir": str(snap.path),
         "corpus_hash": snap.manifest.corpus_hash,
         "total_papers": len(corpus),
         "schema_version": snap.manifest.schema_version,
+        "maturity": maturity,
     }
 
 

--- a/src/bib2graph/service/__init__.py
+++ b/src/bib2graph/service/__init__.py
@@ -17,6 +17,8 @@ Contrato público re-exportado:
   - ``accept_papers``, ``reject_papers``, ``curate_paper`` — escrituras del
     Hito G3 (ADR 0028).
   - ``resolve_dois`` — resolución DOI→source_id (ADR 0035).
+  - ``compute_maturity`` — bloque ``maturity`` para build/snapshot/read top
+    (#160, sub-issue de la superficie CLI 0.10.0, ADR 0037 §f).
 """
 
 from __future__ import annotations
@@ -32,6 +34,7 @@ from bib2graph.service.errors import (
     UsageError,
     code_for,
 )
+from bib2graph.service.maturity import compute_maturity
 from bib2graph.service.reads import (
     compare_rounds,
     corpus_stats,
@@ -57,6 +60,7 @@ __all__ = [
     "build_envelope",
     "code_for",
     "compare_rounds",
+    "compute_maturity",
     "corpus_stats",
     "curate_paper",
     "get_network",

--- a/src/bib2graph/service/maturity.py
+++ b/src/bib2graph/service/maturity.py
@@ -1,0 +1,91 @@
+"""service.maturity — Bloque ``maturity`` para el ``--json`` de build/snapshot/read top.
+
+Función pura sin I/O que calcula el bloque de madurez declarativo (ADR 0037 §f,
+sub-issue #160). La honestidad por construcción requiere declarar explícitamente
+el estado de curación, saturación y vaciedad de redes, **sin afirmar más de lo
+que se sabe**.
+
+Contrato del bloque::
+
+    {
+        "curated": false,          # bool
+        "scope": "all",            # str | None
+        "saturated": false,        # bool — SIEMPRE False en one-shot (PO)
+        "empty_networks": []       # list[str] — solo los kinds vacíos
+    }
+
+``saturated`` es siempre ``False`` en el camino one-shot: el PO decidió no
+sobre-afirmar; la condición de saturación de referencias requeriría comparar
+el conteo de referencias nuevas entre dos rondas consecutivas de ``enrich``
+(gancho futuro: ``referenced_refs_count()`` en el Enricher de OpenAlex).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from bib2graph.corpus import Corpus
+
+
+def compute_maturity(
+    corpus: Corpus,
+    *,
+    scope: str | None,
+    empty_network_kinds: list[str],
+) -> dict[str, Any]:
+    """Calcula el bloque ``maturity`` para el ``--json`` de build/snapshot/read top.
+
+    Función pura: no produce I/O ni efectos de lado.  Recibe el corpus ya
+    cargado (sin abrir stores), el token de scope y los kinds de redes vacías
+    determinados por quien llama.
+
+    ``curated`` es ``True`` si el corpus contiene ≥1 paper con
+    ``curation_status`` ∈ {``accepted``, ``rejected``}.  Refleja si hay
+    decisiones de curación aplicadas, independientemente del scope o del FSM.
+
+    ``saturated`` es siempre ``False`` (decisión PO: never over-claim en one-shot).
+    Gancho futuro: comparar ``referenced_refs_count()`` entre rondas de ``enrich``
+    para detectar convergencia de referencias.
+
+    Args:
+        corpus: Corpus ya cargado.  Se usa para derivar ``curated`` a partir
+            de los conteos de ``curation_status``.
+        scope: Token de scope tal como lo expone ``data["scope"]``.  En build
+            se reutiliza ``data["scope"]``; en snapshot y read top es ``"all"``.
+            Puede ser ``None`` si no aplica.
+        empty_network_kinds: Lista de tokens ``kind`` de redes que resultaron
+            vacías.  En build se extraen de ``data["empty_networks"]`` (lista
+            de dicts ``{kind, reason, fix_command}``).  En read top es
+            ``["cocitation"]`` si la red está vacía; en snapshot es ``[]``.
+            Solo se incluyen los ``kind``, no los ``reason``/``fix_command``
+            (esos siguen viviendo en ``data["empty_networks"]`` de build).
+
+    Returns:
+        Dict con exactamente 4 claves:
+        - ``"curated"``: bool.
+        - ``"scope"``: str | None.
+        - ``"saturated"``: bool (siempre False).
+        - ``"empty_networks"``: list[str] (solo kinds).
+    """
+    import pyarrow.compute as pc
+
+    from bib2graph.constants import Col, CurationStatus
+
+    table = corpus.to_arrow()
+
+    # Derivar curated: ≥1 paper con curation_status ∈ {accepted, rejected}
+    curation_col = table.column(Col.CURATION_STATUS)
+    accepted_mask = pc.equal(curation_col, CurationStatus.ACCEPTED)  # type: ignore[attr-defined]
+    rejected_mask = pc.equal(curation_col, CurationStatus.REJECTED)  # type: ignore[attr-defined]
+    curated_mask = pc.or_(accepted_mask, rejected_mask)  # type: ignore[attr-defined]
+    curated = bool(pc.any(curated_mask).as_py())  # type: ignore[attr-defined]
+
+    return {
+        "curated": curated,
+        "scope": scope,
+        # saturated: SIEMPRE False en one-shot — PO decidió no sobre-afirmar.
+        # Gancho futuro: referenced_refs_count() entre rondas de enrich.
+        "saturated": False,
+        "empty_networks": list(empty_network_kinds),
+    }

--- a/src/bib2graph/service/reads.py
+++ b/src/bib2graph/service/reads.py
@@ -927,7 +927,8 @@ def get_top(
 
     # Honest-empty: si co-citación vacía, agregar reason/fix_command.
     # Igual que "build" con red vacía → exit 0, NO DataError.
-    if not coc_net["edges"]:
+    coc_is_empty = not coc_net["edges"]
+    if coc_is_empty:
         from bib2graph.networks.facade import predict_build_preview
 
         preview = predict_build_preview(corpus)
@@ -938,5 +939,15 @@ def get_top(
         if coc_entry is not None:
             result["reason"] = coc_entry["reason"]
             result["fix_command"] = coc_entry["fix_command"]
+
+    # Maturity (#160): siempre presente en read top (scope="all", redes vacías inferidas).
+    from bib2graph.service.maturity import compute_maturity
+
+    empty_network_kinds = ["cocitation"] if coc_is_empty else []
+    result["maturity"] = compute_maturity(
+        corpus,
+        scope="all",
+        empty_network_kinds=empty_network_kinds,
+    )
 
     return result

--- a/tests/unit/test_maturity.py
+++ b/tests/unit/test_maturity.py
@@ -1,0 +1,727 @@
+"""Tests TDD — bloque ``maturity`` en build/snapshot/read top (#160).
+
+Cubre:
+1. ``compute_maturity`` (helper puro):
+   a. ``curated=False`` cuando todo es candidate/seed.
+   b. ``curated=True`` con ≥1 accepted.
+   c. ``curated=True`` con ≥1 rejected.
+   d. ``saturated`` siempre False.
+   e. ``scope`` y ``empty_networks`` pasan literalmente.
+   f. Key-set consistente (4 claves exactas).
+
+2. ``build`` — ``maturity`` en data:
+   a. Presente en el path normal (corpus no vacío).
+   b. Presente en el early-return (corpus vacío tras scope).
+   c. ``empty_networks`` de maturity = kinds del data["empty_networks"].
+   d. ``schema="1"`` intacto.
+
+3. ``snapshot`` — ``maturity`` en data:
+   a. Presente, scope="all", empty_networks=[].
+   b. ``schema="1"`` intacto.
+
+4. ``read top`` — ``maturity`` en result:
+   a. Presente con corpus bib-coupling (co-cit vacía → maturity.empty_networks=["cocitation"]).
+   b. Presente con corpus co-citación (no vacía → maturity.empty_networks=[]).
+   c. Forma consistente (4 claves).
+
+5. Negativos — maturity AUSENTE en read list/stats/show.
+
+Marcador: ``unit`` (DuckDB en tmp_path, sin red real).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pyarrow as pa
+import pytest
+from click.testing import CliRunner
+
+from bib2graph.schemas import CORPUS_SCHEMA
+
+pytestmark = pytest.mark.unit
+
+# ---------------------------------------------------------------------------
+# Helpers compartidos
+# ---------------------------------------------------------------------------
+
+
+def _row(
+    id: str,
+    *,
+    is_seed: bool = True,
+    curation_status: str = "candidate",
+    references_id: list[str] | None = None,
+    cited_by_id: list[str] | None = None,
+    keywords_id: list[str] | None = None,
+) -> dict[str, Any]:
+    """Fila mínima con schema canónico completo."""
+    return {
+        "id": id,
+        "source_id": None,
+        "doi": None,
+        "title": f"Paper {id}",
+        "year": 2020,
+        "abstract": None,
+        "source": None,
+        "language": None,
+        "publisher": None,
+        "research_areas": None,
+        "is_seed": is_seed,
+        "curation_status": curation_status,
+        "provenance": None,
+        "authors_raw": None,
+        "authors_id": None,
+        "authors_affiliations": None,
+        "keywords_raw": None,
+        "keywords_id": keywords_id,
+        "institutions_raw": None,
+        "institutions_id": None,
+        "references_id": references_id,
+        "references_doi": None,
+        "cited_by_id": cited_by_id,
+    }
+
+
+def _make_corpus(*rows: dict[str, Any]):  # type: ignore[no-untyped-def]
+    """Construye un Corpus en memoria desde filas dict."""
+    from bib2graph.corpus import Corpus
+
+    table = pa.Table.from_pylist(list(rows), schema=CORPUS_SCHEMA)
+    return Corpus.from_arrow(table)
+
+
+def _seed_store(store_path: Path, rows: list[dict[str, Any]]) -> None:
+    """Persiste filas en un DuckDB temporal."""
+    from bib2graph.corpus import Corpus
+    from bib2graph.stores.duckdb import DuckDBStore
+
+    table = pa.Table.from_pylist(rows, schema=CORPUS_SCHEMA)
+    corpus = Corpus.from_arrow(table)
+    store = DuckDBStore(store_path)
+    store.persist(corpus)
+    store.close()
+
+
+def _init_workspace(tmp_path: Path, name: str = "test-ws") -> Any:
+    """Crea y devuelve un Workspace inicializado en tmp_path."""
+    from bib2graph.workspace import Workspace
+
+    ws_dir = tmp_path / name
+    return Workspace.init(ws_dir, name)
+
+
+def _seed_workspace(ws: Any, rows: list[dict[str, Any]]) -> None:
+    """Persiste filas en el store del workspace."""
+    _seed_store(ws.library_path, rows)
+
+
+def _rows_bib_coupling() -> list[dict[str, Any]]:
+    """3 papers con referencias compartidas (coupling); sin cited_by_id → coc vacía."""
+    return [
+        _row("P1", references_id=["R1", "R2", "R3"]),
+        _row("P2", references_id=["R1", "R3"]),
+        _row("P3", references_id=["R2"]),
+    ]
+
+
+def _rows_cocitation() -> list[dict[str, Any]]:
+    """3 papers con cited_by_id → co-citación no vacía."""
+    return [
+        _row("P1", is_seed=True, cited_by_id=["C1", "C2"]),
+        _row("P2", is_seed=True, cited_by_id=["C1", "C3"]),
+        _row("P3", is_seed=True, cited_by_id=["C4"]),
+    ]
+
+
+def _assert_maturity_shape(mat: dict[str, Any]) -> None:
+    """Verifica que el bloque maturity tenga exactamente las 4 claves esperadas."""
+    assert set(mat.keys()) == {
+        "curated",
+        "scope",
+        "saturated",
+        "empty_networks",
+    }, f"Claves de maturity incorrectas: {set(mat.keys())}"
+    assert isinstance(mat["curated"], bool), "curated debe ser bool"
+    assert isinstance(mat["saturated"], bool), "saturated debe ser bool"
+    assert isinstance(mat["empty_networks"], list), "empty_networks debe ser list"
+
+
+# ---------------------------------------------------------------------------
+# 1. compute_maturity — helper puro
+# ---------------------------------------------------------------------------
+
+
+class TestComputeMaturity:
+    """Tests unitarios de la función pura compute_maturity."""
+
+    def test_curated_false_todo_candidate(self) -> None:
+        """corpus con solo candidates → curated=False."""
+        from bib2graph.service.maturity import compute_maturity
+
+        corpus = _make_corpus(
+            _row("P1", curation_status="candidate"),
+            _row("P2", curation_status="candidate"),
+        )
+        mat = compute_maturity(corpus, scope="all", empty_network_kinds=[])
+        assert mat["curated"] is False
+
+    def test_curated_false_solo_seeds_candidate(self) -> None:
+        """corpus con seeds (is_seed=True) pero curation_status='candidate' → curated=False."""
+        from bib2graph.service.maturity import compute_maturity
+
+        corpus = _make_corpus(
+            _row("P1", is_seed=True, curation_status="candidate"),
+            _row("P2", is_seed=True, curation_status="candidate"),
+        )
+        mat = compute_maturity(corpus, scope="all", empty_network_kinds=[])
+        assert mat["curated"] is False
+
+    def test_curated_true_con_accepted(self) -> None:
+        """corpus con ≥1 accepted → curated=True."""
+        from bib2graph.service.maturity import compute_maturity
+
+        corpus = _make_corpus(
+            _row("P1", curation_status="candidate"),
+            _row("P2", curation_status="accepted"),
+        )
+        mat = compute_maturity(corpus, scope="all", empty_network_kinds=[])
+        assert mat["curated"] is True
+
+    def test_curated_true_con_rejected(self) -> None:
+        """corpus con ≥1 rejected → curated=True."""
+        from bib2graph.service.maturity import compute_maturity
+
+        corpus = _make_corpus(
+            _row("P1", curation_status="candidate"),
+            _row("P2", curation_status="rejected"),
+        )
+        mat = compute_maturity(corpus, scope="all", empty_network_kinds=[])
+        assert mat["curated"] is True
+
+    def test_curated_true_con_accepted_y_rejected(self) -> None:
+        """corpus con accepted y rejected → curated=True."""
+        from bib2graph.service.maturity import compute_maturity
+
+        corpus = _make_corpus(
+            _row("P1", curation_status="accepted"),
+            _row("P2", curation_status="rejected"),
+        )
+        mat = compute_maturity(corpus, scope="all", empty_network_kinds=[])
+        assert mat["curated"] is True
+
+    def test_saturated_siempre_false(self) -> None:
+        """saturated siempre es False, independientemente del corpus."""
+        from bib2graph.service.maturity import compute_maturity
+
+        corpus_curado = _make_corpus(_row("P1", curation_status="accepted"))
+        corpus_puro = _make_corpus(_row("P2", curation_status="candidate"))
+
+        mat_curado = compute_maturity(
+            corpus_curado, scope="all", empty_network_kinds=[]
+        )
+        mat_puro = compute_maturity(corpus_puro, scope="all", empty_network_kinds=[])
+
+        assert mat_curado["saturated"] is False
+        assert mat_puro["saturated"] is False
+
+    def test_scope_se_pasa_literalmente(self) -> None:
+        """scope se propaga tal cual al bloque maturity."""
+        from bib2graph.service.maturity import compute_maturity
+
+        corpus = _make_corpus(_row("P1"))
+
+        for token in ("all", "seeds", "accepted", None):
+            mat = compute_maturity(corpus, scope=token, empty_network_kinds=[])
+            assert mat["scope"] == token, (
+                f"scope esperado {token!r}, got {mat['scope']!r}"
+            )
+
+    def test_empty_network_kinds_se_pasan_literalmente(self) -> None:
+        """empty_network_kinds se propaga literalmente."""
+        from bib2graph.service.maturity import compute_maturity
+
+        corpus = _make_corpus(_row("P1"))
+
+        mat_vacia = compute_maturity(corpus, scope="all", empty_network_kinds=[])
+        assert mat_vacia["empty_networks"] == []
+
+        mat_con_kinds = compute_maturity(
+            corpus,
+            scope="all",
+            empty_network_kinds=["cocitation", "keyword_cooccurrence"],
+        )
+        assert mat_con_kinds["empty_networks"] == ["cocitation", "keyword_cooccurrence"]
+
+    def test_keyset_consistente_4_claves(self) -> None:
+        """El bloque maturity tiene exactamente 4 claves (nunca más, nunca menos)."""
+        from bib2graph.service.maturity import compute_maturity
+
+        corpus = _make_corpus(_row("P1", curation_status="accepted"))
+        mat = compute_maturity(corpus, scope="all", empty_network_kinds=["cocitation"])
+        _assert_maturity_shape(mat)
+
+
+# ---------------------------------------------------------------------------
+# 2. build — maturity en data
+# ---------------------------------------------------------------------------
+
+
+class TestBuildMaturity:
+    """``run_build`` incluye ``maturity`` en el dict devuelto."""
+
+    def test_maturity_presente_en_build_normal(self, tmp_path: Path) -> None:
+        """run_build con corpus no vacío incluye data['maturity']."""
+        from bib2graph.cli.commands.build import run_build
+
+        store_path = tmp_path / "lib.duckdb"
+        _seed_store(store_path, _rows_bib_coupling())
+
+        data = run_build(store_path, out_dir=tmp_path / "nets")
+
+        assert "maturity" in data, "data debe tener clave 'maturity'"
+        _assert_maturity_shape(data["maturity"])
+
+    def test_maturity_curated_false_en_build_todo_candidate(
+        self, tmp_path: Path
+    ) -> None:
+        """run_build con corpus de puros candidates → maturity.curated=False."""
+        from bib2graph.cli.commands.build import run_build
+
+        store_path = tmp_path / "lib.duckdb"
+        _seed_store(store_path, _rows_bib_coupling())  # todos candidate
+
+        data = run_build(store_path, out_dir=tmp_path / "nets")
+
+        assert data["maturity"]["curated"] is False
+
+    def test_maturity_curated_true_en_build_con_accepted(self, tmp_path: Path) -> None:
+        """run_build con ≥1 accepted → maturity.curated=True."""
+        from bib2graph.cli.commands.build import run_build
+
+        store_path = tmp_path / "lib.duckdb"
+        rows = [
+            _row("P1", curation_status="accepted", references_id=["R1", "R2"]),
+            _row("P2", curation_status="candidate", references_id=["R1", "R3"]),
+        ]
+        _seed_store(store_path, rows)
+
+        data = run_build(store_path, out_dir=tmp_path / "nets")
+
+        assert data["maturity"]["curated"] is True
+
+    def test_maturity_scope_coincide_con_data_scope(self, tmp_path: Path) -> None:
+        """maturity.scope coincide con data['scope']."""
+        from bib2graph.cli.commands.build import run_build
+
+        store_path = tmp_path / "lib.duckdb"
+        _seed_store(store_path, _rows_bib_coupling())
+
+        data = run_build(
+            store_path,
+            out_dir=tmp_path / "nets",
+            scope_cli_token="seeds",
+            corpus_scope="seeds_only",
+        )
+
+        assert data["maturity"]["scope"] == data["scope"] == "seeds"
+
+    def test_maturity_empty_networks_kinds_de_data_empty_networks(
+        self, tmp_path: Path
+    ) -> None:
+        """maturity.empty_networks son solo los kinds (sin reason/fix_command duplicados)."""
+        from bib2graph.cli.commands.build import run_build
+
+        store_path = tmp_path / "lib.duckdb"
+        # Sin keywords_id → keyword_cooccurrence vacía
+        rows = [_row(f"P{i}", references_id=[f"R{i}", "RSHARED"]) for i in range(3)]
+        _seed_store(store_path, rows)
+
+        data = run_build(store_path, out_dir=tmp_path / "nets")
+
+        empty_kinds_in_data = [en["kind"] for en in data["empty_networks"]]
+        maturity_empty = data["maturity"]["empty_networks"]
+
+        # Los kinds de maturity.empty_networks deben coincidir con data["empty_networks"]
+        assert set(maturity_empty) == set(empty_kinds_in_data), (
+            f"maturity.empty_networks {maturity_empty!r} != "
+            f"data.empty_networks kinds {empty_kinds_in_data!r}"
+        )
+
+        # Maturity SOLO tiene los kinds (no reason ni fix_command)
+        for item in maturity_empty:
+            assert isinstance(item, str), (
+                f"maturity.empty_networks debe contener strings, no dicts: {item!r}"
+            )
+
+    def test_maturity_saturated_false_en_build(self, tmp_path: Path) -> None:
+        """maturity.saturated siempre False en build."""
+        from bib2graph.cli.commands.build import run_build
+
+        store_path = tmp_path / "lib.duckdb"
+        _seed_store(store_path, _rows_bib_coupling())
+
+        data = run_build(store_path, out_dir=tmp_path / "nets")
+
+        assert data["maturity"]["saturated"] is False
+
+    def test_maturity_presente_en_early_return_corpus_vacio(
+        self, tmp_path: Path
+    ) -> None:
+        """Early-return (scope deja 0 papers) también incluye maturity."""
+        from bib2graph.cli.commands.build import run_build
+
+        store_path = tmp_path / "lib.duckdb"
+        # Solo seeds; scope=accepted → corpus_filtrado vacío si ningún accepted
+        _seed_store(
+            store_path,
+            [_row("P1", is_seed=True, curation_status="candidate")],
+        )
+
+        run_build(
+            store_path,
+            out_dir=tmp_path / "nets",
+            corpus_scope="accepted",
+        )
+
+        # Early-return: corpus_scope='accepted' deja 0 papers (P1 es seed pero candidate,
+        # el scope 'accepted' incluye is_seed=True → P1 SÍ entra.
+        # Probamos con corpus_scope='seeds_only' y corpus sin seeds:
+        store_path2 = tmp_path / "lib2.duckdb"
+        _seed_store(
+            store_path2,
+            [_row("C1", is_seed=False, curation_status="candidate")],
+        )
+        data2 = run_build(
+            store_path2,
+            out_dir=tmp_path / "nets2",
+            corpus_scope="seeds_only",
+        )
+
+        assert "maturity" in data2, "Early-return debe incluir 'maturity'"
+        _assert_maturity_shape(data2["maturity"])
+        assert data2["maturity"]["saturated"] is False
+
+    def test_build_schema_1_intacto_con_maturity(self, tmp_path: Path) -> None:
+        """build --json: schema='1' intacto después de agregar maturity."""
+        from bib2graph.workspace import Workspace
+
+        ws_dir = tmp_path / "ws"
+        ws = Workspace.init(ws_dir, "test")
+        _seed_workspace(ws, _rows_bib_coupling())
+
+        from bib2graph.cli import b2g
+
+        runner = CliRunner()
+        result = runner.invoke(
+            b2g,
+            ["--workspace", str(ws_dir), "build", "--json"],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, f"Error: {result.output}"
+        envelope = json.loads(result.output)
+        assert envelope["schema"] == "1"
+        assert envelope["ok"] is True
+        assert "maturity" in envelope["data"]
+
+    def test_build_json_maturity_no_tiene_reason_fix_command(
+        self, tmp_path: Path
+    ) -> None:
+        """maturity en --json NO duplica reason/fix_command de empty_networks."""
+        from bib2graph.workspace import Workspace
+
+        ws_dir = tmp_path / "ws"
+        ws = Workspace.init(ws_dir, "test")
+        # Sin keywords_id → keyword_cooccurrence vacía
+        rows = [_row(f"P{i}", references_id=[f"R{i}", "RS"]) for i in range(3)]
+        _seed_workspace(ws, rows)
+
+        from bib2graph.cli import b2g
+
+        runner = CliRunner()
+        result = runner.invoke(
+            b2g,
+            ["--workspace", str(ws_dir), "build", "--json"],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+        envelope = json.loads(result.output)
+        mat = envelope["data"]["maturity"]
+
+        # maturity.empty_networks son strings (kinds), no dicts
+        for item in mat["empty_networks"]:
+            assert isinstance(item, str), (
+                f"maturity.empty_networks deben ser strings: {item!r}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# 3. snapshot — maturity en data
+# ---------------------------------------------------------------------------
+
+
+class TestSnapshotMaturity:
+    """``run_snapshot`` incluye ``maturity`` en el dict devuelto."""
+
+    def test_maturity_presente_en_snapshot(self, tmp_path: Path) -> None:
+        """run_snapshot incluye data['maturity']."""
+        from bib2graph.cli.commands.snapshot import run_snapshot
+
+        store_path = tmp_path / "lib.duckdb"
+        _seed_store(store_path, _rows_bib_coupling())
+
+        snap_dir = tmp_path / "snapshots"
+        data = run_snapshot(store_path, out_dir=snap_dir)
+
+        assert "maturity" in data, "data debe tener clave 'maturity'"
+        _assert_maturity_shape(data["maturity"])
+
+    def test_snapshot_maturity_scope_all(self, tmp_path: Path) -> None:
+        """snapshot: maturity.scope='all' (exporta completo)."""
+        from bib2graph.cli.commands.snapshot import run_snapshot
+
+        store_path = tmp_path / "lib.duckdb"
+        _seed_store(store_path, _rows_bib_coupling())
+
+        data = run_snapshot(store_path, out_dir=tmp_path / "snaps")
+
+        assert data["maturity"]["scope"] == "all"
+
+    def test_snapshot_maturity_empty_networks_vacia(self, tmp_path: Path) -> None:
+        """snapshot: maturity.empty_networks=[] (snapshot no sabe de redes)."""
+        from bib2graph.cli.commands.snapshot import run_snapshot
+
+        store_path = tmp_path / "lib.duckdb"
+        _seed_store(store_path, _rows_bib_coupling())
+
+        data = run_snapshot(store_path, out_dir=tmp_path / "snaps")
+
+        assert data["maturity"]["empty_networks"] == []
+
+    def test_snapshot_maturity_curated_false_todo_candidate(
+        self, tmp_path: Path
+    ) -> None:
+        """snapshot con corpus de candidates → maturity.curated=False."""
+        from bib2graph.cli.commands.snapshot import run_snapshot
+
+        store_path = tmp_path / "lib.duckdb"
+        _seed_store(store_path, _rows_bib_coupling())
+
+        data = run_snapshot(store_path, out_dir=tmp_path / "snaps")
+
+        assert data["maturity"]["curated"] is False
+
+    def test_snapshot_maturity_curated_true_con_accepted(self, tmp_path: Path) -> None:
+        """snapshot con ≥1 accepted → maturity.curated=True."""
+        from bib2graph.cli.commands.snapshot import run_snapshot
+
+        store_path = tmp_path / "lib.duckdb"
+        rows = [
+            _row("P1", curation_status="accepted"),
+            _row("P2", curation_status="candidate"),
+        ]
+        _seed_store(store_path, rows)
+
+        data = run_snapshot(store_path, out_dir=tmp_path / "snaps")
+
+        assert data["maturity"]["curated"] is True
+
+    def test_snapshot_maturity_saturated_false(self, tmp_path: Path) -> None:
+        """snapshot: maturity.saturated=False."""
+        from bib2graph.cli.commands.snapshot import run_snapshot
+
+        store_path = tmp_path / "lib.duckdb"
+        _seed_store(store_path, _rows_bib_coupling())
+
+        data = run_snapshot(store_path, out_dir=tmp_path / "snaps")
+
+        assert data["maturity"]["saturated"] is False
+
+    def test_snapshot_schema_1_intacto(self, tmp_path: Path) -> None:
+        """snapshot --json: schema='1' intacto después de agregar maturity."""
+        from bib2graph.workspace import Workspace
+
+        ws_dir = tmp_path / "ws"
+        ws = Workspace.init(ws_dir, "test")
+        _seed_workspace(ws, _rows_bib_coupling())
+
+        from bib2graph.cli import b2g
+
+        runner = CliRunner()
+        result = runner.invoke(
+            b2g,
+            ["--workspace", str(ws_dir), "snapshot", "--json"],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, f"Error: {result.output}"
+        envelope = json.loads(result.output)
+        assert envelope["schema"] == "1"
+        assert envelope["ok"] is True
+        assert "maturity" in envelope["data"]
+
+
+# ---------------------------------------------------------------------------
+# 4. read top — maturity en result
+# ---------------------------------------------------------------------------
+
+
+class TestReadTopMaturity:
+    """``get_top`` incluye ``maturity`` en el result."""
+
+    def test_maturity_presente_en_get_top(self, tmp_path: Path) -> None:
+        """get_top incluye result['maturity']."""
+        from bib2graph.service.reads import get_top
+
+        ws = _init_workspace(tmp_path)
+        _seed_workspace(ws, _rows_bib_coupling())
+
+        result = get_top(ws, n=3, kind="bibliographic_coupling")
+
+        assert "maturity" in result, "result debe tener clave 'maturity'"
+        _assert_maturity_shape(result["maturity"])
+
+    def test_read_top_maturity_scope_all(self, tmp_path: Path) -> None:
+        """read top: maturity.scope='all'."""
+        from bib2graph.service.reads import get_top
+
+        ws = _init_workspace(tmp_path)
+        _seed_workspace(ws, _rows_bib_coupling())
+
+        result = get_top(ws, n=3, kind="bibliographic_coupling")
+
+        assert result["maturity"]["scope"] == "all"
+
+    def test_read_top_maturity_cocitacion_vacia_en_empty_networks(
+        self, tmp_path: Path
+    ) -> None:
+        """read top con co-citación vacía → maturity.empty_networks=['cocitation']."""
+        from bib2graph.service.reads import get_top
+
+        ws = _init_workspace(tmp_path)
+        _seed_workspace(ws, _rows_bib_coupling())  # sin cited_by_id → coc vacía
+
+        result = get_top(ws, n=3, kind="bibliographic_coupling")
+
+        assert result["maturity"]["empty_networks"] == ["cocitation"], (
+            f"Expected ['cocitation'], got {result['maturity']['empty_networks']!r}"
+        )
+
+    def test_read_top_maturity_cocitacion_llena_empty_networks_vacia(
+        self, tmp_path: Path
+    ) -> None:
+        """read top con co-citación no vacía → maturity.empty_networks=[]."""
+        from bib2graph.service.reads import get_top
+
+        ws = _init_workspace(tmp_path)
+        _seed_workspace(ws, _rows_cocitation())
+
+        result = get_top(ws, n=5, kind="cocitation")
+
+        assert result["maturity"]["empty_networks"] == []
+
+    def test_read_top_maturity_curated_false_todo_candidate(
+        self, tmp_path: Path
+    ) -> None:
+        """read top con corpus de candidates → maturity.curated=False."""
+        from bib2graph.service.reads import get_top
+
+        ws = _init_workspace(tmp_path)
+        _seed_workspace(ws, _rows_bib_coupling())
+
+        result = get_top(ws, n=3)
+
+        assert result["maturity"]["curated"] is False
+
+    def test_read_top_maturity_curated_true_con_accepted(self, tmp_path: Path) -> None:
+        """read top con ≥1 accepted → maturity.curated=True."""
+        from bib2graph.service.reads import get_top
+
+        ws = _init_workspace(tmp_path)
+        rows = [
+            _row("P1", curation_status="accepted", references_id=["R1", "R2"]),
+            _row("P2", curation_status="candidate", references_id=["R1", "R3"]),
+        ]
+        _seed_workspace(ws, rows)
+
+        result = get_top(ws, n=3)
+
+        assert result["maturity"]["curated"] is True
+
+    def test_read_top_maturity_saturated_false(self, tmp_path: Path) -> None:
+        """read top: maturity.saturated=False."""
+        from bib2graph.service.reads import get_top
+
+        ws = _init_workspace(tmp_path)
+        _seed_workspace(ws, _rows_bib_coupling())
+
+        result = get_top(ws, n=3)
+
+        assert result["maturity"]["saturated"] is False
+
+    def test_read_top_schema_1_intacto_con_maturity(self, tmp_path: Path) -> None:
+        """read top --json: schema='1' intacto después de agregar maturity."""
+        from bib2graph.workspace import Workspace
+
+        ws_dir = tmp_path / "ws"
+        ws = Workspace.init(ws_dir, "test")
+        _seed_workspace(ws, _rows_bib_coupling())
+
+        from bib2graph.cli import b2g
+
+        runner = CliRunner()
+        result = runner.invoke(
+            b2g,
+            ["--workspace", str(ws_dir), "read", "top", "--json"],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, f"Error: {result.output}"
+        envelope = json.loads(result.output)
+        assert envelope["schema"] == "1"
+        assert envelope["ok"] is True
+        assert "maturity" in envelope["data"]
+
+
+# ---------------------------------------------------------------------------
+# 5. Negativos — maturity AUSENTE en read list/stats/show
+# ---------------------------------------------------------------------------
+
+
+class TestMaturityAusenteEnOtrasLecturas:
+    """maturity solo aparece en build/snapshot/read top, NO en list/stats/show."""
+
+    def test_maturity_ausente_en_list_papers(self, tmp_path: Path) -> None:
+        """list_papers NO incluye 'maturity' (es plomería, no presentación)."""
+        from bib2graph.service.reads import list_papers
+
+        ws = _init_workspace(tmp_path)
+        _seed_workspace(ws, _rows_bib_coupling())
+
+        result = list_papers(ws)
+
+        assert "maturity" not in result, (
+            "list_papers NO debe tener 'maturity'; es solo para build/snapshot/read top"
+        )
+
+    def test_maturity_ausente_en_corpus_stats(self, tmp_path: Path) -> None:
+        """corpus_stats NO incluye 'maturity'."""
+        from bib2graph.service.reads import corpus_stats
+
+        ws = _init_workspace(tmp_path)
+        _seed_workspace(ws, _rows_bib_coupling())
+
+        result = corpus_stats(ws)
+
+        assert "maturity" not in result, "corpus_stats NO debe tener 'maturity'"
+
+    def test_maturity_ausente_en_get_paper(self, tmp_path: Path) -> None:
+        """get_paper NO incluye 'maturity'."""
+        from bib2graph.service.reads import get_paper
+
+        ws = _init_workspace(tmp_path)
+        _seed_workspace(ws, _rows_bib_coupling())
+
+        result = get_paper(ws, "P1")
+
+        assert "maturity" not in result, "get_paper NO debe tener 'maturity'"


### PR DESCRIPTION
Closes #160. Sub-issue del epic #167 (superficie CLI 0.10.0, ADR 0037 f + 0038 P3). Última pieza crítica antes del capstone E2E #76.

## Qué
Bloque aditivo `maturity` en el `--json` de `build`, `snapshot` y `read top` — honestidad por construcción (el resultado one-shot se autodeclara borrador):
```json
"maturity": {"curated": false, "scope": "all", "saturated": false, "empty_networks": ["cocitation"]}
```
- **`curated`**: ≥1 paper accepted/rejected (sobre `corpus_full`, pre-scope, para que un scope que deja 0 no falsee curated).
- **`scope`**: token CLI. **`saturated`**: `false` constante (one-shot nunca sobre-afirma). **`empty_networks`**: kinds vacíos (build: de `data.empty_networks`; read top: `["cocitation"]` si vacía; snapshot: `[]`). `reason`/`fix_command` NO se duplican.
- Helper puro `service/maturity.py:compute_maturity` (fuente única). Presente siempre en build/snapshot/read top; ausente en read list/stats/show.

## Tests
`tests/unit/test_maturity.py` (36 tests, `compute_maturity` 100% cobertura): curated true/false, empty_networks coherente con el build real, presencia/ausencia, forma fija. Verifier: **PASA**. Gate verde: ruff + mypy limpios, 1125 passed.

## Docs (lockstep)
`API.md` (apéndice `maturity` + secciones build/snapshot/read top), `AGENTS.md`. **Sin ADR nuevo** (ADR 0038 P3 delegó la forma a API.md).

## Invariante
Envelope `schema="1"`, exit codes, FSM **intactos**; `maturity` es aditivo dentro de `data`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
