### PR TITLE
feat(chain): absorber monitor como chain --since (#158)

### DIFF
--- a/src/bib2graph/cli/_options.py
+++ b/src/bib2graph/cli/_options.py
@@ -1,8 +1,9 @@
 """cli._options — Opciones Click compartidas entre subcomandos.
 
-Define el decorador ``json_option`` (una sola declaración del flag ``--json``)
-y los helpers ``_env_truthy`` / ``json_mode`` para resolver el modo JSON desde
-el flag local o la variable de entorno ``B2G_JSON``.
+Define el decorador ``json_option`` (una sola declaración del flag ``--json``),
+los helpers ``_env_truthy`` / ``json_mode`` para resolver el modo JSON desde
+el flag local o la variable de entorno ``B2G_JSON``, y ``parse_since`` para
+convertir el flag ``--since`` de ``chain`` en un ``date`` concreto.
 
 Precedencia para activar el modo JSON:
   1. ``--json`` explícito en el comando (flag local ``json_output=True``).
@@ -19,12 +20,18 @@ var están presentes.
 from __future__ import annotations
 
 import os
+import re
 from collections.abc import Callable
+from datetime import date, timedelta
 from typing import Any, TypeVar
 
 import click
 
 F = TypeVar("F", bound=Callable[..., Any])
+
+# ---------------------------------------------------------------------------
+# Helpers de modo JSON
+# ---------------------------------------------------------------------------
 
 
 def _env_truthy(name: str) -> bool:
@@ -86,3 +93,64 @@ def json_option(func: F) -> F:
         default=False,
         help="Salida JSON estructurada (también activado por B2G_JSON=1).",
     )(func)
+
+
+# ---------------------------------------------------------------------------
+# Helper de --since
+# ---------------------------------------------------------------------------
+
+_RELATIVE_RE = re.compile(r"^(\d+)(d|m|y)$", re.IGNORECASE)
+
+_DAYS_PER_UNIT: dict[str, int] = {
+    "d": 1,
+    "m": 30,
+    "y": 365,
+}
+
+
+def parse_since(value: str, *, now: date | None = None) -> date:
+    """Parsea el valor de ``--since`` en un ``date`` concreto.
+
+    Acepta dos formatos:
+    - Fecha ISO ``YYYY-MM-DD`` (p. ej. ``"2024-01-01"``).
+    - Atajo relativo ``Nd``, ``Nm``, ``Ny`` (p. ej. ``"90d"``, ``"6m"``, ``"1y"``).
+      El relativo se resuelve contra ``now`` o ``datetime.now(UTC).date()``
+      inyectado en la frontera (R2/ADR 0017).
+
+    La resolución del reloj se hace en la -frontera- (el comando Click), NO
+    dentro del núcleo ni del servicio.
+
+    Args:
+        value: Cadena recibida del flag CLI.
+        now: Fecha base para relativos (inyectable en tests).  Cuando es
+            ``None``, se usa ``date.today()`` (equivalente a ``datetime.now(UTC).date()``).
+
+    Returns:
+        Fecha resuelta como ``date``.
+
+    Raises:
+        UsageError: Si el formato no es reconocido.
+    """
+    from bib2graph.service.errors import UsageError
+
+    value = value.strip()
+
+    # Intento ISO primero
+    try:
+        return date.fromisoformat(value)
+    except ValueError:
+        pass
+
+    # Intento relativo
+    m = _RELATIVE_RE.match(value)
+    if m:
+        n = int(m.group(1))
+        unit = m.group(2).lower()
+        base = now if now is not None else date.today()
+        delta_days = n * _DAYS_PER_UNIT[unit]
+        return base - timedelta(days=delta_days)
+
+    raise UsageError(
+        f"Formato de --since no reconocido: {value!r}.  "
+        "Usá una fecha ISO (YYYY-MM-DD) o un atajo relativo (90d, 6m, 1y)."
+    )

--- a/src/bib2graph/cli/commands/chain.py
+++ b/src/bib2graph/cli/commands/chain.py
@@ -6,14 +6,14 @@ Transiciona el CycleState a FORAGED tras persistir con éxito.
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime
 from pathlib import Path
 from typing import Any, Literal
 
 import click
 
 from bib2graph.cli._envelope import build_envelope, emit, emit_human
-from bib2graph.cli._errors import DependencyError, handle_errors
+from bib2graph.cli._errors import DataError, DependencyError, UsageError, handle_errors
 from bib2graph.cli._ingest import normalize_and_dedup
 from bib2graph.cli._options import json_mode, json_option
 from bib2graph.cli._store import open_store, resolve_library_path
@@ -33,6 +33,8 @@ def run_chain(
     email: str | None = None,
     transport: Any = None,
     preview: bool = False,
+    since: date | None = None,
+    _fsm_action: str | None = None,
 ) -> dict[str, Any]:
     """Expande el corpus con candidatos rankeados por information scent.
 
@@ -73,9 +75,30 @@ def run_chain(
             max_candidates=max_candidates,
         )
 
+    # Validación de --since: backward + since no tiene sentido.
+    if since is not None and direction == "backward":
+        raise UsageError(
+            "--since no es compatible con --direction backward.  "
+            "Usá --direction forward (o 'both', donde la ventana aplica solo al tramo forward)."
+        )
+
+    # Cuando since está activo con direction='both', la ventana aplica solo
+    # al tramo forward — opción más simple y clara (ADR 0037 §c).
+    effective_direction = direction
+    if since is not None and direction == "both":
+        effective_direction = "forward"
+
     from bib2graph.cycle import apply_transition
     from bib2graph.foraging import Forager
     from bib2graph.sources.openalex import OpenAlexSource
+
+    # Selección de acción FSM: "monitor" si --since activo O si se fuerza
+    # desde run_monitor (_fsm_action="monitor"); sino "chain" → FORAGED.
+    fsm_action = (
+        _fsm_action
+        if _fsm_action is not None
+        else ("monitor" if since is not None else "chain")
+    )
 
     merged_backend_close = None
     store = open_store(store_path)
@@ -86,7 +109,23 @@ def run_chain(
         # no un literal en el comando (ADR 0016 enmendado §1).
         current_state = store.backend.loop_state()
         current_round = store.backend.loop_round()
-        new_state, new_round = apply_transition(current_state, "chain", current_round)
+
+        # Guarda corpus vacío (portada de monitor, ADR 0037 §c).
+        if fsm_action == "monitor":
+            if current_state is None:
+                raise DataError(
+                    "No hay corpus ni estado previo en el store.  "
+                    "Iniciá la investigación con 'b2g seed' antes de monitorear."
+                )
+            if len(corpus) == 0:
+                raise DataError(
+                    "El corpus está vacío.  "
+                    "Usá 'b2g seed' para sembrar papers antes de monitorear."
+                )
+
+        new_state, new_round = apply_transition(
+            current_state, fsm_action, current_round
+        )
 
         source = OpenAlexSource(email=email, transport=transport)
 
@@ -95,7 +134,7 @@ def run_chain(
         # antes de entrar al Forager — así un ``AttributeError`` genuino que surja
         # dentro de chain/merge/_fetch_forward no queda disfrazado de "source no
         # soporta forward" (exit 3).
-        if direction in ("forward", "both") and not (
+        if effective_direction in ("forward", "both") and not (
             hasattr(source, "fetch_citing_batch") or hasattr(source, "fetch_citing")
         ):
             raise DependencyError(
@@ -112,7 +151,7 @@ def run_chain(
                 max_candidates=max_candidates,
                 max_citing_per_paper=max_citing_per_paper,
             )
-            ranked = forager.chain(corpus, direction=direction)
+            ranked = forager.chain(corpus, direction=effective_direction, since=since)
         except NotImplementedError as exc:
             raise DependencyError(
                 f"Profundidad {depth} no soportada aún: {exc}. Usá depth=1 (por defecto)."
@@ -126,6 +165,13 @@ def run_chain(
         ranking_preview = [
             {"id": id_, "scent": scent} for id_, scent in ranked.ranking[:10]
         ]
+        # Calcular genuinamente nuevos vs corpus (reusado de monitor, ADR 0037 §c).
+        existing_ids = set(corpus.to_arrow().column("id").to_pylist())
+        new_candidates_count = sum(
+            1
+            for id_ in ranked.corpus.to_arrow().column("id").to_pylist()
+            if id_ not in existing_ids
+        )
         # Merge primero, dedup después sobre el corpus COMPLETO (fix cross-biblioteca, #88).
         # Los IDs backward (ranked.observed_refs) NO van al corpus — se persisten en la
         # tabla auxiliar ``referenced_but_not_fetched`` (#54, opción B).
@@ -155,11 +201,14 @@ def run_chain(
 
     return {
         "candidates_found": candidates_found,
+        "new_candidates": new_candidates_count,
         "total_papers": total_papers,
-        "direction": direction,
+        "direction": effective_direction,
         "depth": depth,
         "ranking_preview": ranking_preview,
         "observed_refs_count": len(ranked.observed_refs),
+        "loop_state": new_state.value,
+        "round": new_round,
     }
 
 
@@ -284,6 +333,17 @@ def _run_chain_preview(
         "indica que se necesita fetch."
     ),
 )
+@click.option(
+    "--since",
+    "since_str",
+    default=None,
+    help=(
+        "Forrajeo incremental: solo trae citantes publicados desde esta fecha.  "
+        "Acepta fecha ISO (YYYY-MM-DD) o atajo relativo (90d, 6m, 1y).  "
+        "Fuerza direction=forward y transiciona a MONITORED (no a FORAGED).  "
+        "Incompatible con --direction backward."
+    ),
+)
 @json_option
 @click.pass_context
 @handle_errors("chain")
@@ -295,6 +355,7 @@ def chain_cmd(
     max_citing_per_paper: int,
     email: str | None,
     preview: bool,
+    since_str: str | None,
     json_output: bool,
 ) -> None:
     """Expande el corpus con candidatos rankeados por information scent.
@@ -302,7 +363,15 @@ def chain_cmd(
     Con --preview (dry-run), solo muestra la estimación de crecimiento sin
     tocar la red ni el corpus.  Sin --preview, transiciona el estado a FORAGED.
     """
+    from bib2graph.cli._options import parse_since
+
     store_path = resolve_library_path(ctx.obj)
+
+    # Parsear --since en la frontera (R2/ADR 0017): el reloj se fija aquí.
+    since: date | None = None
+    if since_str is not None:
+        since = parse_since(since_str, now=datetime.now(UTC).date())
+
     data = run_chain(
         store_path,
         direction=direction,  # type: ignore[arg-type]
@@ -311,6 +380,7 @@ def chain_cmd(
         max_citing_per_paper=max_citing_per_paper,
         email=email,
         preview=preview,
+        since=since,
     )
 
     if json_mode(json_output):

--- a/src/bib2graph/cli/commands/monitor.py
+++ b/src/bib2graph/cli/commands/monitor.py
@@ -7,6 +7,11 @@ CycleState a MONITORED (paso 8 del ciclo, Ellis).
 Requiere que el corpus tenga al menos una semilla con ``source_id``
 conocido (de lo contrario el forward chaining no encuentra nada).  Si no
 hay corpus ni estado previo, falla con un error accionable.
+
+**Implementación:** ``run_monitor`` es ahora un delegador fino sobre
+``run_chain`` (con ``_fsm_action="monitor"``), garantizando fuente única
+de la lógica de forrajeo (ADR 0037 §c).  La retirada formal de este
+subcomando es el issue #165.
 """
 
 from __future__ import annotations
@@ -17,9 +22,9 @@ from typing import Any
 import click
 
 from bib2graph.cli._envelope import build_envelope, emit, emit_human
-from bib2graph.cli._errors import DataError, handle_errors
+from bib2graph.cli._errors import handle_errors
 from bib2graph.cli._options import json_mode, json_option
-from bib2graph.cli._store import open_store, resolve_library_path
+from bib2graph.cli._store import resolve_library_path
 
 # ---------------------------------------------------------------------------
 # Función núcleo (testeable, sin Click)
@@ -34,11 +39,9 @@ def run_monitor(
 ) -> dict[str, Any]:
     """Re-chequea OpenAlex por nuevos citantes del corpus y transiciona a MONITORED.
 
-    Usa forward chaining (``Forager`` con ``direction="forward"``, que usa
-    ``fetch_citing_batch`` del source, batcheado y con cap por semilla) para
-    encontrar nuevos papers que citan al corpus.
-    Mergea los candidatos nuevos a la biblioteca viva y transiciona el estado a
-    MONITORED vía ``apply_transition(current_state, "monitor", current_round)``.
+    Delega en ``run_chain`` con ``direction="forward"`` y
+    ``_fsm_action="monitor"`` para mantener fuente única de la lógica de
+    forrajeo (ADR 0037 §c).
 
     Args:
         store_path: Ruta al archivo ``.duckdb``.
@@ -53,63 +56,20 @@ def run_monitor(
         NetworkError: Si falla la conexión a OpenAlex.
         StoreError: Si el store está bloqueado.
     """
-    from bib2graph.cycle import apply_transition
-    from bib2graph.foraging import Forager
-    from bib2graph.sources.openalex import OpenAlexSource
+    from bib2graph.cli.commands.chain import run_chain
 
-    merged_backend_close = None
-    store = open_store(store_path)
-    try:
-        current_state = store.backend.loop_state()
-        current_round = store.backend.loop_round()
-
-        # Error accionable: monitor requiere un corpus previo sembrado.
-        if current_state is None:
-            raise DataError(
-                "No hay corpus ni estado previo en el store. "
-                "Iniciá la investigación con 'b2g seed' antes de monitorear."
-            )
-
-        corpus = store.load()
-        if len(corpus) == 0:
-            raise DataError(
-                "El corpus está vacío. "
-                "Usá 'b2g seed' para sembrar papers antes de monitorear."
-            )
-
-        new_state, new_round = apply_transition(current_state, "monitor", current_round)
-
-        source = OpenAlexSource(email=email, transport=transport)
-
-        # Forward chaining: nuevos citantes del corpus.
-        forager = Forager(source, depth=1)
-        ranked = forager.chain(corpus, direction="forward")
-
-        # Calcular cuántos son genuinamente nuevos (no estaban en el corpus).
-        existing_ids = set(corpus.to_arrow().column("id").to_pylist())
-        new_candidate_ids = [
-            id_
-            for id_ in ranked.corpus.to_arrow().column("id").to_pylist()
-            if id_ not in existing_ids
-        ]
-        new_candidates_count = len(new_candidate_ids)
-
-        # Merge de candidatos nuevos y persistencia.
-        merged = corpus.merge(ranked.corpus)
-        total_papers = len(merged)
-        merged_backend_close = getattr(merged._backend, "close", None)
-        store.persist(merged)
-        store.backend.set_loop_state(new_state, cycle_round=new_round)
-    finally:
-        if merged_backend_close is not None:
-            merged_backend_close()
-        store.close()
-
+    result = run_chain(
+        store_path,
+        direction="forward",
+        email=email,
+        transport=transport,
+        _fsm_action="monitor",
+    )
     return {
-        "new_candidates": new_candidates_count,
-        "total_papers": total_papers,
-        "loop_state": new_state.value,
-        "round": new_round,
+        "new_candidates": result["new_candidates"],
+        "total_papers": result["total_papers"],
+        "loop_state": result["loop_state"],
+        "round": result["round"],
     }
 
 

--- a/src/bib2graph/foraging/forager.py
+++ b/src/bib2graph/foraging/forager.py
@@ -41,7 +41,7 @@ Ver docs/API.md §5.
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime
 from typing import Any
 
 import pyarrow as pa
@@ -274,6 +274,7 @@ class Forager:
         corpus: Corpus,
         *,
         direction: Direction = "both",
+        since: date | None = None,
     ) -> RankedCandidates:
         """Computa candidatos rankeados por *information scent*.
 
@@ -315,7 +316,9 @@ class Forager:
                 bwd_observed.add(ref_id)
 
         if direction in ("forward", "both"):
-            fwd_scent, fwd_rows = self._fetch_forward(rows, fetched_at=fetched_at)
+            fwd_scent, fwd_rows = self._fetch_forward(
+                rows, fetched_at=fetched_at, since=since
+            )
             for cand_id, scent_val in fwd_scent.items():
                 combined_scent[cand_id] = combined_scent.get(cand_id, 0.0) + scent_val
                 if cand_id not in fwd_candidate_rows:
@@ -379,6 +382,7 @@ class Forager:
         corpus_rows: list[dict[str, Any]],
         *,
         fetched_at: str,
+        since: date | None = None,
     ) -> tuple[dict[str, float], dict[str, dict[str, Any]]]:
         """Trae citantes via batcheo y calcula scent forward.
 
@@ -453,24 +457,26 @@ class Forager:
                 unit="lote",
                 leave=False,
             ) as pbar:
+                _since_kw = {"since": since} if since is not None else {}
                 if use_with_works:
                     citing_dict, works_map = self._source.fetch_citing_batch_with_works(
-                        seed_ids, max_per_paper=self._max_citing_per_paper
+                        seed_ids, max_per_paper=self._max_citing_per_paper, **_since_kw
                     )
                 else:
                     citing_dict = self._source.fetch_citing_batch(
-                        seed_ids, max_per_paper=self._max_citing_per_paper
+                        seed_ids, max_per_paper=self._max_citing_per_paper, **_since_kw
                     )
                     works_map = {}
                 pbar.update(1)
         except ImportError:
+            _since_kw = {"since": since} if since is not None else {}
             if use_with_works:
                 citing_dict, works_map = self._source.fetch_citing_batch_with_works(
-                    seed_ids, max_per_paper=self._max_citing_per_paper
+                    seed_ids, max_per_paper=self._max_citing_per_paper, **_since_kw
                 )
             else:
                 citing_dict = self._source.fetch_citing_batch(
-                    seed_ids, max_per_paper=self._max_citing_per_paper
+                    seed_ids, max_per_paper=self._max_citing_per_paper, **_since_kw
                 )
                 works_map = {}
 

--- a/src/bib2graph/sources/openalex.py
+++ b/src/bib2graph/sources/openalex.py
@@ -26,7 +26,7 @@ import json
 import os
 import re
 import time
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime
 from typing import Any
 
 import httpx
@@ -921,6 +921,7 @@ class OpenAlexSource:
         ids: list[str],
         *,
         max_per_paper: int | None = None,
+        since: date | None = None,
     ) -> tuple[dict[str, list[str]], dict[str, dict[str, Any]]]:
         """Núcleo compartido de paginación y atribución para los citantes en lote.
 
@@ -934,6 +935,9 @@ class OpenAlexSource:
             ids: IDs cortos de OpenAlex ya normalizados (p. ej. ``["W111"]``).
             max_per_paper: Presupuesto máximo de citantes por semilla.
                 ``None`` = sin tope.
+            since: Filtrar citantes publicados desde esta fecha
+                (``from_publication_date:YYYY-MM-DD`` en OpenAlex).  ``None``
+                = sin filtro de fecha.
 
         Returns:
             Tupla ``(attribution, works_map)`` donde:
@@ -955,6 +959,8 @@ class OpenAlexSource:
             batch_acc: dict[str, set[str]] = {tid: set() for tid in lote}
 
             filter_str = "cites:" + "|".join(lote)
+            if since is not None:
+                filter_str += f",from_publication_date:{since.isoformat()}"
 
             cursor: str = "*"
             with self._client() as client:
@@ -1006,7 +1012,11 @@ class OpenAlexSource:
         return result, works_map
 
     def fetch_citing_batch(
-        self, ids: list[str], *, max_per_paper: int | None = None
+        self,
+        ids: list[str],
+        *,
+        max_per_paper: int | None = None,
+        since: date | None = None,
     ) -> dict[str, list[str]]:
         """Trae en lote los citantes de varios papers usando ``cites:W1|W2|...``.
 
@@ -1045,12 +1055,16 @@ class OpenAlexSource:
             return {}
         normalized = [_oa_id_short(i) or i for i in ids]
         attribution, _ = self._fetch_citing_pages(
-            normalized, max_per_paper=max_per_paper
+            normalized, max_per_paper=max_per_paper, since=since
         )
         return attribution
 
     def fetch_citing_batch_with_works(
-        self, ids: list[str], *, max_per_paper: int | None = None
+        self,
+        ids: list[str],
+        *,
+        max_per_paper: int | None = None,
+        since: date | None = None,
     ) -> tuple[dict[str, list[str]], dict[str, dict[str, Any]]]:
         """Como ``fetch_citing_batch`` pero conserva los objetos JSON completos.
 
@@ -1080,7 +1094,9 @@ class OpenAlexSource:
         if not ids:
             return {}, {}
         normalized = [_oa_id_short(i) or i for i in ids]
-        return self._fetch_citing_pages(normalized, max_per_paper=max_per_paper)
+        return self._fetch_citing_pages(
+            normalized, max_per_paper=max_per_paper, since=since
+        )
 
     def _fetch_page_with_retry(
         self,

--- a/tests/unit/test_chain_since.py
+++ b/tests/unit/test_chain_since.py
@@ -1,0 +1,688 @@
+"""Tests TDD — issue #158: chain --since (forrajeo incremental).
+
+Verifica:
+1. parse_since: ISO date y atajos relativos (90d, 6m, 1y).
+2. chain --since -> MONITORED; chain sin --since -> FORAGED.
+3. --since + direction=backward -> UsageError.
+4. --since + direction=both -> forzado a forward (sin error).
+5. new_candidates reportado en el envelope (campo aditivo).
+6. Guarda corpus vacio cuando fsm_action="monitor".
+7. run_monitor suelto sigue funcionando igual (delega en run_chain).
+8. stdout puro: envelope una sola linea JSON (schema="1").
+
+Marcador: unit (DuckDB en tmp_path, red mockeada con httpx.MockTransport).
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import date, timedelta
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pyarrow as pa
+import pytest
+
+from bib2graph.schemas import CORPUS_SCHEMA
+
+pytestmark = pytest.mark.unit
+
+# ---------------------------------------------------------------------------
+# Helpers compartidos
+# ---------------------------------------------------------------------------
+
+_FIXTURES_DIR = Path(__file__).resolve().parent.parent / "fixtures"
+_SAMPLE_WORKS: list[dict[str, Any]] = json.loads(
+    (_FIXTURES_DIR / "sample_works.json").read_text(encoding="utf-8")
+)
+
+# Citante genuinamente nuevo: cita al seed W2741809807, no esta en el corpus.
+_CITING_NEW_WORK: dict[str, Any] = {
+    "id": "https://openalex.org/W8888888888",
+    "doi": None,
+    "title": "New paper citing the corpus seed",
+    "display_name": "New paper citing the corpus seed",
+    "publication_year": 2025,
+    "language": "en",
+    "abstract_inverted_index": None,
+    "authorships": [],
+    "keywords": [],
+    "referenced_works": [
+        "https://openalex.org/W2741809807",
+    ],
+    "primary_location": {"source": {"display_name": "Test Journal"}},
+    "type": "article",
+}
+
+
+def _make_row(
+    *,
+    id: str,
+    source_id: str | None = None,
+    is_seed: bool = True,
+    curation_status: str = "candidate",
+) -> dict[str, Any]:
+    """Fila minima con schema canonico completo."""
+    return {
+        "id": id,
+        "source_id": source_id,
+        "doi": None,
+        "title": f"Paper {id}",
+        "year": 2020,
+        "abstract": None,
+        "source": None,
+        "language": "en",
+        "publisher": None,
+        "research_areas": None,
+        "is_seed": is_seed,
+        "curation_status": curation_status,
+        "provenance": None,
+        "authors_raw": None,
+        "authors_id": None,
+        "authors_affiliations": None,
+        "keywords_raw": None,
+        "keywords_id": None,
+        "institutions_raw": None,
+        "institutions_id": None,
+        "references_id": None,
+        "references_doi": None,
+        "cited_by_id": None,
+    }
+
+
+def _seed_store(
+    store_path: Path,
+    rows: list[dict[str, Any]] | None = None,
+    *,
+    state_action: str = "seed",
+) -> None:
+    """Puebla un store DuckDB con filas y fija el estado del lazo."""
+    from bib2graph.corpus import Corpus
+    from bib2graph.cycle import apply_transition
+    from bib2graph.stores.duckdb import DuckDBStore
+
+    if rows is None:
+        rows = [
+            _make_row(id="P1", source_id="W2741809807"),
+            _make_row(id="P2", source_id="W9999999999"),
+        ]
+    table = pa.Table.from_pylist(rows, schema=CORPUS_SCHEMA)
+    corpus = Corpus.from_arrow(table)
+    store = DuckDBStore(store_path)
+    store.persist(corpus)
+    new_state, new_round = apply_transition(None, state_action, 0)
+    store.backend.set_loop_state(new_state, cycle_round=new_round)
+    store.close()
+
+
+def _make_citing_transport(
+    works: list[dict[str, Any]] | None = None,
+) -> httpx.MockTransport:
+    """MockTransport que devuelve los works dados como citantes en la primera llamada."""
+    if works is None:
+        works = [_CITING_NEW_WORK]
+
+    calls: list[int] = [0]
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls[0] += 1
+        body = (
+            {
+                "results": works,
+                "meta": {"count": len(works), "next_cursor": None},
+            }
+            if calls[0] == 1
+            else {"results": [], "meta": {"count": 0, "next_cursor": None}}
+        )
+        return httpx.Response(
+            200,
+            json=body,
+            headers={"x-openalex-api-version": "2026-05-01"},
+        )
+
+    return httpx.MockTransport(handler)
+
+
+def _make_empty_transport() -> httpx.MockTransport:
+    """MockTransport que siempre devuelve sin resultados."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={"results": [], "meta": {"count": 0, "next_cursor": None}},
+            headers={"x-openalex-api-version": "2026-05-01"},
+        )
+
+    return httpx.MockTransport(handler)
+
+
+# ---------------------------------------------------------------------------
+# 1. parse_since: ISO date y atajos relativos
+# ---------------------------------------------------------------------------
+
+
+class TestParseSince:
+    """parse_since convierte string -> date para el flag --since."""
+
+    def test_iso_date(self) -> None:
+        """Fecha ISO YYYY-MM-DD -> date exacta."""
+        from bib2graph.cli._options import parse_since
+
+        result = parse_since("2024-01-15")
+        assert result == date(2024, 1, 15)
+
+    def test_relativo_dias(self) -> None:
+        """90d resta 90 dias desde la fecha base inyectada."""
+        from bib2graph.cli._options import parse_since
+
+        now = date(2024, 6, 1)
+        result = parse_since("90d", now=now)
+        assert result == now - timedelta(days=90)
+
+    def test_relativo_meses(self) -> None:
+        """6m resta 6*30 dias desde la fecha base."""
+        from bib2graph.cli._options import parse_since
+
+        now = date(2024, 6, 1)
+        result = parse_since("6m", now=now)
+        assert result == now - timedelta(days=180)
+
+    def test_relativo_anios(self) -> None:
+        """1y resta 365 dias desde la fecha base."""
+        from bib2graph.cli._options import parse_since
+
+        now = date(2024, 6, 1)
+        result = parse_since("1y", now=now)
+        assert result == now - timedelta(days=365)
+
+    def test_mayusculas_relativo(self) -> None:
+        """El atajo relativo es case-insensitive (90D, 6M, 1Y)."""
+        from bib2graph.cli._options import parse_since
+
+        now = date(2024, 6, 1)
+        assert parse_since("90D", now=now) == parse_since("90d", now=now)
+        assert parse_since("6M", now=now) == parse_since("6m", now=now)
+        assert parse_since("1Y", now=now) == parse_since("1y", now=now)
+
+    def test_formato_invalido_lanza_usage_error(self) -> None:
+        """Formato no reconocido lanza UsageError con mensaje accionable."""
+        from bib2graph.cli._options import parse_since
+        from bib2graph.service.errors import UsageError
+
+        with pytest.raises(UsageError, match="Formato de --since"):
+            parse_since("invalid-value")
+
+    def test_formato_invalido_parcial(self) -> None:
+        """Fecha incompleta tambien lanza UsageError."""
+        from bib2graph.cli._options import parse_since
+        from bib2graph.service.errors import UsageError
+
+        with pytest.raises(UsageError):
+            parse_since("2024-01")  # no es YYYY-MM-DD
+
+    def test_iso_minimo_format(self) -> None:
+        """Fecha ISO de principio de anio."""
+        from bib2graph.cli._options import parse_since
+
+        result = parse_since("2024-01-01")
+        assert result == date(2024, 1, 1)
+
+
+# ---------------------------------------------------------------------------
+# 2. chain --since -> MONITORED; chain normal -> FORAGED
+# ---------------------------------------------------------------------------
+
+
+class TestChainSinceTransicion:
+    """chain --since transiciona a MONITORED; chain normal transiciona a FORAGED."""
+
+    def test_chain_normal_transiciona_a_foraged(self, tmp_path: Path) -> None:
+        """run_chain sin since -> FORAGED."""
+        from bib2graph.cli.commands.chain import run_chain
+        from bib2graph.cycle import CycleState
+        from bib2graph.stores.duckdb import DuckDBStore
+
+        store_path = tmp_path / "lib.duckdb"
+        _seed_store(store_path)
+
+        run_chain(
+            store_path,
+            direction="forward",
+            transport=_make_empty_transport(),
+        )
+
+        store = DuckDBStore(store_path)
+        assert store.backend.loop_state() == CycleState.FORAGED
+        store.close()
+
+    def test_chain_since_transiciona_a_monitored(self, tmp_path: Path) -> None:
+        """run_chain con since -> MONITORED."""
+        from bib2graph.cli.commands.chain import run_chain
+        from bib2graph.cycle import CycleState
+        from bib2graph.stores.duckdb import DuckDBStore
+
+        store_path = tmp_path / "lib.duckdb"
+        _seed_store(store_path)
+
+        run_chain(
+            store_path,
+            direction="forward",
+            since=date(2024, 1, 1),
+            transport=_make_empty_transport(),
+        )
+
+        store = DuckDBStore(store_path)
+        assert store.backend.loop_state() == CycleState.MONITORED
+        store.close()
+
+    def test_chain_since_devuelve_loop_state_monitored(self, tmp_path: Path) -> None:
+        """El resultado de run_chain con since incluye loop_state=MONITORED."""
+        from bib2graph.cli.commands.chain import run_chain
+
+        store_path = tmp_path / "lib.duckdb"
+        _seed_store(store_path)
+
+        result = run_chain(
+            store_path,
+            direction="forward",
+            since=date(2024, 1, 1),
+            transport=_make_empty_transport(),
+        )
+
+        assert result["loop_state"] == "MONITORED"
+        assert "round" in result
+
+    def test_chain_normal_devuelve_loop_state_foraged(self, tmp_path: Path) -> None:
+        """El resultado de run_chain normal incluye loop_state=FORAGED."""
+        from bib2graph.cli.commands.chain import run_chain
+
+        store_path = tmp_path / "lib.duckdb"
+        _seed_store(store_path)
+
+        result = run_chain(
+            store_path,
+            direction="forward",
+            transport=_make_empty_transport(),
+        )
+
+        assert result["loop_state"] == "FORAGED"
+
+
+# ---------------------------------------------------------------------------
+# 3. --since + direction=backward -> UsageError
+# ---------------------------------------------------------------------------
+
+
+class TestChainSinceBackwardError:
+    """--since + direction=backward -> UsageError accionable."""
+
+    def test_since_backward_lanza_usage_error(self, tmp_path: Path) -> None:
+        """run_chain con since y direction=backward lanza UsageError."""
+        from bib2graph.cli._errors import UsageError
+        from bib2graph.cli.commands.chain import run_chain
+
+        store_path = tmp_path / "lib.duckdb"
+        _seed_store(store_path)
+
+        with pytest.raises(UsageError, match="backward"):
+            run_chain(
+                store_path,
+                direction="backward",
+                since=date(2024, 1, 1),
+                transport=_make_empty_transport(),
+            )
+
+
+# ---------------------------------------------------------------------------
+# 4. --since + direction=both -> forzado a forward (sin error)
+# ---------------------------------------------------------------------------
+
+
+class TestChainSinceBothForzaForward:
+    """--since + direction=both fuerza effective_direction=forward."""
+
+    def test_since_both_acepta_sin_error(self, tmp_path: Path) -> None:
+        """run_chain con since y direction=both no lanza error y transiciona MONITORED."""
+        from bib2graph.cli.commands.chain import run_chain
+        from bib2graph.cycle import CycleState
+        from bib2graph.stores.duckdb import DuckDBStore
+
+        store_path = tmp_path / "lib.duckdb"
+        _seed_store(store_path)
+
+        result = run_chain(
+            store_path,
+            direction="both",
+            since=date(2024, 1, 1),
+            transport=_make_empty_transport(),
+        )
+
+        # No debe lanzar; debe ir a MONITORED
+        assert result["loop_state"] == "MONITORED"
+        # La direccion efectiva debe ser forward
+        assert result["direction"] == "forward"
+
+        store = DuckDBStore(store_path)
+        assert store.backend.loop_state() == CycleState.MONITORED
+        store.close()
+
+
+# ---------------------------------------------------------------------------
+# 5. new_candidates reportado en el envelope
+# ---------------------------------------------------------------------------
+
+
+class TestChainNewCandidates:
+    """new_candidates refleja los papers genuinamente nuevos vs el corpus."""
+
+    def test_new_candidates_se_reporta(self, tmp_path: Path) -> None:
+        """run_chain incluye new_candidates en el resultado."""
+        from bib2graph.cli.commands.chain import run_chain
+
+        store_path = tmp_path / "lib.duckdb"
+        _seed_store(store_path)
+
+        result = run_chain(
+            store_path,
+            direction="forward",
+            transport=_make_empty_transport(),
+        )
+
+        assert "new_candidates" in result
+        assert isinstance(result["new_candidates"], int)
+
+    def test_new_candidates_cuenta_nuevos(self, tmp_path: Path) -> None:
+        """new_candidates = 1 cuando se agrega un citante genuinamente nuevo."""
+        from bib2graph.cli.commands.chain import run_chain
+
+        store_path = tmp_path / "lib.duckdb"
+        _seed_store(store_path)
+
+        result = run_chain(
+            store_path,
+            direction="forward",
+            transport=_make_citing_transport([_CITING_NEW_WORK]),
+        )
+
+        assert result["new_candidates"] == 1
+
+    def test_new_candidates_cero_sin_nuevos(self, tmp_path: Path) -> None:
+        """new_candidates = 0 cuando no hay citantes nuevos."""
+        from bib2graph.cli.commands.chain import run_chain
+
+        store_path = tmp_path / "lib.duckdb"
+        _seed_store(store_path)
+
+        result = run_chain(
+            store_path,
+            direction="forward",
+            transport=_make_empty_transport(),
+        )
+
+        assert result["new_candidates"] == 0
+
+    def test_new_candidates_en_chain_since(self, tmp_path: Path) -> None:
+        """new_candidates tambien esta presente cuando se usa chain --since."""
+        from bib2graph.cli.commands.chain import run_chain
+
+        store_path = tmp_path / "lib.duckdb"
+        _seed_store(store_path)
+
+        result = run_chain(
+            store_path,
+            direction="forward",
+            since=date(2024, 1, 1),
+            transport=_make_citing_transport([_CITING_NEW_WORK]),
+        )
+
+        assert "new_candidates" in result
+        assert result["new_candidates"] == 1
+
+    def test_envelope_json_incluye_new_candidates(self, tmp_path: Path) -> None:
+        """El envelope JSON de chain incluye new_candidates."""
+        from bib2graph.cli._envelope import build_envelope
+        from bib2graph.cli.commands.chain import run_chain
+
+        store_path = tmp_path / "lib.duckdb"
+        _seed_store(store_path)
+
+        data = run_chain(
+            store_path,
+            direction="forward",
+            transport=_make_empty_transport(),
+        )
+        envelope = build_envelope(command="chain", ok=True, data=data, exit_code=0)
+
+        assert envelope["schema"] == "1"
+        assert "new_candidates" in envelope["data"]
+
+        # JSON-serializable y una sola linea (sin newlines internos)
+        serialized = json.dumps(envelope)
+        assert "\n" not in serialized, "El envelope debe ser una sola linea JSON"
+
+
+# ---------------------------------------------------------------------------
+# 6. Guarda corpus vacio cuando since activo
+# ---------------------------------------------------------------------------
+
+
+class TestChainSinceGuardaCorpusVacio:
+    """chain --since falla con DataError si no hay corpus previo."""
+
+    def test_since_sin_estado_previo_lanza_data_error(self, tmp_path: Path) -> None:
+        """run_chain con since sin estado previo -> DataError accionable."""
+        from bib2graph.cli._errors import DataError
+        from bib2graph.cli.commands.chain import run_chain
+        from bib2graph.stores.duckdb import DuckDBStore
+
+        store_path = tmp_path / "empty.duckdb"
+        DuckDBStore(store_path)  # inicializa tablas, sin estado
+
+        with pytest.raises(DataError, match="b2g seed"):
+            run_chain(
+                store_path,
+                direction="forward",
+                since=date(2024, 1, 1),
+                transport=_make_empty_transport(),
+            )
+
+    def test_since_corpus_vacio_lanza_data_error(self, tmp_path: Path) -> None:
+        """run_chain con since y corpus vacio -> DataError accionable."""
+        from bib2graph.cli._errors import DataError
+        from bib2graph.cli.commands.chain import run_chain
+        from bib2graph.cycle import CycleState
+        from bib2graph.stores.duckdb import DuckDBStore
+
+        store_path = tmp_path / "no_papers.duckdb"
+        store = DuckDBStore(store_path)
+        store.backend.set_loop_state(CycleState.SEEDED, cycle_round=1)
+        store.close()
+
+        with pytest.raises(DataError, match="b2g seed"):
+            run_chain(
+                store_path,
+                direction="forward",
+                since=date(2024, 1, 1),
+                transport=_make_empty_transport(),
+            )
+
+
+# ---------------------------------------------------------------------------
+# 7. run_monitor suelto delega en run_chain y sigue funcionando
+# ---------------------------------------------------------------------------
+
+
+class TestMonitorDelegaEnChain:
+    """run_monitor suelto sigue funcionando igual (delega en run_chain)."""
+
+    def test_monitor_encuentra_nuevos_y_transiciona_a_monitored(
+        self, tmp_path: Path
+    ) -> None:
+        """run_monitor mergea 1 citante nuevo y transiciona a MONITORED."""
+        from bib2graph.cli.commands.monitor import run_monitor
+        from bib2graph.cycle import CycleState
+        from bib2graph.stores.duckdb import DuckDBStore
+
+        store_path = tmp_path / "monitor.duckdb"
+        _seed_store(store_path)
+
+        data = run_monitor(
+            store_path, transport=_make_citing_transport([_CITING_NEW_WORK])
+        )
+
+        store = DuckDBStore(store_path)
+        assert store.backend.loop_state() == CycleState.MONITORED
+        store.close()
+
+        assert data["new_candidates"] == 1
+        assert data["loop_state"] == "MONITORED"
+        assert data["round"] == 1
+        assert data["total_papers"] == 3
+
+    def test_monitor_sin_nuevos_transiciona_a_monitored(self, tmp_path: Path) -> None:
+        """run_monitor con 0 citantes igual transiciona a MONITORED."""
+        from bib2graph.cli.commands.monitor import run_monitor
+        from bib2graph.cycle import CycleState
+        from bib2graph.stores.duckdb import DuckDBStore
+
+        store_path = tmp_path / "monitor_empty.duckdb"
+        _seed_store(store_path)
+
+        data = run_monitor(store_path, transport=_make_empty_transport())
+
+        assert data["new_candidates"] == 0
+        assert data["loop_state"] == "MONITORED"
+
+        store = DuckDBStore(store_path)
+        assert store.backend.loop_state() == CycleState.MONITORED
+        store.close()
+
+    def test_monitor_sin_estado_previo_lanza_data_error(self, tmp_path: Path) -> None:
+        """run_monitor sin estado previo -> DataError accionable."""
+        from bib2graph.cli._errors import DataError
+        from bib2graph.cli.commands.monitor import run_monitor
+        from bib2graph.stores.duckdb import DuckDBStore
+
+        store_path = tmp_path / "empty.duckdb"
+        DuckDBStore(store_path)
+
+        with pytest.raises(DataError, match="b2g seed"):
+            run_monitor(store_path, transport=_make_empty_transport())
+
+    def test_monitor_corpus_vacio_lanza_data_error(self, tmp_path: Path) -> None:
+        """run_monitor con corpus vacio -> DataError accionable."""
+        from bib2graph.cli._errors import DataError
+        from bib2graph.cli.commands.monitor import run_monitor
+        from bib2graph.cycle import CycleState
+        from bib2graph.stores.duckdb import DuckDBStore
+
+        store_path = tmp_path / "no_papers.duckdb"
+        store = DuckDBStore(store_path)
+        store.backend.set_loop_state(CycleState.SEEDED, cycle_round=1)
+        store.close()
+
+        with pytest.raises(DataError, match="b2g seed"):
+            run_monitor(store_path, transport=_make_empty_transport())
+
+    def test_monitor_envelope_json_schema_1(self, tmp_path: Path) -> None:
+        """El envelope de monitor incluye schema='1' y los campos canonicos."""
+        from bib2graph.cli._envelope import build_envelope
+        from bib2graph.cli.commands.monitor import run_monitor
+
+        store_path = tmp_path / "env.duckdb"
+        _seed_store(store_path)
+
+        data = run_monitor(store_path, transport=_make_empty_transport())
+        envelope = build_envelope(
+            command="monitor",
+            ok=True,
+            data=data,
+            exit_code=0,
+        )
+
+        assert envelope["schema"] == "1"
+        assert envelope["ok"] is True
+        assert envelope["command"] == "monitor"
+        assert envelope["exit_code"] == 0
+        assert "new_candidates" in envelope["data"]
+        assert "total_papers" in envelope["data"]
+        assert "loop_state" in envelope["data"]
+        assert "round" in envelope["data"]
+
+        serialized = json.dumps(envelope)
+        parsed = json.loads(serialized)
+        assert parsed["data"]["loop_state"] == "MONITORED"
+
+
+# ---------------------------------------------------------------------------
+# 8. since filtra la URL enviada a OpenAlex (cableado de la ventana)
+# ---------------------------------------------------------------------------
+
+
+class TestChainSinceFiltroURL:
+    """Cuando se pasa since, el filtro from_publication_date aparece en la URL."""
+
+    def test_since_agrega_filtro_fecha_en_url(self, tmp_path: Path) -> None:
+        """La URL enviada a OpenAlex incluye from_publication_date cuando since activo."""
+        urls_llamadas: list[str] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            urls_llamadas.append(str(request.url))
+            return httpx.Response(
+                200,
+                json={"results": [], "meta": {"count": 0, "next_cursor": None}},
+                headers={"x-openalex-api-version": "2026-05-01"},
+            )
+
+        transport = httpx.MockTransport(handler)
+
+        store_path = tmp_path / "lib.duckdb"
+        _seed_store(store_path)
+
+        from bib2graph.cli.commands.chain import run_chain
+
+        run_chain(
+            store_path,
+            direction="forward",
+            since=date(2024, 1, 1),
+            transport=transport,
+        )
+
+        # Al menos una URL debe contener el filtro de fecha
+        filtros_fecha = [u for u in urls_llamadas if "from_publication_date" in u]
+        assert len(filtros_fecha) >= 1, (
+            f"Ninguna URL contiene from_publication_date. URLs: {urls_llamadas}"
+        )
+        assert "2024-01-01" in filtros_fecha[0]
+
+    def test_sin_since_no_agrega_filtro_fecha(self, tmp_path: Path) -> None:
+        """Sin --since, la URL no contiene from_publication_date."""
+        urls_llamadas: list[str] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            urls_llamadas.append(str(request.url))
+            return httpx.Response(
+                200,
+                json={"results": [], "meta": {"count": 0, "next_cursor": None}},
+                headers={"x-openalex-api-version": "2026-05-01"},
+            )
+
+        transport = httpx.MockTransport(handler)
+
+        store_path = tmp_path / "lib.duckdb"
+        _seed_store(store_path)
+
+        from bib2graph.cli.commands.chain import run_chain
+
+        run_chain(
+            store_path,
+            direction="forward",
+            since=None,
+            transport=transport,
+        )
+
+        filtros_fecha = [u for u in urls_llamadas if "from_publication_date" in u]
+        assert len(filtros_fecha) == 0, (
+            f"Sin --since no debe haber filtro de fecha. URLs: {urls_llamadas}"
+        )


### PR DESCRIPTION
Closes #158. Sub-issue del epic #167 (ADR 0037 c).

## Qué
- **`chain --since`** (forrajeo incremental): fecha ISO `YYYY-MM-DD` o atajos relativos (`90d`/`6m`/`1y`); ventana resuelta contra `now` inyectado en la frontera (R2/ADR 0017). `--since` **fuerza forward** (backward+since → UsageError; both+since → forward). `chain --since` → **MONITORED**; `chain` normal → **FORAGED** (no existe CHAINED). Vía `apply_transition` (fuente única, sin estados nuevos).
- **Plumbing de la ventana:** `Forager.chain(since=)` → `fetch_citing_batch(since=)` agrega `from_publication_date:` al filtro `cites:`; sin `since` el comportamiento es idéntico al previo.
- **`new_candidates`** aditivo (siempre). Guarda de corpus vacío portada de monitor.
- **`monitor` suelto INTACTO** pero delega en `run_chain(_fsm_action="monitor")` → fuente única (su retiro es #165).

## ⚠️ Cambio de comportamiento (a notar)
`monitor` ahora deduplica post-merge (`persist_replace` + `normalize_and_dedup`); antes hacía `persist` sin dedup. Más consistente con el pipeline; el esquema de salida se conserva. Autorizado por ADR 0037 §c (fuente única).

## Tests
`tests/unit/test_chain_since.py` (28 tests): parse ISO/relativo, FSM ambos caminos, forward forzado, new_candidates, guarda vacío, monitor-delegación, filtro de fecha en URL. Verifier: **PASA**. Gate verde: ruff+mypy limpios, 1117 passed.

## Docs
El contrato de `chain --since` se consolida en el docs-sync final **#166** (junto al resto de la superficie 0.10.0). ADRs ya autorizan el cambio (0037 c).

## Invariante
Envelope `schema="1"`, exit codes, FSM (`apply_transition`) intactos; campos aditivos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
