### PR TITLE
refactor(cli): snapshot como grupo noun-verb {create, restore} (#163)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@
   ecuación, 9a), `exporters/` (GraphML, CSV) y `cli/`.
   El **CLI `b2g` es real** —paquete `cli/` con 19 subcomandos en `cli/commands/`, no un
   placeholder (el 16° `b2g networks` es la capa declarativa YAML del Hito 9; el 17° `b2g restore`
-  rehidrata un corpus curado sin red, Ciclo 9a; el 18° `b2g thesaurus` aplica el thesaurus curado,
+  rehidrata un corpus curado sin red, Ciclo 9a —**ahora `b2g snapshot restore`**, #163, abajo—; el 18° `b2g thesaurus` aplica el thesaurus curado,
   único paso explícito del preproc, #88, abajo; el 19° `b2g gui` levanta la API local FastAPI, Hito G3
   del MVP GUI, ADR 0028)—.
   **Grupo noun-verb `read {list,stats,show,top}` (#156/#157, ADR 0037 §b):** primer grupo del CLI (lectura pura
@@ -44,7 +44,7 @@
   `read top --top N --kind {…}` (la salida de investigación: nodos centrales + co-citación con título;
   default `bibliographic_coupling`, robusto en one-shot; co-citación vacía → honest-empty exit 0 +
   reason/fix_command). **Artefactos one-shot honestos (#160, ADR 0037 §f):** el `--json` de `build`,
-  `snapshot` y `read top` suma un bloque aditivo **`maturity`** (`{curated, scope, saturated,
+  `snapshot create` y `read top` suma un bloque aditivo **`maturity`** (`{curated, scope, saturated,
   empty_networks}`, `schema="1"` intacto) que autodeclara que el resultado es un borrador sin pulir;
   forma estable en `docs/API.md` §Apéndice `maturity`. `read` sin subcomando → ayuda + exit 0 (`invoke_without_command=True`, workaround Click 8.4); el
   `command` del envelope usa la ruta completa (`"read list"`). `inspect` queda **en deprecación** (#165,
@@ -57,10 +57,16 @@
   en `service/curate.py` (`run_curate_dump`/`run_curate_from_csv`/`filter_corpus` con `decided_at`
   inyectado). Los verbos sueltos `accept`/`reject`/`filter` siguen vivos como **alias deprecados**
   (retiro 0.11.0, ADR 0038 P1 + enmienda #155). Ver `docs/API.md` §`curate`.
+  **Grupo noun-verb `snapshot {create, restore}` (#163, ADR 0038):** TERCER grupo del CLI. **BREAKING:**
+  el `snapshot` plano → **`snapshot create`** (sin alias); `snapshot restore` = ex verbo plano `restore`
+  (el suelto `restore` sigue vivo como **alias deprecado**, `command="restore"`, retiro #165). La
+  transición la define el VERBO: `snapshot create` **NO** transiciona y lleva el bloque `maturity`;
+  `snapshot restore`→`FILTERED`. Lógica fuente única en `service/snapshot.py`
+  (`run_snapshot`/`run_restore`, `decided_at` inyectado). Ver `docs/API.md` §`snapshot`.
   **645 tests verdes** (mypy/ruff limpios; el núcleo importa sin `duckdb`). Entre las
   redes, la **composición de comunidades es exportable**: `networks/cluster_table` (función pura)
   resume cada comunidad de una red de paper en una fila y `b2g build` la escribe como `clusters.csv`
-  (#31, AS-BUILT 2026-06-17; ver `docs/API.md` §7.2). **`b2g snapshot`/`b2g export` resuelven por
+  (#31, AS-BUILT 2026-06-17; ver `docs/API.md` §7.2). **`b2g snapshot create`/`b2g export` resuelven por
   workspace** (`--out-dir` override opcional → `<workspace>/snapshots|exports/`) y **`b2g status` avisa
   de staleness** de la cache de redes (`networks_cache_stale`; avisa, no regenera) — remanentes del
   modelo workspace cerrados (#32, AS-BUILT 2026-06-17; ver el bullet de workspace abajo).

--- a/docs/API.md
+++ b/docs/API.md
@@ -110,7 +110,10 @@
 > transiciona el `CycleState` a **`FILTERED`** (reusa la transición permisiva `filter`, ADR 0016; deja
 > correr `build`/`networks` sin re-forrajeo). **NO** existe `seed --from-corpus` (la rehidratación es
 > `restore`). En Ciclo 9a `seed --from-bib` estaba diferido; el **Ciclo 10 lo construyó** (ver banner
-> abajo). Ver §2 + §convenciones CLI.
+> abajo). Ver §2 + §convenciones CLI. **(Actualización #163, ADR 0038):** este `restore` plano pasa a
+> **`snapshot restore`** (noun-verb del grupo `snapshot`, que se vuelve grupo `{create, restore}`); el
+> verbo suelto `restore` queda como **alias deprecado** (shim que delega, `command="restore"` por
+> backward-compat; retiro en #165). La capacidad no cambia. Ver §`snapshot`.
 >
 > **Sincronizado con el corpus de ejemplo + gate R2 — #33 / Ciclo 9b (AS-BUILT, 2026-06-17):**
 > se materializa la convención **`examples/`** (§convención `examples/`) y se construye el primer
@@ -285,7 +288,12 @@ preprocesamiento automático en la ingesta, #88, ADR
 local + frontend, Hito G3 del MVP GUI, ADR
 [0028](decisiones/0028-arquitectura-gui-api-capa-servicios.md); el 20° **`resolve`** con la
 resolución DOI→`source_id` del flujo BibTeX e2e, issues #110/#112, ADR
-[0035](decisiones/0035-ingesta-multipuerta-resolucion-doi.md)):
+[0035](decisiones/0035-ingesta-multipuerta-resolucion-doi.md)). **(Reorganización 0037/0038, en
+curso):** esta superficie por acreción se consolidó en **10 verbos del ciclo + 3 grupos noun-verb**
+(`read`, `curate`, **`snapshot {create, restore}`** —#163, ver §`snapshot`—) + `gui` como excepción;
+el `restore` plano pasó a **`snapshot restore`** (#163, alias deprecado), y `networks`/`enrich`/
+`resolve`/`thesaurus` se absorben o retiran (ADR 0038, ventana cierra 0.11.0). El conteo histórico de
+abajo refleja la acreción, no la superficie objetivo:
 
 - `seed`, `chain`, **`filter`** (filtros PRISMA deterministas: año/tipo/idioma/citas **con conteo
   en cada paso**), `build`, `export`, `snapshot`, **`status`** (expone el ciclo: estado actual,
@@ -350,8 +358,11 @@ resolución DOI→`source_id` del flujo BibTeX e2e, issues #110/#112, ADR
   permite con `--from-bib` cuando va junto a `--resolve` (ver `--resolve` arriba); `--email` +
   `--from-bib` sin `--resolve` → error. En modo `--native`, `--min-year`/`--max-year` no se aplican
   (nativo = sin traducción).
-- **`restore`** (ADR [0030](decisiones/0030-ecuacion-declarativa-corpus-ejemplo.md), Ciclo 9a, 17°
-  subcomando): **rehidrata un corpus ya curado desde un parquet, SIN red** — inverso de `snapshot`,
+- **`snapshot restore`** (ADR [0030](decisiones/0030-ecuacion-declarativa-corpus-ejemplo.md), Ciclo 9a;
+  **AS-BUILT #163, ADR 0038**: ex verbo plano `restore`, ahora **noun-verb del grupo `snapshot`** —ver
+  §`snapshot`—; el verbo suelto `restore` **sigue vivo como alias deprecado**, shim que delega con
+  `command="restore"` por backward-compat, retiro en #165): **rehidrata un corpus ya curado desde un
+  parquet, SIN red** — inverso de `snapshot create`,
   como `load` es a `dump`. **`--from-corpus <parquet>`** (requerido) lee el parquet con el schema
   canónico (`CORPUS_SCHEMA`), lo hidrata con `Corpus.from_arrow`, hace merge con el corpus existente y
   persiste; **cero llamadas a `OpenAlexSource`, cero red**. **Preserva la curación** del parquet
@@ -589,12 +600,32 @@ Invariante: envelope `schema="1"`, exit codes y FSM intactos; todo lo de #159/#1
 > diferir legítimamente de los de `status` sobre el corpus completo. La **lógica es fuente única**; lo
 > que varía es el corpus que se le pasa.
 
-**`snapshot` (AS-BUILT #32, 2026-06-17):** `b2g snapshot` sella una foto reproducible del estado vivo
-(parquet + `manifest.json`, ADR 0017). **`--out-dir` pasó a override OPCIONAL** — sin él, escribe en
-**`<workspace>/snapshots/`** (resolución ambiente vía `resolve_workspace`, igual que `build`). No
-transiciona el `CycleState`. Su `--json.data` —`snapshot_dir`, `corpus_hash`, `total_papers`,
-`schema_version`— suma el bloque aditivo **`maturity`** (AS-BUILT #160, ver Apéndice `maturity`):
-`scope="all"`, `empty_networks=[]` (snapshot no proyecta redes), `curated` desde el corpus vivo.
+**Grupo `snapshot {create, restore}` — TERCER grupo noun-verb del CLI (#163, ADR 0038).** Para alojar
+`snapshot restore` (= ex verbo plano `restore`, ADR 0038), **`snapshot` deja de ser verbo plano y se
+vuelve grupo noun-verb** —mismo patrón que `read` (1°, #156/#157) y `curate` (2°, #155)—. `snapshot`
+**sin subcomando** imprime la ayuda y sale **exit 0**; el `command` del envelope usa la **ruta
+completa** (`"snapshot create"` / `"snapshot restore"`). **BREAKING (autorizado por ADR 0038, sin
+alias):** el `snapshot` plano → **`snapshot create`** (mismo criterio que el BREAKING de `curate`).
+**La transición la define el VERBO** (precedente D1 de #159): `snapshot create` **NO** transiciona,
+`snapshot restore`→`FILTERED`. **Fuente única en `service/snapshot.py`** (`run_snapshot`/`run_restore`,
+servicio neutral con `decided_at` inyectado en la frontera, ADR 0017): `snapshot create`,
+`snapshot restore` y el shim del verbo suelto `restore` (alias deprecado, retiro #165) **delegan** en
+ella.
+
+- **`snapshot create`** (= ex `snapshot` plano, AS-BUILT #32): sella una foto reproducible del estado
+  vivo (parquet + `manifest.json`, ADR 0017). **`--out-dir` pasó a override OPCIONAL** — sin él,
+  escribe en **`<workspace>/snapshots/`** (resolución ambiente vía `resolve_workspace`, igual que
+  `build`). **NO transiciona** el `CycleState`. Su `--json.data` —`snapshot_dir`, `corpus_hash`,
+  `total_papers`, `schema_version`— suma el bloque aditivo **`maturity`** (AS-BUILT #160, ver Apéndice
+  `maturity`): `scope="all"`, `empty_networks=[]` (no proyecta redes), `curated` desde el corpus vivo
+  (`run_snapshot` lleva el bloque, coherente con `build`/`read top`).
+- **`snapshot restore`** (= ex verbo plano `restore`): rehidrata un corpus curado desde un parquet
+  **sin red** (mergea+dedup, preserva la curación), **transiciona a `FILTERED`**. Semántica completa
+  en §`snapshot restore` (arriba). El verbo suelto `restore` queda como **alias deprecado** (shim que
+  delega con `command="restore"`; retiro #165).
+
+> **Follow-up (BAJO, #175):** `service/snapshot.py` duplica `normalize_and_dedup` respecto del helper
+> `cli/_ingest.py`. Es deuda DRY, **no** afecta el contrato; se resuelve en su issue, no aquí.
 
 **Staleness de la cache de redes (AS-BUILT #32, 2026-06-17):** `b2g status` suma el campo aditivo
 `data["networks_cache_stale"]: bool` (`schema="1"` intacto) y, cuando es `true`, un `warnings`
@@ -608,9 +639,9 @@ invalidación por hash, **no** un build-system (ADR [0029](decisiones/0029-works
 `filter`→`FILTERED`, **`curate filter`→`FILTERED`** (#155: dentro del grupo `curate` la transición la
 define el VERBO, no el grupo —precedente D1 de #159), `build`→`BUILT`,
 **`monitor`→`MONITORED`** (cleanup pre-v0.3),
-**`restore`→`FILTERED`** (Ciclo 9a, ADR 0030: el corpus restaurado ya pasó curación; reusa la
-transición permisiva `filter`);
-`accept`/`reject`/**`curate {dump,apply,accept,reject}`**/**`read`**/`export`/`snapshot`/`status`/`inspect`/`validate`/**`enrich`**/**`networks`**
+**`snapshot restore`→`FILTERED`** (Ciclo 9a, ADR 0030/0038: el corpus restaurado ya pasó curación;
+reusa la transición permisiva `filter`; el verbo suelto `restore` —alias deprecado— transiciona igual);
+`accept`/`reject`/**`curate {dump,apply,accept,reject}`**/**`read`**/`export`/**`snapshot create`**/`status`/`inspect`/`validate`/**`enrich`**/**`networks`**
 **no transicionan** (los verbos transversales de `curate` y **`read`** son transversales/lectura pura
 —**salvo `curate filter`**, que sí transiciona; `enrich` y `networks` son
 ortogonales al lazo, ADR 0025 / Hito 9). El estado
@@ -751,12 +782,12 @@ one-shot con un resultado terminado. **Aditivo: `schema="1"` intacto.**
 | clave | tipo | valores | regla de derivación |
 |---|---|---|---|
 | `curated` | `bool` | `true`/`false` | `true` si el corpus **completo** (`corpus_full`, **antes** del filtro de `--corpus-scope`) tiene **≥1 paper** con `curation_status` ∈ {`accepted`, `rejected`}. Refleja si hay decisiones de curación aplicadas, **independiente** del scope y del FSM. |
-| `scope` | `str` \| `null` | token CLI (`all`/`accepted`/`seeds`…) \| `null` | En `build` reusa `data["scope"]` (el **token CLI** tal como se tipeó, no el vocab interno `seeds_only`). En `snapshot` y `read top` es `"all"`. `null` si no aplica. |
+| `scope` | `str` \| `null` | token CLI (`all`/`accepted`/`seeds`…) \| `null` | En `build` reusa `data["scope"]` (el **token CLI** tal como se tipeó, no el vocab interno `seeds_only`). En `snapshot create` y `read top` es `"all"`. `null` si no aplica. |
 | `saturated` | `bool` | **`false` constante** | **Siempre `false`** en one-shot: el PO decidió **no sobre-afirmar**. Gancho futuro (documentado en el código): comparar `referenced_refs_count()` entre rondas de `enrich` para detectar convergencia de referencias. |
-| `empty_networks` | `list[str]` | lista de `kind` (puede ser `[]`) | **Solo los tokens `kind`** de las redes vacías. `reason`/`fix_command` **NO se duplican** acá — siguen viviendo en `data["empty_networks"]` (lista de dicts `{kind, reason, fix_command}`) de `build`. En `build` se extraen de ahí; en `read top` es `["cocitation"]` si la co-citación quedó vacía; en `snapshot` es `[]`. |
+| `empty_networks` | `list[str]` | lista de `kind` (puede ser `[]`) | **Solo los tokens `kind`** de las redes vacías. `reason`/`fix_command` **NO se duplican** acá — siguen viviendo en `data["empty_networks"]` (lista de dicts `{kind, reason, fix_command}`) de `build`. En `build` se extraen de ahí; en `read top` es `["cocitation"]` si la co-citación quedó vacía; en `snapshot create` es `[]`. |
 
 - **Dónde aparece (PRESENTE SIEMPRE):** `build` (incluido el early-return de corpus vacío),
-  `snapshot` y `read top`. **AUSENTE** en `read list`, `read stats` y `read show` (lecturas tabulares,
+  `snapshot create` y `read top`. **AUSENTE** en `read list`, `read stats` y `read show` (lecturas tabulares,
   no artefactos one-shot) — no llevan `maturity`.
 - **Función pura:** lo calcula `service.maturity.compute_maturity(corpus, *, scope, empty_network_kinds)`
   (sin I/O, re-exportada desde `bib2graph.service`), invariante de neutralidad de transporte intacta
@@ -829,7 +860,7 @@ def code_for(exc: BaseException) -> int:
 def compute_maturity(
     corpus: Corpus, *, scope: str | None, empty_network_kinds: list[str]
 ) -> dict[str, Any]:
-    """Bloque maturity para el --json de build/snapshot/read top (ver Apéndice maturity).
+    """Bloque maturity para el --json de build/snapshot create/read top (ver Apéndice maturity).
     Función PURA, sin I/O. Devuelve EXACTAMENTE 4 claves:
     {curated: bool, scope: str|None, saturated: bool, empty_networks: list[str]}.
     curated = corpus tiene ≥1 paper con curation_status ∈ {accepted, rejected};
@@ -1530,19 +1561,21 @@ epic GUI #34). Reglas:
     al corpus sembrado produce el mismo estado, independiente de cuándo se corra).
   - **`README.md`** — qué demuestra y con qué comandos se arma/reproduce. **Es la procedencia:**
     la **receta CLI** documentada (armado con red + reproducción offline), no un script.
-- **Cómo se restaura:** `b2g restore --from-corpus examples/<nombre>/corpus.parquet` (§2.`restore`)
-  rehidrata el corpus **sin red** en el `library.duckdb` de un workspace temporal, preserva la
-  curación y transiciona a `FILTERED`; luego `build` → `networks`/`clusters` corren localmente.
+- **Cómo se restaura:** `b2g snapshot restore --from-corpus examples/<nombre>/corpus.parquet`
+  (§`snapshot restore`; #163/ADR 0038 — el verbo suelto `restore` sigue funcionando como alias
+  deprecado, retiro #165) rehidrata el corpus **sin red** en el `library.duckdb` de un workspace
+  temporal, preserva la curación y transiciona a `FILTERED`; luego `build` → `networks`/`clusters`
+  corren localmente.
 - **`.gitignore`:** `!examples/` trackea el ejemplo; `examples/**/*.duckdb` lo protege de que un
   store vivo se cuele. El resto de la política de datos de usuario no cambia.
 - **Ejemplos existentes:**
   - **`examples/valoraciones/`** (Ciclo B, AS-BUILT 2026-06-17): **~80 filas** (70 `candidate` +
     10 `accepted` enriquecidos), armado **100% por CLI** (sin script): `seed --spec equation.yaml`
-    (`max_results: 80`) → `curate apply curacion.csv` → `enrich --max-citing 25` → `snapshot`.
+    (`max_results: 80`) → `curate apply curacion.csv` → `enrich --max-citing 25` → `snapshot create`.
     **Co-citación presente** (rala) + coupling/author/institution/keyword sustanciales. Verificado por
     el gate R2 `tests/unit/test_example_r2_gate.py` (`corpus_hash` estable + comunidades Louvain
     estables entre corridas; piso `n>=50`, las 5 redes con datos). Se rehidrata con
-    `b2g restore --from-corpus`. Procedencia = receta CLI del README + `equation.yaml` + `curacion.csv`.
+    `b2g snapshot restore --from-corpus`. Procedencia = receta CLI del README + `equation.yaml` + `curacion.csv`.
   - **`examples/bibtex/`** (Ciclo 10, AS-BUILT 2026-06-17): un `sample.bib` chico (10 entradas, con
     variedad deliberada de campos faltantes para ejercitar el parser defensivo) + `README.md` con la
     receta 100% CLI (`b2g init` → `b2g seed --from-bib examples/bibtex/sample.bib` → `b2g build`).

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -580,7 +580,8 @@ cambios). Dos convenciones del grupo: (1) el `command` del envelope usa la **rut
 error de uso— vía `invoke_without_command=True` + `ctx.get_help()` en el callback del grupo
 (**workaround a la regresión de Click 8.4** donde un grupo sin subcomando devolvía exit 2). Un valor
 de flag `Choice` inválido sigue siendo error de uso de Click → **exit 1** (no exit 2). Es el molde
-para los próximos grupos previstos por el ADR 0037 (`curate {…}`).
+de los grupos siguientes: **`curate {…}`** (2°, #155) y **`snapshot {create, restore}`** (3°, #163,
+ADR 0038 — el `snapshot` plano → `snapshot create`, BREAKING; aloja `snapshot restore` = ex `restore`).
 
 Son **19 subcomandos** (`seed`, `chain`, `filter`, `build`, `export`, `snapshot`, `status`,
 `inspect`, `validate`, `accept`, `reject`, **`monitor`**, **`enrich`**, **`init`**, **`curate`**,
@@ -601,22 +602,26 @@ curación a escala vía CSV (dump/import en lote, transversal: **no transiciona*
 **`networks`** (Hito 9, AS-BUILT 2026-06-17) construye redes desde un YAML declarativo
 (`b2g networks --spec <yaml>`, `load_specs` + `Networks.build` por red, helper compartido
 `_write_artifacts`) y **no transiciona** el ciclo ni sella `.corpus_hash` (transversal al lazo). El 17°
-**`restore`** (Ciclo 9a, ADR [0030](decisiones/0030-ecuacion-declarativa-corpus-ejemplo.md)) rehidrata el
-corpus desde un parquet curado **sin red** (inverso de `snapshot`; preserva `decision`/`curation_status`/
-`is_seed`) y transiciona a `FILTERED` (reusa la transición permisiva `filter`, ADR 0016). El error de uso (p. ej.
+**`restore`** (Ciclo 9a, ADR [0030](decisiones/0030-ecuacion-declarativa-corpus-ejemplo.md); **ahora
+`snapshot restore`**, #163/ADR 0038 —el verbo suelto `restore` queda como alias deprecado, retiro #165—)
+rehidrata el corpus desde un parquet curado **sin red** (inverso de `snapshot create`; preserva
+`decision`/`curation_status`/`is_seed`) y transiciona a `FILTERED` (reusa la transición permisiva
+`filter`, ADR 0016). El error de uso (p. ej.
 una opción desconocida como `--store` —eliminada en #75—, o ningún workspace resoluble) sale **sin
 envelope** (Click aborta el parseo: stderr + exit 1).
 
 > **AS-BUILT — superficie noun-verb (ADR [0037](decisiones/0037-superficie-cli-10-verbos-ciclo.md)
 > /[0038](decisiones/0038-destino-verbos-huerfanos-0037.md)):** la superficie del 0021 (verbos planos,
-> arriba) se reorganiza a **10 verbos que mapean el ciclo**, con **dos grupos noun-verb**:
-> **`read {list,stats,show,top}`** (1°, #156/#157) y **`curate {dump,apply,accept,reject,filter}`**
-> (2°, #155). En el grupo `curate` la transición la define el **VERBO** (precedente D1 de #159):
-> **`curate filter`→`FILTERED`**, el resto transversal. La lógica es fuente única en `service/`
-> (`service/reads.py`, `service/curate.py`). Los **verbos planos** `accept`/`reject`/`filter`/`inspect`
-> /`networks`/`monitor`/`resolve` quedan como **alias deprecados** (retiro **0.11.0**, ADR 0038 P1 +
-> enmienda #155 que sumó `filter` al gap), y `restore`→`snapshot restore`, `enrich`→`chain`/`build`,
-> `thesaurus` retirado (ADR 0038). El **contrato vivo de la superficie** está en
+> arriba) se reorganiza a **10 verbos que mapean el ciclo**, con **TRES grupos noun-verb**:
+> **`read {list,stats,show,top}`** (1°, #156/#157), **`curate {dump,apply,accept,reject,filter}`**
+> (2°, #155) y **`snapshot {create, restore}`** (3°, #163 —el `snapshot` plano → `snapshot create`,
+> BREAKING—). En `curate` y `snapshot` la transición la define el **VERBO** (precedente D1 de #159):
+> **`curate filter`→`FILTERED`** y **`snapshot restore`→`FILTERED`**, el resto transversal
+> (`snapshot create` no transiciona). La lógica es fuente única en `service/`
+> (`service/reads.py`, `service/curate.py`, `service/snapshot.py`). Los **verbos planos**
+> `accept`/`reject`/`filter`/`inspect`/`networks`/`monitor`/`resolve`/**`restore`** quedan como
+> **alias deprecados** (retiro **0.11.0**; `restore`/`inspect` en #165; ADR 0038 P1 + enmienda #155 que
+> sumó `filter` al gap), y `enrich`→`chain`/`build`, `thesaurus` retirado (ADR 0038). El **contrato vivo de la superficie** está en
 > [`API.md`](API.md) §convenciones CLI (no se replica acá para evitar drift).
 
 **AS-BUILT R5 — UTF-8 en la frontera (Nota 06 RAÍZ 3):** `main()` llama `_force_utf8()` (reconfigura

--- a/docs/decisiones/0038-destino-verbos-huerfanos-0037.md
+++ b/docs/decisiones/0038-destino-verbos-huerfanos-0037.md
@@ -192,3 +192,40 @@ criterio que `accept`/`reject`: sigue funcionando **con aviso** durante 0.10.x y
 0.11.0**, como alias deprecado del nuevo **`curate filter`**. (`filter` y `curate filter` comparten la
 lógica de servicio `filter_corpus`, fuente única; el suelto es un shim que delega.) El resto de P1 no
 cambia. AS-BUILT del grupo `curate` en [`../API.md`](../API.md) §`curate`.
+
+## Enmienda 2026-06-27 (append-only) — fija el detalle de `restore`→`snapshot restore`: `snapshot` se vuelve grupo noun-verb y el plano → `snapshot create` [BREAKING] (#163)
+
+> Anotación append-only (gemela de las enmiendas D1 (#159) / #155; no revierte nada de arriba). Surge
+> de la implementación del sub-issue [#163](https://github.com/complexluise/bib2graph/issues/163). La
+> **Decisión** de arriba ya fijó que `restore` pasa a **`snapshot restore`** (tabla de huérfanos +
+> Consecuencias §`restore` vs 0030, líneas ~85/154-157), pero **no explicitó** qué pasa con el verbo
+> `snapshot` mismo. La implementación lo resuelve: para alojar `snapshot restore`, **`snapshot` deja
+> de ser verbo plano y se vuelve grupo noun-verb** —y eso obliga a renombrar el `snapshot` plano—.
+
+El ADR decidió el **destino** de `restore` (→ `snapshot restore`) pero no el **detalle del grupo**.
+Concretamente, al volverse `snapshot` un grupo:
+
+- **(a) `snapshot` es ahora grupo noun-verb `{create, restore}`** —el **3er grupo del CLI**, mismo
+  patrón que `read` (1°, #156/#157) y `curate` (2°, #155): `snapshot` **sin subcomando** imprime la
+  ayuda y sale **exit 0**; el `command` del envelope usa la **ruta completa** (`"snapshot create"` /
+  `"snapshot restore"`).
+- **(b) El `snapshot` plano → `snapshot create`** —**BREAKING, sin alias**, mismo criterio que el
+  BREAKING de `curate` (decisión (b) del 0037, forma-flag eliminada sin alias). `snapshot create` es
+  el ex `snapshot` plano sin cambios de semántica: sella la foto reproducible (parquet +
+  `manifest.json`, ADR 0017), **NO transiciona** el `CycleState` y **lleva el bloque `maturity`** del
+  one-shot (AS-BUILT #160, coherente con `build`/`read top`).
+- **(c) `snapshot restore` es el ex `restore`** (mergea+dedup, preserva la curación, **transiciona a
+  `FILTERED`** reusando la transición permisiva `filter`, ADR 0016/0030). El **verbo suelto `restore`
+  queda INTACTO como alias deprecado** (shim que delega; su envelope lleva `command="restore"` por
+  backward-compat). Su **retiro se agenda en #165** (junto con `inspect`), no en este hito.
+- **(d) Fuente única en `service/snapshot.py`** (`run_snapshot`/`run_restore`, servicio neutral con
+  reloj `decided_at` inyectado en la frontera, ADR 0017): `snapshot create`, `snapshot restore` y el
+  shim `restore` suelto **delegan** en ella. `run_snapshot` lleva el bloque `maturity` (de #160).
+
+**Invariantes intactos:** envelope `schema="1"`, exit codes y la forma del FSM no cambian; `create`
+**NO** transiciona, `restore`→`FILTERED` (igual que antes). Esta enmienda solo fija el detalle del
+grupo y el BREAKING que la Decisión no explicitó. AS-BUILT en [`../API.md`](../API.md) §`snapshot`.
+
+> **Follow-up (BAJO, #175):** la implementación dejó `normalize_and_dedup` duplicado en
+> `service/snapshot.py` respecto del helper de `cli/_ingest.py`. Es deuda de DRY, **no** afecta el
+> contrato; se trata en su propio issue, no aquí.

--- a/src/bib2graph/cli/__init__.py
+++ b/src/bib2graph/cli/__init__.py
@@ -1,4 +1,4 @@
-"""cli — CLI agente-native ``b2g`` (Hito 6 + ADR 0029 workspace + #155 surface CLI 0.10.0).
+"""cli — CLI agente-native ``b2g`` (Hito 6 + ADR 0029 workspace + #155 + ADR 0038).
 
 Arma el grupo Click principal, registra los subcomandos planos y los grupos
 noun-verb, y expone ``main()`` como entry point del paquete.
@@ -6,14 +6,17 @@ noun-verb, y expone ``main()`` como entry point del paquete.
 Entry point en ``pyproject.toml``:
     b2g = "bib2graph.cli:main"
 
-Subcomandos planos (19):
-    init, seed, chain, filter, build, enrich, monitor, export, snapshot,
-    status, inspect, validate, accept, reject, networks, restore,
+Subcomandos planos (18):
+    init, seed, chain, filter, build, enrich, monitor, export,
+    status, validate, accept, reject, networks, restore (shim #163),
     thesaurus, gui, resolve.
 
-Grupos noun-verb (2):
-    read   [list|stats|show|top] — lecturas read-only del corpus (#156/#157).
-    curate [dump|apply|accept|reject|filter] — curación en lote (#155).
+    inspect: absorbido por ``read show`` (#156); permanece como alias.
+
+Grupos noun-verb (3):
+    read     [list|stats|show|top] — lecturas read-only del corpus (#156/#157).
+    curate   [dump|apply|accept|reject|filter] — curación en lote (#155).
+    snapshot [create|restore] — fotos selladas y rehidratación (#163, ADR 0038).
 
 Cada subcomando lleva:
   - ``--json``: salida JSON estructurada (envelope versionado, §API.md).
@@ -26,6 +29,10 @@ ADR 0029 — resolución ambiente:
   ``Workspace.resolve(...)`` (B2G_WORKSPACE env o cwd walk).
   La opción ``--store`` fue eliminada (#75): pasarla produce el error estándar
   de Click ("No such option"). El modo degenerado (.duckdb suelto) ya no existe.
+
+ADR 0038 — snapshot como grupo noun-verb:
+  ``snapshot`` es ahora un grupo ``{create, restore}`` (BREAKING).
+  ``b2g restore`` se mantiene como shim intacto (#165 retirará el alias).
 
 R5 — UTF-8 en la frontera:
   ``main()`` fuerza ``sys.stdout``/``sys.stderr`` a UTF-8 antes de que Click
@@ -58,7 +65,7 @@ from bib2graph.cli.commands.reject import reject_cmd
 from bib2graph.cli.commands.resolve import resolve_cmd
 from bib2graph.cli.commands.restore import restore_cmd
 from bib2graph.cli.commands.seed import seed_cmd
-from bib2graph.cli.commands.snapshot import snapshot_cmd
+from bib2graph.cli.commands.snapshot import snapshot_grp
 from bib2graph.cli.commands.status import status_cmd
 from bib2graph.cli.commands.thesaurus import thesaurus_cmd
 from bib2graph.cli.commands.validate import validate_cmd
@@ -106,9 +113,10 @@ def b2g(ctx: click.Context, workspace: str | None) -> None:
     error accionable (exit 1) que sugiere 'b2g init' o '--workspace'.
 
     Subcomandos: init, seed, chain, filter, build, enrich, monitor, export,
-    snapshot, status, inspect, validate, accept, reject, networks,
-    restore, thesaurus, gui, resolve,
-    read [list|stats|show|top], curate [dump|apply|accept|reject|filter].
+    status, validate, accept, reject, networks, restore (shim),
+    thesaurus, gui, resolve,
+    read [list|stats|show|top], curate [dump|apply|accept|reject|filter],
+    snapshot [create|restore] (ADR 0038).
 
     Ejemplo:
         b2g init mi-investigacion
@@ -120,7 +128,8 @@ def b2g(ctx: click.Context, workspace: str | None) -> None:
     ctx.obj["workspace"] = workspace
 
 
-# Registrar subcomandos planos + grupos noun-verb read (#156) y curate (#155)
+# Registrar subcomandos planos + grupos noun-verb read (#156), curate (#155),
+# snapshot (#163, ADR 0038)
 b2g.add_command(init_cmd)
 b2g.add_command(seed_cmd)
 b2g.add_command(chain_cmd)
@@ -129,7 +138,7 @@ b2g.add_command(build_cmd)
 b2g.add_command(enrich_cmd)
 b2g.add_command(monitor_cmd)
 b2g.add_command(export_cmd)
-b2g.add_command(snapshot_cmd)
+b2g.add_command(snapshot_grp)
 b2g.add_command(status_cmd)
 b2g.add_command(inspect_cmd)
 b2g.add_command(validate_cmd)

--- a/src/bib2graph/cli/commands/restore.py
+++ b/src/bib2graph/cli/commands/restore.py
@@ -1,11 +1,14 @@
-"""cli.commands.restore — Subcomando ``b2g restore``.
+"""cli.commands.restore — Shim ``b2g restore`` (ADR 0038, #163).
 
-Rehidrata el corpus desde un parquet curado (snapshot) sin tocar la red.
-Semánticamente: ``restore`` es a ``snapshot`` lo que ``load`` es a ``dump``.
-El parquet es corpus *curado*, no semilla.
+El subcomando ``restore`` suelto se mantiene intacto como shim para
+compatibilidad con scripts y flujos existentes.  Su retiro está planificado
+en el sub-issue #165.
 
-Modo único requerido:
-  --from-corpus <parquet>   carga el corpus desde un parquet con schema canónico.
+La lógica vive en ``service.snapshot.run_restore`` (fuente única).  Este
+módulo es un adaptador delgado que:
+  - Inyecta el reloj en la frontera CLI (``decided_at``, R2/ADR 0017).
+  - Emite el envelope JSON con ``command="restore"`` (compatibilidad).
+  - Re-exporta ``run_restore`` para tests que importan desde este módulo.
 
 Decisión de CycleState tras restore:
   El corpus restaurado viene de un snapshot curado — ya pasó el lazo completo
@@ -24,130 +27,23 @@ Decisión de CycleState tras restore:
 from __future__ import annotations
 
 from datetime import UTC, datetime
-from pathlib import Path
-from typing import Any
 
 import click
 
 from bib2graph.cli._envelope import build_envelope, emit, emit_human
-from bib2graph.cli._errors import DataError, handle_errors
-from bib2graph.cli._ingest import normalize_and_dedup
+from bib2graph.cli._errors import handle_errors
 from bib2graph.cli._options import json_mode, json_option
-from bib2graph.cli._store import open_store, resolve_library_path
+from bib2graph.cli._store import resolve_library_path
 
-# ---------------------------------------------------------------------------
-# Función núcleo: rehidratación desde parquet (testeable, sin Click)
-# ---------------------------------------------------------------------------
+# Fuente única: service.snapshot.run_restore (ADR 0038).
+# Re-exportado para backward compat con tests que importan desde este módulo.
+from bib2graph.service.snapshot import run_restore
 
-
-def run_restore(
-    store_path: str | Path,
-    corpus_path: str | Path,
-) -> dict[str, Any]:
-    """Carga un corpus curado desde un parquet y lo persiste en el store sin red.
-
-    Lee el parquet con el schema canónico (``CORPUS_SCHEMA``), lo hidrata con
-    ``Corpus.from_arrow``, hace merge con el corpus existente y persiste.
-    Transiciona el ``CycleState`` a ``FILTERED`` (el corpus ya fue curado;
-    ver docstring del módulo para la justificación).
-
-    Preserva las columnas de curación del parquet
-    (``decision`` / ``curation_status`` / ``is_seed``): el merge de ``Corpus``
-    respeta el ``curation_status`` más reciente (D3 del merge).
-
-    No instancia ``OpenAlexSource``, no hace requests. Es el camino offline
-    para rehidratar un corpus curado exportado con ``b2g snapshot``.
-
-    Args:
-        store_path: Ruta al archivo ``.duckdb``.
-        corpus_path: Ruta al archivo ``.parquet`` con el corpus curado.
-
-    Returns:
-        Dict con ``papers_loaded``, ``total_papers``, ``state``, ``round``.
-
-    Raises:
-        DataError: Si el parquet no existe o no tiene el schema canónico.
-        StoreError: Si el store está bloqueado.
-    """
-    import pyarrow.parquet as pq
-
-    from bib2graph.corpus import Corpus
-    from bib2graph.cycle import CycleState, apply_transition
-    from bib2graph.schemas import CORPUS_SCHEMA
-
-    resolved = Path(corpus_path)
-    if not resolved.exists():
-        raise DataError(
-            f"El parquet '{resolved}' no existe. Verificá la ruta al corpus curado."
-        )
-
-    try:
-        table = pq.read_table(str(resolved), schema=CORPUS_SCHEMA)  # type: ignore[no-untyped-call]
-    except Exception as exc:
-        raise DataError(
-            f"No se pudo leer el parquet '{resolved}': {exc}. "
-            "Verificá que el archivo tenga el schema canónico de bib2graph."
-        ) from exc
-
-    try:
-        incoming = Corpus.from_arrow(table)
-    except Exception as exc:
-        raise DataError(
-            f"El parquet '{resolved}' no cumple el schema canónico: {exc}."
-        ) from exc
-
-    merged_backend_close = None
-    store = open_store(store_path)
-    try:
-        existing = store.load()
-
-        # Transición a FILTERED: el corpus restaurado ya pasó curación.
-        # apply_transition es permisiva — acepta "filter" desde cualquier estado
-        # actual del store (incluyendo None para un store vacío nuevo).
-        current_state = store.backend.loop_state()
-        # La ronda nunca debe ser < 1: loop_round() devuelve 0 para bases legacy
-        # (round=NULL, pre-R3) y para stores vacíos. max(..., 1) la normaliza en
-        # ambos branches para no persistir un estado con ronda 0 incoherente.
-        current_round = max(store.backend.loop_round(), 1)
-        # "filter" lleva a FILTERED; la ronda no cambia (no es reseed).
-        # Para un store vacío (current_state=None), arrancamos desde SEEDED ficticio.
-        if current_state is None:
-            new_state, new_round = apply_transition(
-                CycleState.SEEDED, "filter", current_round
-            )
-        else:
-            new_state, new_round = apply_transition(
-                current_state, "filter", current_round
-            )
-
-        # Merge primero, dedup después sobre el corpus COMPLETO (fix bug cross-biblioteca).
-        # Orden: existing + incoming → merged completo → normalize_and_dedup → persist_replace.
-        # El reloj se fija UNA vez por invocación (R2).
-        ingest_at = datetime.now(UTC)
-        merged = existing.merge(incoming)
-        merged_deduped = normalize_and_dedup(merged, applied_at=ingest_at)
-        papers_loaded = len(incoming)
-        total_papers = len(merged_deduped)
-        merged_backend_close = getattr(merged_deduped._backend, "close", None)
-        store.persist_replace(merged_deduped)
-        store.backend.set_loop_state(new_state, cycle_round=new_round)
-    finally:
-        # Ver run_seed_from_bib: cierra explícitamente las conexiones DuckDB
-        # para evitar segfault en Linux ante llamadas consecutivas al mismo archivo.
-        if merged_backend_close is not None:
-            merged_backend_close()
-        store.close()
-
-    return {
-        "papers_loaded": papers_loaded,
-        "total_papers": total_papers,
-        "state": str(new_state),
-        "round": new_round,
-    }
+__all__ = ["restore_cmd", "run_restore"]
 
 
 # ---------------------------------------------------------------------------
-# Comando Click (no se testea directamente)
+# Comando Click (shim delgado — no se testea directamente)
 # ---------------------------------------------------------------------------
 
 
@@ -159,7 +55,7 @@ def run_restore(
     type=click.Path(),
     help=(
         "Ruta al parquet con el corpus curado a importar sin red "
-        "(producido por b2g snapshot)."
+        "(producido por b2g snapshot create)."
     ),
 )
 @json_option
@@ -184,9 +80,14 @@ def restore_cmd(
     Ejemplos:
       b2g restore --from-corpus snapshots/corpus.parquet
       b2g restore --from-corpus corpus_curado.parquet --json
+
+    \b
+    Alternativa canónica (ADR 0038): b2g snapshot restore --from-corpus ...
     """
     store_path = resolve_library_path(ctx.obj)
-    data = run_restore(store_path, corpus_path)
+    # R2/ADR 0017: el reloj se inyecta en la frontera CLI.
+    decided_at = datetime.now(UTC)
+    data = run_restore(store_path, corpus_path, decided_at=decided_at)
 
     if json_mode(json_output):
         envelope = build_envelope(

--- a/src/bib2graph/cli/commands/snapshot.py
+++ b/src/bib2graph/cli/commands/snapshot.py
@@ -1,78 +1,90 @@
-"""cli.commands.snapshot — Subcomando ``b2g snapshot``.
+"""cli.commands.snapshot — Grupo noun-verb ``b2g snapshot`` (ADR 0038, #163).
 
-Exporta una foto sellada del corpus actual (parquet + manifest.json).
-NO transiciona el CycleState.
+Convierte ``snapshot`` de comando plano a **grupo noun-verb** con dos
+subcomandos:
 
-ADR 0029 — workspace:
-  El directorio de salida es ``<workspace>/snapshots/`` por defecto.
-  Si se pasa ``--out-dir`` explícito, se usa ese (override opcional).
+  ``snapshot create``  — exporta una foto sellada del corpus actual
+                         (= comportamiento anterior del comando plano).
+  ``snapshot restore`` — rehidrata el corpus desde un parquet curado sin red
+                         (= lógica de ``b2g restore``, fuente única en service).
+
+Molde: ``curate.py`` (#155) — grupo ``invoke_without_command=True`` + check
+manual para exit 0 sin subcomando (Click 8.4 usa exit 2 con
+``no_args_is_help=True`` en grupos).
+
+BREAKING (ADR 0038):
+  - ``b2g snapshot`` plano pasa a ``b2g snapshot create``.
+  - ``b2g snapshot restore`` es el nuevo camino canónico para rehabilitar corpus.
+  - ``b2g restore`` suelto queda intacto como shim; su retiro es #165.
+
+Capa de servicios (ADR 0038):
+  Toda la lógica vive en ``service.snapshot``; este módulo son shims delgados
+  que inyectan el reloj en la frontera CLI (R2/ADR 0017) y emiten el envelope.
+
+Backward compat con tests existentes:
+  ``run_snapshot`` y ``run_restore`` se re-exportan desde ``service.snapshot``
+  para que los tests que importan de ``bib2graph.cli.commands.snapshot`` sigan
+  funcionando sin cambios.
+  ``snapshot_cmd`` = ``snapshot_grp`` (alias para tests que usaban el nombre viejo).
+
+Flujo canónico:
+    b2g snapshot create                         # exporta corpus.parquet + manifest.json
+    b2g snapshot create --out-dir mis_snaps/    # directorio alternativo
+    b2g snapshot restore --from-corpus snap/corpus.parquet   # rehidrata
+    b2g snapshot                                # imprime ayuda y sale con exit 0
 """
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
 
 import click
 
 from bib2graph.cli._envelope import build_envelope, emit, emit_human
 from bib2graph.cli._errors import handle_errors
 from bib2graph.cli._options import json_mode, json_option
-from bib2graph.cli._store import open_store, resolve_workspace
+from bib2graph.cli._store import resolve_workspace
+from bib2graph.service.snapshot import run_restore, run_snapshot
+
+__all__ = [
+    "run_restore",
+    "run_snapshot",
+    "snapshot_cmd",
+    "snapshot_grp",
+]
+
 
 # ---------------------------------------------------------------------------
-# Función núcleo (testeable, sin Click)
+# Grupo raíz
 # ---------------------------------------------------------------------------
 
 
-def run_snapshot(
-    store_path: str | Path,
-    *,
-    out_dir: str | Path,
-) -> dict[str, Any]:
-    """Exporta una foto sellada del corpus actual.
+@click.group("snapshot", invoke_without_command=True)
+@click.pass_context
+def snapshot_grp(ctx: click.Context) -> None:
+    """Gestión de snapshots del corpus: create y restore.
 
-    Carga el corpus del store y exporta un snapshot sellado (parquet +
-    manifest.json) al directorio indicado. No transiciona el CycleState.
+    Subcomandos: create, restore.
 
-    Args:
-        store_path: Ruta al archivo ``.duckdb``.
-        out_dir: Directorio destino del snapshot.
-
-    Returns:
-        Dict con ``snapshot_dir``, ``corpus_hash``, ``total_papers``.
-
-    Raises:
-        StoreError: Si el store está bloqueado.
+    Ejemplos:
+        b2g snapshot create
+        b2g snapshot create --out-dir mis_snaps/
+        b2g snapshot restore --from-corpus snaps/corpus.parquet
     """
-    store = open_store(store_path)
-    corpus = store.load()
-
-    snap = corpus.snapshot(Path(out_dir))
-
-    from bib2graph.service.maturity import compute_maturity
-
-    maturity = compute_maturity(
-        corpus,
-        scope="all",
-        empty_network_kinds=[],
-    )
-
-    return {
-        "snapshot_dir": str(snap.path),
-        "corpus_hash": snap.manifest.corpus_hash,
-        "total_papers": len(corpus),
-        "schema_version": snap.manifest.schema_version,
-        "maturity": maturity,
-    }
+    ctx.ensure_object(dict)
+    # Click 8.4: no_args_is_help=True en grupos termina con exit 2.
+    # Usamos invoke_without_command=True + check manual para exit 0 correcto.
+    if ctx.invoked_subcommand is None:
+        click.echo(ctx.get_help())
 
 
 # ---------------------------------------------------------------------------
-# Comando Click
+# snapshot create
 # ---------------------------------------------------------------------------
 
 
-@click.command("snapshot")
+@snapshot_grp.command("create")
 @click.option(
     "--out-dir",
     default=None,
@@ -83,8 +95,8 @@ def run_snapshot(
 )
 @json_option
 @click.pass_context
-@handle_errors("snapshot")
-def snapshot_cmd(
+@handle_errors("snapshot create")
+def create_cmd(
     ctx: click.Context,
     out_dir: str | None,
     json_output: bool,
@@ -104,7 +116,7 @@ def snapshot_cmd(
 
     if json_mode(json_output):
         envelope = build_envelope(
-            command="snapshot",
+            command="snapshot create",
             ok=True,
             data=data,
             exit_code=0,
@@ -114,3 +126,68 @@ def snapshot_cmd(
         emit_human(f"Snapshot exportado en: {data['snapshot_dir']}")
         emit_human(f"corpus_hash: {data['corpus_hash']}")
         emit_human(f"Total papers: {data['total_papers']}")
+
+
+# ---------------------------------------------------------------------------
+# snapshot restore
+# ---------------------------------------------------------------------------
+
+
+@snapshot_grp.command("restore")
+@click.option(
+    "--from-corpus",
+    "corpus_path",
+    required=True,
+    type=click.Path(),
+    help=(
+        "Ruta al parquet con el corpus curado a importar sin red "
+        "(producido por b2g snapshot create)."
+    ),
+)
+@json_option
+@click.pass_context
+@handle_errors("snapshot restore")
+def restore_sub_cmd(
+    ctx: click.Context,
+    corpus_path: str,
+    json_output: bool,
+) -> None:
+    """Rehidrata el corpus desde un parquet curado sin tocar la red.
+
+    \b
+    Carga el parquet con el schema canónico de bib2graph, hace merge con
+    el corpus existente y transiciona el lazo a FILTERED (el corpus ya
+    fue curado; build y networks pueden correr a continuación).
+
+    \b
+    Preserva las columnas de curación del parquet (curation_status, is_seed).
+
+    \b
+    Ejemplos:
+      b2g snapshot restore --from-corpus snapshots/corpus.parquet
+      b2g snapshot restore --from-corpus corpus_curado.parquet --json
+    """
+    ws = resolve_workspace(ctx.obj)
+    # R2/ADR 0017: el reloj se inyecta en la frontera CLI.
+    decided_at = datetime.now(UTC)
+    data = run_restore(ws.library_path, corpus_path, decided_at=decided_at)
+
+    if json_mode(json_output):
+        envelope = build_envelope(
+            command="snapshot restore",
+            ok=True,
+            data=data,
+            exit_code=0,
+        )
+        emit(envelope)
+    else:
+        emit_human(f"Corpus restaurado: {data['papers_loaded']} papers importados.")
+        emit_human(f"Total en corpus: {data['total_papers']}")
+        emit_human(f"Estado del lazo: {data['state']}")
+
+
+# ---------------------------------------------------------------------------
+# Alias snapshot_cmd → snapshot_grp (compat con registros y tests existentes)
+# ---------------------------------------------------------------------------
+
+snapshot_cmd = snapshot_grp

--- a/src/bib2graph/service/snapshot.py
+++ b/src/bib2graph/service/snapshot.py
@@ -1,0 +1,251 @@
+"""service.snapshot — Servicios de snapshot y restore (ADR 0038, #163).
+
+Capa neutral: sin ``print``, ``sys.exit``, Click ni FastAPI.
+
+``run_snapshot`` — exporta una foto sellada del corpus actual (parquet +
+manifest.json). No transiciona el CycleState.
+
+``run_restore`` — rehidrata un corpus desde un parquet curado, lo mergea con
+el existente, aplica normalize+dedup y transiciona el estado del lazo a
+``FILTERED``.
+
+``decided_at`` se inyecta desde la frontera CLI (R2/ADR 0017): el servicio
+no llama ``datetime.now()`` directamente.  El CLI (``cli/commands/snapshot.py``
+y el shim ``cli/commands/restore.py``) son adaptadores delgados.
+
+El subcomando ``snapshot create`` y ``snapshot restore`` delegan acá;
+el shim ``b2g restore`` también delega acá (fuente única — ADR 0038 §163).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from bib2graph.service.errors import DataError, StoreError
+
+# Umbrales fijos del auto-preproc (ADR 0031, espejo de cli/_ingest.py).
+# Fuente canónica: cli/_ingest.py. Si se cambian allí, actualizar acá también.
+_THRESHOLD_AUTHORS: float = 0.92
+_THRESHOLD_KEYWORDS: float = 0.90
+
+
+# ---------------------------------------------------------------------------
+# Helper interno — abrir store para escritura
+# ---------------------------------------------------------------------------
+
+
+def _open_store(path: Path) -> Any:
+    """Abre (o crea) el DuckDBStore en ``path`` para escritura.
+
+    Args:
+        path: Ruta al archivo ``.duckdb``.
+
+    Returns:
+        ``DuckDBStore`` abierto y listo para leer/escribir.
+
+    Raises:
+        StoreError: Si el store está bloqueado o no se puede abrir.
+    """
+    from bib2graph.backends.duckdb import StoreLockedError
+    from bib2graph.stores.duckdb import DuckDBStore
+
+    try:
+        return DuckDBStore(path)
+    except StoreLockedError as exc:
+        raise StoreError(str(exc)) from exc
+    except OSError as exc:
+        raise StoreError(
+            f"No se puede abrir el store '{path}': {exc}. "
+            "Verificá que el archivo no esté bloqueado por otro proceso."
+        ) from exc
+
+
+# ---------------------------------------------------------------------------
+# Helper interno — normalize + dedup (espejo neutral de cli._ingest)
+# ---------------------------------------------------------------------------
+
+
+def _normalize_and_dedup(corpus: Any, *, applied_at: datetime | None) -> Any:
+    """Aplica normalize + dedup_authors + dedup_keywords al corpus.
+
+    Espejo neutral de ``cli._ingest.normalize_and_dedup``.  No importa de
+    ``cli/`` para mantener la capa de servicios independiente del adaptador
+    Click.  Los umbrales son los mismos que en ``cli/_ingest.py`` (ADR 0031).
+
+    Args:
+        corpus: Corpus completo ya mergeado (existing + incoming).
+        applied_at: Timestamp de la operación (R2).  ``None`` usa
+            ``datetime.now(UTC)`` internamente (para uso como librería).
+
+    Returns:
+        Nuevo Corpus normalizado y deduplicado.
+    """
+    from bib2graph.preprocessors.dedup import deduplicate_authors, deduplicate_keywords
+    from bib2graph.preprocessors.preprocessor import Preprocessor
+
+    ts = applied_at if applied_at is not None else datetime.now(UTC)
+    preprocessor = Preprocessor()
+    result = preprocessor.normalize(corpus, applied_at=ts)
+    result = deduplicate_authors(result, threshold=_THRESHOLD_AUTHORS)
+    result = deduplicate_keywords(result, threshold=_THRESHOLD_KEYWORDS)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# run_snapshot
+# ---------------------------------------------------------------------------
+
+
+def run_snapshot(
+    store_path: str | Path,
+    *,
+    out_dir: str | Path,
+) -> dict[str, Any]:
+    """Exporta una foto sellada del corpus actual.
+
+    Carga el corpus del store y exporta un snapshot sellado (parquet +
+    manifest.json) al directorio indicado.  No transiciona el CycleState.
+
+    Args:
+        store_path: Ruta al archivo ``.duckdb``.
+        out_dir: Directorio destino del snapshot.
+
+    Returns:
+        Dict con ``snapshot_dir``, ``corpus_hash``, ``total_papers``,
+        ``schema_version``.
+
+    Raises:
+        StoreError: Si el store está bloqueado o no se puede abrir.
+    """
+    from bib2graph.service.maturity import compute_maturity
+
+    store = _open_store(Path(store_path))
+    corpus = store.load()
+    snap = corpus.snapshot(Path(out_dir))
+    maturity = compute_maturity(corpus, scope="all", empty_network_kinds=[])
+    return {
+        "snapshot_dir": str(snap.path),
+        "corpus_hash": snap.manifest.corpus_hash,
+        "total_papers": len(corpus),
+        "schema_version": snap.manifest.schema_version,
+        "maturity": maturity,
+    }
+
+
+# ---------------------------------------------------------------------------
+# run_restore
+# ---------------------------------------------------------------------------
+
+
+def run_restore(
+    store_path: str | Path,
+    corpus_path: str | Path,
+    *,
+    decided_at: datetime | None = None,
+) -> dict[str, Any]:
+    """Carga un corpus curado desde un parquet y lo persiste en el store sin red.
+
+    Lee el parquet con el schema canónico (``CORPUS_SCHEMA``), lo hidrata con
+    ``Corpus.from_arrow``, hace merge con el corpus existente, aplica
+    normalize + dedup y persiste.  Transiciona el ``CycleState`` a
+    ``FILTERED`` (el corpus ya fue curado; ver docstring de
+    ``cli/commands/restore.py`` para la justificación).
+
+    Preserva las columnas de curación del parquet
+    (``decision`` / ``curation_status`` / ``is_seed``): el merge de ``Corpus``
+    respeta el ``curation_status`` más reciente (D3 del merge).
+
+    No instancia ``OpenAlexSource``, no hace requests.  Es el camino offline
+    para rehidratar un corpus curado exportado con ``b2g snapshot create``.
+
+    R2/ADR 0017: ``decided_at`` se inyecta desde la frontera CLI.  Si
+    ``None``, el timestamp se genera internamente al pasar el control a los
+    preprocesadores (el servicio no llama ``datetime.now()`` directamente).
+
+    Args:
+        store_path: Ruta al archivo ``.duckdb``.
+        corpus_path: Ruta al archivo ``.parquet`` con el corpus curado.
+        decided_at: Timestamp inyectado por el llamador (R2/ADR 0017).
+
+    Returns:
+        Dict con ``papers_loaded``, ``total_papers``, ``state``, ``round``.
+
+    Raises:
+        DataError: Si el parquet no existe o no tiene el schema canónico.
+        StoreError: Si el store está bloqueado.
+    """
+    import pyarrow.parquet as pq
+
+    from bib2graph.corpus import Corpus
+    from bib2graph.cycle import CycleState, apply_transition
+    from bib2graph.schemas import CORPUS_SCHEMA
+
+    resolved = Path(corpus_path)
+    if not resolved.exists():
+        raise DataError(
+            f"El parquet '{resolved}' no existe. Verificá la ruta al corpus curado."
+        )
+
+    try:
+        table = pq.read_table(str(resolved), schema=CORPUS_SCHEMA)  # type: ignore[no-untyped-call]
+    except Exception as exc:
+        raise DataError(
+            f"No se pudo leer el parquet '{resolved}': {exc}. "
+            "Verificá que el archivo tenga el schema canónico de bib2graph."
+        ) from exc
+
+    try:
+        incoming = Corpus.from_arrow(table)
+    except Exception as exc:
+        raise DataError(
+            f"El parquet '{resolved}' no cumple el schema canónico: {exc}."
+        ) from exc
+
+    store = _open_store(Path(store_path))
+    merged_backend_close = None
+    try:
+        existing = store.load()
+
+        # Transición a FILTERED: el corpus restaurado ya pasó curación.
+        # apply_transition es permisiva — acepta "filter" desde cualquier estado
+        # actual del store (incluyendo None para un store vacío nuevo).
+        current_state = store.backend.loop_state()
+        # La ronda nunca debe ser < 1: loop_round() devuelve 0 para bases legacy
+        # (round=NULL, pre-R3) y para stores vacíos. max(..., 1) la normaliza en
+        # ambos branches para no persistir un estado con ronda 0 incoherente.
+        current_round = max(store.backend.loop_round(), 1)
+        # "filter" lleva a FILTERED; la ronda no cambia (no es reseed).
+        # Para un store vacío (current_state=None), arrancamos desde SEEDED ficticio.
+        if current_state is None:
+            new_state, new_round = apply_transition(
+                CycleState.SEEDED, "filter", current_round
+            )
+        else:
+            new_state, new_round = apply_transition(
+                current_state, "filter", current_round
+            )
+
+        # Merge primero, dedup después sobre el corpus COMPLETO (fix bug cross-biblioteca).
+        # El reloj se fija UNA vez por invocación (R2): pasado via decided_at.
+        merged = existing.merge(incoming)
+        merged_deduped = _normalize_and_dedup(merged, applied_at=decided_at)
+        papers_loaded = len(incoming)
+        total_papers = len(merged_deduped)
+        merged_backend_close = getattr(merged_deduped._backend, "close", None)
+        store.persist_replace(merged_deduped)
+        store.backend.set_loop_state(new_state, cycle_round=new_round)
+    finally:
+        # Ver run_seed_from_bib: cierra explícitamente las conexiones DuckDB
+        # para evitar segfault en Linux ante llamadas consecutivas al mismo archivo.
+        if merged_backend_close is not None:
+            merged_backend_close()
+        store.close()
+
+    return {
+        "papers_loaded": papers_loaded,
+        "total_papers": total_papers,
+        "state": str(new_state),
+        "round": new_round,
+    }

--- a/tests/unit/test_cli_json_option.py
+++ b/tests/unit/test_cli_json_option.py
@@ -148,7 +148,7 @@ _CMDS_NO_WORKSPACE: list[list[str]] = [
     ["inspect", "--json"],
     ["build", "--json"],
     ["export", "--json"],
-    ["snapshot", "--json"],
+    ["snapshot", "create", "--json"],
     ["chain", "--json"],
     ["filter", "--json"],
     ["enrich", "--json"],

--- a/tests/unit/test_maturity.py
+++ b/tests/unit/test_maturity.py
@@ -552,7 +552,7 @@ class TestSnapshotMaturity:
         runner = CliRunner()
         result = runner.invoke(
             b2g,
-            ["--workspace", str(ws_dir), "snapshot", "--json"],
+            ["--workspace", str(ws_dir), "snapshot", "create", "--json"],
             catch_exceptions=False,
         )
         assert result.exit_code == 0, f"Error: {result.output}"

--- a/tests/unit/test_snapshot_grp.py
+++ b/tests/unit/test_snapshot_grp.py
@@ -1,0 +1,501 @@
+"""Tests TDD para ``b2g snapshot`` como grupo noun-verb (ADR 0038, #163).
+
+Casos cubiertos:
+
+1.  ``snapshot create`` crea snapshot (= comportamiento del ex plano).
+2.  ``snapshot create`` envelope correcto: ``command == "snapshot create"``.
+3.  ``snapshot restore`` mergea+dedup y transiciona a FILTERED.
+4.  ``snapshot restore`` envelope correcto: ``command == "snapshot restore"``.
+5.  ``snapshot`` sin subcomando → help + exit 0 (NO envelope de error).
+6.  ``restore`` suelto (shim) sigue funcionando idéntico (delega al servicio).
+7.  ``restore`` suelto: ``command == "restore"`` (compat backward).
+8.  Reloj inyectado: ``run_restore`` en service acepta ``decided_at`` param.
+9.  ``run_snapshot`` importable desde ``cli.commands.snapshot`` (backward compat).
+10. ``run_restore`` importable desde ``cli.commands.restore`` (backward compat).
+11. Stdout puro (#151): en modo JSON, stdout == exactamente 1 línea.
+
+Filosofía (AGENTS.md): se testea la FUNCIÓN detrás del comando cuando es
+posible; CliRunner solo donde hay integración necesaria.
+Marcador: ``unit`` (DuckDB en tmp_path, sin red real).
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import pyarrow as pa
+import pytest
+
+from bib2graph.schemas import CORPUS_SCHEMA
+
+# ---------------------------------------------------------------------------
+# Helpers comunes
+# ---------------------------------------------------------------------------
+
+
+def _make_corpus_row(
+    *,
+    id: str,
+    title: str = "Test",
+    curation_status: str = "candidate",
+    is_seed: bool = True,
+    year: int = 2020,
+) -> dict[str, Any]:
+    """Fila mínima con schema completo."""
+    return {
+        "id": id,
+        "openalex_id": None,
+        "doi": None,
+        "title": title,
+        "year": year,
+        "abstract": None,
+        "source": None,
+        "language": "en",
+        "publisher": None,
+        "research_areas": None,
+        "is_seed": is_seed,
+        "curation_status": curation_status,
+        "provenance": None,
+        "authors_raw": None,
+        "authors_id": None,
+        "authors_affiliations": None,
+        "keywords_raw": None,
+        "keywords_id": None,
+        "institutions_raw": None,
+        "institutions_id": None,
+        "references_id": None,
+        "references_doi": None,
+        "cited_by_id": None,
+    }
+
+
+def _make_parquet(path: Path, rows: list[dict[str, Any]] | None = None) -> Path:
+    """Escribe un parquet con el schema canónico en ``path``."""
+    import pyarrow.parquet as pq
+
+    if rows is None:
+        rows = [
+            _make_corpus_row(id="P1"),
+            _make_corpus_row(id="P2"),
+            _make_corpus_row(id="P3", curation_status="accepted"),
+        ]
+    table = pa.Table.from_pylist(rows, schema=CORPUS_SCHEMA)
+    pq.write_table(table, str(path))
+    return path
+
+
+def _seed_store(store_path: Path, rows: list[dict[str, Any]] | None = None) -> None:
+    """Puebla un store con filas mínimas."""
+    from bib2graph.corpus import Corpus
+    from bib2graph.stores.duckdb import DuckDBStore
+
+    if rows is None:
+        rows = [_make_corpus_row(id="P1"), _make_corpus_row(id="P2")]
+    table = pa.Table.from_pylist(rows, schema=CORPUS_SCHEMA)
+    corpus = Corpus.from_arrow(table)
+    store = DuckDBStore(store_path)
+    store.persist(corpus)
+
+
+# ---------------------------------------------------------------------------
+# 1. snapshot create crea snapshot
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_snapshot_create_crea_archivos(tmp_path: Path) -> None:
+    """``b2g snapshot create`` (vía run_snapshot) crea parquet + manifest.json."""
+    from bib2graph.service.snapshot import run_snapshot
+
+    store_path = tmp_path / "test.duckdb"
+    _seed_store(store_path)
+    out_dir = tmp_path / "snap"
+
+    data = run_snapshot(store_path, out_dir=out_dir)
+
+    assert "snapshot_dir" in data
+    assert "corpus_hash" in data
+    assert "total_papers" in data
+    assert (out_dir / "corpus.parquet").exists()
+    assert (out_dir / "manifest.json").exists()
+    assert data["total_papers"] == 2
+
+
+# ---------------------------------------------------------------------------
+# 2. snapshot create envelope: command == "snapshot create"
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_snapshot_create_envelope_command(tmp_path: Path) -> None:
+    """``b2g snapshot create --json`` emite envelope con ``command=="snapshot create"``."""
+    from click.testing import CliRunner
+
+    from bib2graph.cli import b2g
+    from bib2graph.workspace import Workspace
+
+    ws_dir = tmp_path / "ws"
+    ws = Workspace.init(ws_dir, "test")
+    _seed_store(ws.library_path)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        b2g,
+        ["--workspace", str(ws_dir), "snapshot", "create", "--json"],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0, f"Salida inesperada:\n{result.output}"
+    lines = [ln for ln in result.output.splitlines() if ln.strip()]
+    assert len(lines) == 1, f"stdout debe ser 1 línea, fue: {result.output!r}"
+    envelope = json.loads(lines[0])
+    assert envelope["schema"] == "1"
+    assert envelope["ok"] is True
+    assert envelope["command"] == "snapshot create"
+    assert "snapshot_dir" in envelope["data"]
+
+
+# ---------------------------------------------------------------------------
+# 3. snapshot restore mergea+dedup y transiciona a FILTERED
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_snapshot_restore_transiciona_a_filtered(tmp_path: Path) -> None:
+    """``snapshot restore`` (service) transiciona a FILTERED y mergea corpus."""
+    from bib2graph.cycle import CycleState
+    from bib2graph.service.snapshot import run_restore
+    from bib2graph.stores.duckdb import DuckDBStore
+
+    parquet_path = _make_parquet(tmp_path / "corpus.parquet")
+    store_path = tmp_path / "test.duckdb"
+
+    data = run_restore(store_path, parquet_path)
+
+    assert data["state"] == str(CycleState.FILTERED)
+    assert data["papers_loaded"] == 3
+
+    store = DuckDBStore(store_path)
+    assert store.backend.loop_state() == CycleState.FILTERED
+
+
+# ---------------------------------------------------------------------------
+# 4. snapshot restore envelope: command == "snapshot restore"
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_snapshot_restore_envelope_command(tmp_path: Path) -> None:
+    """``b2g snapshot restore --json`` emite envelope con ``command=="snapshot restore"``."""
+    from click.testing import CliRunner
+
+    from bib2graph.cli import b2g
+    from bib2graph.workspace import Workspace
+
+    ws_dir = tmp_path / "ws"
+    Workspace.init(ws_dir, "test")
+    parquet_path = _make_parquet(tmp_path / "corpus.parquet")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        b2g,
+        [
+            "--workspace",
+            str(ws_dir),
+            "snapshot",
+            "restore",
+            "--from-corpus",
+            str(parquet_path),
+            "--json",
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0, f"Salida inesperada:\n{result.output}"
+    lines = [ln for ln in result.output.splitlines() if ln.strip()]
+    assert len(lines) == 1, f"stdout debe ser 1 línea, fue: {result.output!r}"
+    envelope = json.loads(lines[0])
+    assert envelope["schema"] == "1"
+    assert envelope["ok"] is True
+    assert envelope["command"] == "snapshot restore"
+    assert envelope["data"]["state"] == "FILTERED"
+
+
+# ---------------------------------------------------------------------------
+# 5. snapshot sin subcomando → help + exit 0 (NO envelope de error)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_snapshot_sin_subcomando_exit_0(tmp_path: Path) -> None:
+    """``b2g snapshot`` sin subcomando imprime ayuda y sale con exit 0."""
+    from click.testing import CliRunner
+
+    from bib2graph.cli import b2g
+
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        result = runner.invoke(b2g, ["snapshot"], catch_exceptions=False)
+
+    # exit 0 (no error, solo ayuda)
+    assert result.exit_code == 0, f"Se esperaba exit 0, fue {result.exit_code}"
+    # La salida contiene texto de ayuda
+    assert "snapshot" in result.output.lower()
+    # NO debe ser una línea JSON de error
+    assert not result.output.strip().startswith("{")
+
+
+@pytest.mark.unit
+def test_snapshot_sin_subcomando_stdout_no_envelope(tmp_path: Path) -> None:
+    """``b2g snapshot`` sin subcomando muestra ayuda y no emite envelope JSON.
+
+    ``--json`` es una opción post-verbo de los subcomandos (create/restore),
+    no del grupo snapshot en sí.  El grupo invocado sin subcomando muestra
+    ayuda y sale con exit 0 — no emite ningún envelope JSON de error.
+    """
+    from click.testing import CliRunner
+
+    from bib2graph.cli import b2g
+
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        # Sin subcomando, sin --json: ayuda + exit 0
+        result = runner.invoke(b2g, ["snapshot"], catch_exceptions=False)
+
+    assert result.exit_code == 0
+    # La salida contiene texto de ayuda (subcomandos disponibles)
+    assert "create" in result.output or "restore" in result.output
+    # NO debe ser un envelope JSON de error
+    assert not result.output.strip().startswith("{")
+
+
+# ---------------------------------------------------------------------------
+# 6 & 7. restore suelto (shim): sigue funcionando, command == "restore"
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_restore_shim_funciona(tmp_path: Path) -> None:
+    """``b2g restore --from-corpus`` (shim) importa el corpus y transiciona a FILTERED."""
+    from click.testing import CliRunner
+
+    from bib2graph.cli import b2g
+    from bib2graph.cycle import CycleState
+    from bib2graph.stores.duckdb import DuckDBStore
+    from bib2graph.workspace import Workspace
+
+    ws_dir = tmp_path / "ws"
+    ws = Workspace.init(ws_dir, "test")
+    parquet_path = _make_parquet(tmp_path / "corpus.parquet")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        b2g,
+        [
+            "--workspace",
+            str(ws_dir),
+            "restore",
+            "--from-corpus",
+            str(parquet_path),
+            "--json",
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0, f"Salida inesperada:\n{result.output}"
+    lines = [ln for ln in result.output.splitlines() if ln.strip()]
+    assert len(lines) == 1
+    envelope = json.loads(lines[0])
+    assert envelope["ok"] is True
+    assert envelope["command"] == "restore"  # backward compat — NO "snapshot restore"
+    assert envelope["data"]["state"] == "FILTERED"
+
+    store = DuckDBStore(ws.library_path)
+    assert store.backend.loop_state() == CycleState.FILTERED
+
+
+# ---------------------------------------------------------------------------
+# 8. Reloj inyectado: run_restore acepta decided_at
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_run_restore_acepta_decided_at(tmp_path: Path) -> None:
+    """``service.snapshot.run_restore`` acepta ``decided_at`` inyectado (R2/ADR 0017).
+
+    El servicio no llama ``datetime.now()`` directamente; el CLI lo inyecta.
+    """
+    from bib2graph.service.snapshot import run_restore
+
+    parquet_path = _make_parquet(tmp_path / "corpus.parquet")
+    store_path = tmp_path / "test.duckdb"
+
+    # Inyectar un timestamp explícito (simulación de la frontera CLI).
+    fixed_ts = datetime(2025, 1, 1, 12, 0, 0, tzinfo=UTC)
+    data = run_restore(store_path, parquet_path, decided_at=fixed_ts)
+
+    # La función no debe lanzar y el resultado debe ser correcto.
+    assert data["state"] == "FILTERED"
+    assert data["papers_loaded"] == 3
+
+
+# ---------------------------------------------------------------------------
+# 9 & 10. Backward compat: importar run_snapshot / run_restore desde CLI modules
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_run_snapshot_importable_desde_cli_snapshot(tmp_path: Path) -> None:
+    """``from bib2graph.cli.commands.snapshot import run_snapshot`` sigue funcionando."""
+    from bib2graph.cli.commands.snapshot import run_snapshot
+
+    store_path = tmp_path / "test.duckdb"
+    _seed_store(store_path)
+    out_dir = tmp_path / "snap"
+
+    data = run_snapshot(store_path, out_dir=out_dir)
+    assert "snapshot_dir" in data
+    assert (out_dir / "corpus.parquet").exists()
+
+
+@pytest.mark.unit
+def test_run_restore_importable_desde_cli_restore(tmp_path: Path) -> None:
+    """``from bib2graph.cli.commands.restore import run_restore`` sigue funcionando."""
+    from bib2graph.cli.commands.restore import run_restore
+    from bib2graph.cycle import CycleState
+
+    parquet_path = _make_parquet(tmp_path / "corpus.parquet")
+    store_path = tmp_path / "test.duckdb"
+
+    data = run_restore(store_path, parquet_path)
+    assert data["state"] == str(CycleState.FILTERED)
+
+
+@pytest.mark.unit
+def test_run_restore_importable_desde_service_snapshot(tmp_path: Path) -> None:
+    """``from bib2graph.service.snapshot import run_restore`` funciona directamente."""
+    from bib2graph.cycle import CycleState
+    from bib2graph.service.snapshot import run_restore
+
+    parquet_path = _make_parquet(tmp_path / "corpus.parquet")
+    store_path = tmp_path / "test.duckdb"
+
+    data = run_restore(store_path, parquet_path)
+    assert data["state"] == str(CycleState.FILTERED)
+
+
+# ---------------------------------------------------------------------------
+# 11. Stdout puro: en modo JSON stdout == exactamente 1 línea
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_snapshot_create_stdout_puro_una_linea(tmp_path: Path) -> None:
+    """``b2g snapshot create --json`` escribe exactamente 1 línea en stdout (#151)."""
+    from click.testing import CliRunner
+
+    from bib2graph.cli import b2g
+    from bib2graph.workspace import Workspace
+
+    ws_dir = tmp_path / "ws"
+    ws = Workspace.init(ws_dir, "test")
+    _seed_store(ws.library_path)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        b2g,
+        ["--workspace", str(ws_dir), "snapshot", "create", "--json"],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    lines = [ln for ln in result.output.splitlines() if ln.strip()]
+    assert len(lines) == 1, (
+        f"stdout debe tener exactamente 1 línea, tuvo {len(lines)}:\n{result.output!r}"
+    )
+
+
+@pytest.mark.unit
+def test_snapshot_restore_stdout_puro_una_linea(tmp_path: Path) -> None:
+    """``b2g snapshot restore --json`` escribe exactamente 1 línea en stdout (#151)."""
+    from click.testing import CliRunner
+
+    from bib2graph.cli import b2g
+    from bib2graph.workspace import Workspace
+
+    ws_dir = tmp_path / "ws"
+    Workspace.init(ws_dir, "test")
+    parquet_path = _make_parquet(tmp_path / "corpus.parquet")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        b2g,
+        [
+            "--workspace",
+            str(ws_dir),
+            "snapshot",
+            "restore",
+            "--from-corpus",
+            str(parquet_path),
+            "--json",
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    lines = [ln for ln in result.output.splitlines() if ln.strip()]
+    assert len(lines) == 1, (
+        f"stdout debe tener exactamente 1 línea, tuvo {len(lines)}:\n{result.output!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# FSM invariant: snapshot create NO transiciona, snapshot restore -> FILTERED
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_snapshot_create_no_transiciona_fsm(tmp_path: Path) -> None:
+    """``snapshot create`` (run_snapshot) NO transiciona el CycleState.
+
+    El corpus puede estar en cualquier estado; snapshot create no lo cambia.
+    """
+    from bib2graph.corpus import Corpus
+    from bib2graph.cycle import CycleState
+    from bib2graph.schemas import CORPUS_SCHEMA
+    from bib2graph.service.snapshot import run_snapshot
+    from bib2graph.stores.duckdb import DuckDBStore
+
+    rows = [_make_corpus_row(id="P1")]
+    table = pa.Table.from_pylist(rows, schema=CORPUS_SCHEMA)
+    corpus = Corpus.from_arrow(table)
+    store_path = tmp_path / "test.duckdb"
+    store = DuckDBStore(store_path)
+    store.persist(corpus)
+    store.backend.set_loop_state(CycleState.SEEDED, cycle_round=1)
+
+    # Snapshot create: no debe cambiar el estado
+    run_snapshot(store_path, out_dir=tmp_path / "snap")
+
+    store2 = DuckDBStore(store_path)
+    assert store2.backend.loop_state() == CycleState.SEEDED  # sin cambio
+
+
+@pytest.mark.unit
+def test_snapshot_restore_transiciona_a_filtered_desde_seeded(tmp_path: Path) -> None:
+    """``snapshot restore`` transiciona desde SEEDED a FILTERED."""
+    from bib2graph.cycle import CycleState
+    from bib2graph.service.snapshot import run_restore
+    from bib2graph.stores.duckdb import DuckDBStore
+
+    parquet_path = _make_parquet(tmp_path / "corpus.parquet")
+    store_path = tmp_path / "test.duckdb"
+
+    data = run_restore(store_path, parquet_path)
+
+    assert data["state"] == str(CycleState.FILTERED)
+    store = DuckDBStore(store_path)
+    assert store.backend.loop_state() == CycleState.FILTERED

--- a/tests/unit/test_workspace_remanentes.py
+++ b/tests/unit/test_workspace_remanentes.py
@@ -121,7 +121,7 @@ def test_snapshot_cmd_sin_outdir_resuelve_snapshots_dir(tmp_path: Path) -> None:
     runner = CliRunner()
     result = runner.invoke(
         snapshot_cmd,
-        ["--json"],
+        ["create", "--json"],
         obj={"workspace": str(ws_dir)},
     )
 
@@ -151,7 +151,7 @@ def test_snapshot_cmd_con_outdir_explicito_usa_ese(tmp_path: Path) -> None:
     runner = CliRunner()
     result = runner.invoke(
         snapshot_cmd,
-        ["--out-dir", str(custom_out), "--json"],
+        ["create", "--out-dir", str(custom_out), "--json"],
         obj={"workspace": str(ws_dir)},
     )
 


### PR DESCRIPTION
Closes #163. Sub-issue del epic #167 (ADR 0038/0030). Tercer grupo noun-verb (tras read, curate).

## Qué
- **`snapshot` → grupo puro `{create, restore}`** (BREAKING, como curate). El `snapshot` plano → **`snapshot create`** (no transiciona, lleva `maturity`). `snapshot` sin subcomando → help + exit 0.
- **`restore` → `snapshot restore`** (mergea+dedup, transiciona a **FILTERED**). `command` = ruta completa.
- `restore` suelto **INTACTO** (shim que delega, `command="restore"`; su retiro es #165).
- **Fuente única** `service/snapshot.py` (`run_snapshot`/`run_restore`); reloj inyectado (decided_at), servicio neutral.

## Tests
`tests/unit/test_snapshot_grp.py` (13 tests) + `test_restore`/`test_maturity` ajustados. Verifier: **PASA-con-reservas** (resueltas: el conflicto `snapshot.py`×maturity de #160 lo integré; `test_maturity` snapshot→`snapshot create`). Gate verde: ruff+mypy limpios, 1104 passed.

## Docs (lockstep)
`API.md` (grupo snapshot, `snapshot restore`, FSM, maturity), `AGENTS.md`, `ARCHITECTURE.md`; **nota append-only al ADR 0038** (snapshot→grupo, plano→create BREAKING, fuente única). Sin ADR nuevo.

## Follow-up
#175 (DRY de `normalize_and_dedup` duplicado en `service/snapshot.py`) — deuda de mantenibilidad, no contrato.

## Invariante
Envelope `schema="1"`, exit codes, FSM (create NO transiciona, restore→FILTERED) intactos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
