### PR TITLE
feat(cli): absorber enrich en chain/build (#162)

### DIFF
--- a/src/bib2graph/cli/_enrich.py
+++ b/src/bib2graph/cli/_enrich.py
@@ -1,0 +1,118 @@
+"""cli._enrich — Helper de enriquecimiento en memoria (sin I/O de store).
+
+Centraliza la lógica de enriquecimiento para que ``chain``, ``build`` y
+``enrich`` compartan UNA sola implementación (fuente única, sin duplicar).
+
+El helper opera sobre un ``Corpus`` ya en memoria, dentro de la transacción
+existente de quien lo llama. NO abre ni cierra el store: eso es
+responsabilidad del llamante.
+
+Pasadas soportadas:
+  - ``"refs_doi"``: resuelve ``references_id`` → ``references_doi`` (Hito 8a).
+    Corre en ``chain`` (forrajeo puro), automática.
+  - ``"cited_by"``: puebla ``cited_by_id`` de las semillas aceptadas (Hito 8b).
+    Corre en ``build``, automática si hay seeds aceptadas; si no, no-op graceful.
+  - ``"both"``: ambas pasadas (se usa en ``enrich`` standalone).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from bib2graph.corpus import Corpus
+    from bib2graph.sources.openalex import OpenAlexSource
+
+
+def enrich_corpus(
+    corpus: Corpus,
+    source: OpenAlexSource,
+    *,
+    max_citing: int | None = None,
+    pass_name: str = "both",
+) -> tuple[Corpus, dict[str, Any]]:
+    """Enriquece el corpus en memoria con una o ambas pasadas de OpenAlex.
+
+    Construye un ``OpenAlexEnricher`` con el ``source`` dado y ejecuta la(s)
+    pasada(s) indicadas.  Extrae las métricas del Manifest del corpus resultado
+    y las devuelve junto al corpus enriquecido.
+
+    No abre store ni hace I/O de persistencia — eso es responsabilidad
+    del llamante (chain/build/enrich).
+
+    Args:
+        corpus: Corpus en memoria sobre el que operar.
+        source: ``OpenAlexSource`` ya instanciado y configurado.
+            El mismo source que el comando ya creó para chaining o build.
+        max_citing: Tope de citantes por semilla para la pasada ``cited_by``.
+            ``None`` = sin tope.  Ignorado en ``refs_doi``.
+        pass_name: Pasada(s) a ejecutar.
+            ``"refs_doi"`` = solo Pasada 1 (resuelve DOIs de referencias).
+            ``"cited_by"`` = solo Pasada 2 (puebla citantes de seeds aceptadas).
+            ``"both"`` = ambas en orden (Pasada 1 → Pasada 2).  Default.
+
+    Returns:
+        Tupla ``(corpus_enriquecido, metricas)`` donde ``metricas`` es un
+        dict con un subconjunto de:
+          - ``refs_resolved`` (int): referencias resueltas a DOI.
+          - ``refs_total_unique`` (int): total de references_id únicos.
+          - ``citing_new`` (int): nuevos citantes añadidos a cited_by_id.
+          - ``citing_targets`` (int): seeds aceptadas procesadas en pasada 2.
+        Solo aparecen las claves de las pasadas que se ejecutaron.
+
+    Raises:
+        httpx.HTTPError: Si falla la conexión a OpenAlex (propagado).
+        ValueError: Si ``pass_name`` no es ``"refs_doi"``, ``"cited_by"``
+            ni ``"both"``.
+    """
+    from bib2graph.enrichers.openalex import OpenAlexEnricher
+
+    if pass_name not in ("refs_doi", "cited_by", "both"):
+        raise ValueError(
+            f"pass_name desconocido: {pass_name!r}. "
+            "Usá 'refs_doi', 'cited_by' o 'both'."
+        )
+
+    enricher = OpenAlexEnricher(source, max_citing_per_paper=max_citing)
+
+    if pass_name == "refs_doi":
+        enriched = enricher.enrich_references_doi(corpus)
+    elif pass_name == "cited_by":
+        enriched = enricher.enrich_cited_by(corpus)
+    else:  # "both"
+        enriched = enricher.enrich(corpus)
+
+    metrics = _extract_metrics(enriched)
+    return enriched, metrics
+
+
+def _extract_metrics(corpus: Corpus) -> dict[str, Any]:
+    """Extrae métricas de enriquecimiento del Manifest del corpus.
+
+    Recorre ``corpus.manifest.enrichers`` buscando las entradas de las
+    pasadas 1 (``openalex_references_doi``) y 2 (``openalex_cited_by``).
+    Devuelve un dict con solo las claves presentes.
+
+    Args:
+        corpus: Corpus enriquecido (con el Manifest actualizado por el Enricher).
+
+    Returns:
+        Dict con claves ``refs_resolved``, ``refs_total_unique``, ``citing_new``
+        y/o ``citing_targets`` según las pasadas ejecutadas.
+    """
+    enricher_refs = corpus.manifest.enrichers
+    metrics: dict[str, Any] = {}
+
+    doi_entry = next(
+        (e for e in enricher_refs if e.name == "openalex_references_doi"), None
+    )
+    if doi_entry is not None:
+        metrics["refs_resolved"] = int(doi_entry.params.get("resolved", 0))
+        metrics["refs_total_unique"] = int(doi_entry.params.get("total_unique_refs", 0))
+
+    cb_entry = next((e for e in enricher_refs if e.name == "openalex_cited_by"), None)
+    if cb_entry is not None:
+        metrics["citing_new"] = int(cb_entry.params.get("resolved", 0))
+        metrics["citing_targets"] = int(cb_entry.params.get("total", 0))
+
+    return metrics

--- a/src/bib2graph/cli/commands/build.py
+++ b/src/bib2graph/cli/commands/build.py
@@ -42,6 +42,7 @@ from typing import TYPE_CHECKING, Any
 
 import click
 
+from bib2graph.cli._enrich import enrich_corpus
 from bib2graph.cli._envelope import build_envelope, emit, emit_human
 from bib2graph.cli._errors import DataError, DependencyError, handle_errors
 from bib2graph.cli._options import json_mode, json_option
@@ -248,6 +249,9 @@ def run_build(
     spec_path: str | Path | None = None,
     min_weight: int = 1,
     scope_cli_token: str | None = None,
+    email: str | None = None,
+    transport: Any = None,
+    max_citing: int | None = None,
 ) -> dict[str, Any]:
     """Computa redes bibliométricas y escribe artefactos a disco.
 
@@ -263,6 +267,9 @@ def run_build(
       del corpus **filtrado** (D1 — ADR 0038).
     - Se diagnostican redes vacías usando ``predict_build_preview`` como fuente
       única (ADR 0037 §(e) — no-divergencia con ``status``).
+    - Si hay seeds aceptadas, corre la pasada cited_by ANTES de proyectar las
+      redes (ADR 0038 §enrich), de modo que la co-citación salga poblada.
+      Si no hay seeds aceptadas, la pasada es no-op graceful (→ 4 redes).
 
     Para redes de paper con comunidades detectadas escribe también clusters.csv
     (tabla de resumen de comunidades, issue #31).
@@ -282,11 +289,16 @@ def run_build(
             expone este token en lugar del vocab interno. Permite que #160
             (maturity) y la CLI sean consistentes. Si se omite (llamadas directas
             sin CLI), ``data["scope"]`` queda igual a ``corpus_scope``.
+        email: Email para el polite pool de OpenAlex (pasada cited_by).
+        transport: Transport inyectable para tests (``httpx.MockTransport``).
+        max_citing: Tope de citantes por seed en la pasada cited_by.
+            ``None`` = sin tope.
 
     Returns:
         Dict con ``networks_built``, ``artifacts_dir``, ``corpus_hash``,
         ``corpus_scope`` (vocab interno), ``scope`` (token CLI o vocab interno),
-        lista de redes, ``warnings`` y ``empty_networks``.
+        lista de redes, ``warnings``, ``empty_networks``, ``maturity``
+        y ``enrichment`` (bloque aditivo con métricas de la pasada cited_by).
 
     Raises:
         DataError: Si ``spec_path`` está malformado (modo spec).
@@ -313,6 +325,27 @@ def run_build(
             artifacts_dir = store_path_obj.parent / "networks"
         else:
             artifacts_dir = Path(out_dir)
+
+        # Pasada cited_by: enriquecer con citantes ANTES de proyectar redes
+        # (ADR 0038 §enrich).  Solo si hay seeds aceptadas; si no, no-op graceful
+        # (→ 4 redes en vez de 5, sin error).  Persiste el corpus enriquecido para
+        # que la co-citación quede disponible en runs posteriores (idempotente).
+        from bib2graph.constants import Col, CurationStatus
+        from bib2graph.sources.openalex import OpenAlexSource
+
+        _rows = corpus_full.to_arrow().to_pylist()
+        _has_accepted_seeds = any(
+            row.get(Col.IS_SEED)
+            and row.get(Col.CURATION_STATUS) == CurationStatus.ACCEPTED
+            for row in _rows
+        )
+        enrich_metrics: dict[str, Any] = {}
+        if _has_accepted_seeds:
+            _source = OpenAlexSource(email=email, transport=transport)
+            corpus_full, enrich_metrics = enrich_corpus(
+                corpus_full, _source, max_citing=max_citing, pass_name="cited_by"
+            )
+            store.persist_replace(corpus_full)
 
         # Filtrar el corpus según el scope ANTES de construir redes (#56).
         # El corpus filtrado también es el que se pasa a _write_artifacts para que
@@ -353,6 +386,7 @@ def run_build(
                 "warnings": build_warnings,
                 "empty_networks": [],
                 "maturity": _maturity_empty,
+                "enrichment": enrich_metrics,
             }
 
         # Diagnóstico pre-build (ADR 0037 §(e), fuente única con status-time).
@@ -468,6 +502,7 @@ def run_build(
         "warnings": build_warnings,
         "empty_networks": empty_networks,
         "maturity": maturity,
+        "enrichment": enrich_metrics,
     }
 
 
@@ -533,6 +568,21 @@ def run_build(
         "Solo aplica al modo quick (sin --spec); en modo spec el YAML lleva su propio min_weight."
     ),
 )
+@click.option(
+    "--max-citing",
+    "max_citing",
+    default=None,
+    type=int,
+    help=(
+        "Tope de citantes por seed en la pasada cited_by automática. "
+        "Default: sin tope. Solo aplica cuando hay seeds aceptadas."
+    ),
+)
+@click.option(
+    "--email",
+    default=None,
+    help="Email para el polite pool de OpenAlex (pasada cited_by).",
+)
 @json_option
 @click.pass_context
 @handle_errors("build")
@@ -543,6 +593,8 @@ def build_cmd(
     corpus_scope_deprecated: str | None,
     spec_path: str | None,
     min_weight: int,
+    max_citing: int | None,
+    email: str | None,
     json_output: bool,
 ) -> None:
     """Computa redes bibliométricas y escribe artefactos.
@@ -590,6 +642,8 @@ def build_cmd(
         spec_path=spec_path,
         min_weight=min_weight,
         scope_cli_token=cli_token,
+        email=email,
+        max_citing=max_citing,
     )
 
     if json_mode(json_output):

--- a/src/bib2graph/cli/commands/chain.py
+++ b/src/bib2graph/cli/commands/chain.py
@@ -12,6 +12,7 @@ from typing import Any, Literal
 
 import click
 
+from bib2graph.cli._enrich import enrich_corpus
 from bib2graph.cli._envelope import build_envelope, emit, emit_human
 from bib2graph.cli._errors import DataError, DependencyError, UsageError, handle_errors
 from bib2graph.cli._ingest import normalize_and_dedup
@@ -179,6 +180,14 @@ def run_chain(
         ingest_at = datetime.now(UTC)
         merged = corpus.merge(ranked.corpus)
         merged_deduped = normalize_and_dedup(merged, applied_at=ingest_at)
+
+        # Pasada refs→DOI: enriquecer el corpus mergeado+dedup con el mismo source
+        # ya instanciado (forrajeo puro, ADR 0038 §enrich). Automático, sin flag.
+        # El source reutiliza la misma conexión HTTP → sin overhead extra.
+        merged_deduped, enrich_metrics = enrich_corpus(
+            merged_deduped, source, pass_name="refs_doi"
+        )
+
         total_papers = len(merged_deduped)
         merged_backend_close = getattr(merged_deduped._backend, "close", None)
         store.persist_replace(merged_deduped)
@@ -209,6 +218,7 @@ def run_chain(
         "observed_refs_count": len(ranked.observed_refs),
         "loop_state": new_state.value,
         "round": new_round,
+        "enrichment": enrich_metrics,
     }
 
 

--- a/src/bib2graph/cli/commands/enrich.py
+++ b/src/bib2graph/cli/commands/enrich.py
@@ -18,6 +18,7 @@ from typing import Any
 
 import click
 
+from bib2graph.cli._enrich import enrich_corpus
 from bib2graph.cli._envelope import build_envelope, emit, emit_human
 from bib2graph.cli._errors import handle_errors
 from bib2graph.cli._options import json_mode, json_option
@@ -66,45 +67,25 @@ def run_enrich(
             ``@handle_errors`` como exit 4).
         StoreError: Si el store está bloqueado (exit 5).
     """
-    from bib2graph.enrichers.openalex import OpenAlexEnricher
     from bib2graph.sources.openalex import OpenAlexSource
 
     store = open_store(store_path)
     try:
         corpus = store.load()
-
         source = OpenAlexSource(email=email, api_key=api_key, transport=transport)
-        enricher = OpenAlexEnricher(source, max_citing_per_paper=max_citing)
-        enriched = enricher.enrich(corpus)
-
+        enriched, metrics = enrich_corpus(
+            corpus, source, max_citing=max_citing, pass_name="both"
+        )
         store.persist(enriched)
-
-        # Extraer métricas de los EnricherRef registrados
-        enricher_refs = enriched.manifest.enrichers
-
-        doi_entry = next(
-            (e for e in enricher_refs if e.name == "openalex_references_doi"), None
-        )
-        refs_resolved = int(doi_entry.params.get("resolved", 0)) if doi_entry else 0
-        refs_total = (
-            int(doi_entry.params.get("total_unique_refs", 0)) if doi_entry else 0
-        )
-
-        cb_entry = next(
-            (e for e in enricher_refs if e.name == "openalex_cited_by"), None
-        )
-        citing_new = int(cb_entry.params.get("resolved", 0)) if cb_entry else 0
-        citing_targets = int(cb_entry.params.get("total", 0)) if cb_entry else 0
-
         total_papers = len(enriched)
     finally:
         store.close()
 
     return {
-        "refs_resolved": refs_resolved,
-        "refs_total_unique": refs_total,
-        "citing_new": citing_new,
-        "citing_targets": citing_targets,
+        "refs_resolved": metrics.get("refs_resolved", 0),
+        "refs_total_unique": metrics.get("refs_total_unique", 0),
+        "citing_new": metrics.get("citing_new", 0),
+        "citing_targets": metrics.get("citing_targets", 0),
         "total_papers": total_papers,
     }
 

--- a/src/bib2graph/enrichers/openalex.py
+++ b/src/bib2graph/enrichers/openalex.py
@@ -100,19 +100,37 @@ class OpenAlexEnricher:
             y dos ``EnricherRef`` registrados en el Manifest.
         """
         # Pasada 1: references_id → references_doi
-        corpus = self._enrich_references_doi(corpus)
+        corpus = self.enrich_references_doi(corpus)
 
         # Pasada 2: cited_by_id para semillas aceptadas
-        corpus = self._enrich_cited_by(corpus)
+        corpus = self.enrich_cited_by(corpus)
 
         return corpus
 
     # ------------------------------------------------------------------
-    # Pasada 1: references_id → references_doi
+    # Pasada 1: references_id → references_doi (pública para absorción en chain)
     # ------------------------------------------------------------------
 
-    def _enrich_references_doi(self, corpus: Corpus) -> Corpus:
+    def enrich_references_doi(self, corpus: Corpus) -> Corpus:
         """Rellena ``references_doi`` alineado a ``references_id``.
+
+        Pasada 1 del enriquecimiento (Hito 8a). Expuesta como método público
+        para que ``chain`` pueda ejecutarla de forma aislada (sin la pasada
+        de co-citación), usando el mismo helper ``enrich_corpus`` que ``enrich``
+        standalone y ``build``.
+
+        Args:
+            corpus: Corpus de entrada.
+
+        Returns:
+            Corpus con ``references_doi`` rellenado y ``EnricherRef`` registrado.
+        """
+        return self._enrich_references_doi(corpus)
+
+    def _enrich_references_doi(self, corpus: Corpus) -> Corpus:
+        """Implementación interna de la pasada refs→DOI.
+
+        Ver ``enrich_references_doi`` para la documentación pública.
 
         Args:
             corpus: Corpus de entrada.
@@ -157,11 +175,29 @@ class OpenAlexEnricher:
         )
 
     # ------------------------------------------------------------------
-    # Pasada 2: cited_by_id para semillas aceptadas (Hito 8b)
+    # Pasada 2: cited_by_id para semillas aceptadas (Hito 8b, pública para build)
     # ------------------------------------------------------------------
 
-    def _enrich_cited_by(self, corpus: Corpus) -> Corpus:
+    def enrich_cited_by(self, corpus: Corpus) -> Corpus:
         """Puebla ``cited_by_id`` de las semillas aceptadas.
+
+        Pasada 2 del enriquecimiento (Hito 8b). Expuesta como método público
+        para que ``build`` pueda ejecutarla de forma aislada (sin la pasada
+        de refs→DOI), usando el mismo helper ``enrich_corpus`` que ``enrich``
+        standalone y ``chain``.
+
+        Args:
+            corpus: Corpus de entrada.
+
+        Returns:
+            Corpus con ``cited_by_id`` rellenado y ``EnricherRef`` registrado.
+        """
+        return self._enrich_cited_by(corpus)
+
+    def _enrich_cited_by(self, corpus: Corpus) -> Corpus:
+        """Implementación interna de la pasada cited_by.
+
+        Ver ``enrich_cited_by`` para la documentación pública.
 
         Algoritmo:
         1. Filtra las semillas con ``curation_status=accepted`` y ``source_id``

--- a/tests/unit/test_backward_no_placeholders.py
+++ b/tests/unit/test_backward_no_placeholders.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
+import httpx
 import pyarrow as pa
 import pytest
 
@@ -30,6 +31,17 @@ from bib2graph.backends.memory import InMemoryBackend
 from bib2graph.corpus import Corpus
 from bib2graph.foraging.forager import Forager
 from bib2graph.schemas import CORPUS_SCHEMA
+
+# Transport nulo para tests de backward chain: chain.py ejecuta la pasada
+# refs→DOI automáticamente (ADR 0038); los tests que sólo verifican la lógica
+# backward necesitan un transport que devuelva resultados vacíos sin red real.
+_NOOP_TRANSPORT = httpx.MockTransport(
+    lambda _req: httpx.Response(
+        200,
+        json={"results": [], "meta": {"count": 0, "next_cursor": None}},
+        headers={"x-openalex-api-version": "2026-05-01"},
+    )
+)
 
 pytestmark = pytest.mark.unit
 
@@ -401,7 +413,7 @@ class TestRunChainBackwardNoPersistePlaceholders:
         n_before = len(store_before.load())
         store_before.close()
 
-        run_chain(store_path, direction="backward")
+        run_chain(store_path, direction="backward", transport=_NOOP_TRANSPORT)
 
         store_after = DuckDBStore(store_path)
         corpus_after = store_after.load()
@@ -422,7 +434,7 @@ class TestRunChainBackwardNoPersistePlaceholders:
         store_path = tmp_path / "lib.duckdb"
         self._seed_store(store_path, ["REF_A"])
 
-        run_chain(store_path, direction="backward")
+        run_chain(store_path, direction="backward", transport=_NOOP_TRANSPORT)
 
         store = DuckDBStore(store_path)
         rows = store.load().to_arrow().to_pylist()
@@ -442,7 +454,7 @@ class TestRunChainBackwardNoPersistePlaceholders:
         store_path = tmp_path / "lib.duckdb"
         self._seed_store(store_path, ["REF_A", "REF_B"])
 
-        run_chain(store_path, direction="backward")
+        run_chain(store_path, direction="backward", transport=_NOOP_TRANSPORT)
 
         backend = DuckDBBackend(path=store_path)
         refs = set(backend.referenced_refs())
@@ -457,7 +469,7 @@ class TestRunChainBackwardNoPersistePlaceholders:
         store_path = tmp_path / "lib.duckdb"
         self._seed_store(store_path, ["REF_A", "REF_B"])
 
-        result = run_chain(store_path, direction="backward")
+        result = run_chain(store_path, direction="backward", transport=_NOOP_TRANSPORT)
 
         assert "observed_refs_count" in result
         assert result["observed_refs_count"] == 2
@@ -470,8 +482,8 @@ class TestRunChainBackwardNoPersistePlaceholders:
         store_path = tmp_path / "lib.duckdb"
         self._seed_store(store_path, ["REF_A", "REF_B"])
 
-        run_chain(store_path, direction="backward")
-        run_chain(store_path, direction="backward")
+        run_chain(store_path, direction="backward", transport=_NOOP_TRANSPORT)
+        run_chain(store_path, direction="backward", transport=_NOOP_TRANSPORT)
 
         backend = DuckDBBackend(path=store_path)
         count = backend.referenced_refs_count()
@@ -507,7 +519,7 @@ class TestStatusReferencedNotFetched:
         store.backend.set_loop_state(CycleState.SEEDED, cycle_round=1)
         store.close()
 
-        run_chain(store_path, direction="backward")
+        run_chain(store_path, direction="backward", transport=_NOOP_TRANSPORT)
 
         data = run_status(store_path)
 

--- a/tests/unit/test_enrich_absorb.py
+++ b/tests/unit/test_enrich_absorb.py
@@ -1,0 +1,659 @@
+"""Tests TDD — absorción de ``enrich`` en ``chain``/``build`` (ADR 0038, #162).
+
+Cubre las decisiones de implementación del sub-issue #162:
+
+1. ``chain`` ejecuta la pasada refs→DOI automáticamente sobre el corpus
+   mergeado+dedup, ANTES de ``persist_replace``.
+2. ``build`` ejecuta la pasada cited_by automáticamente cuando hay seeds
+   aceptadas, ANTES de proyectar las redes.
+3. ``build`` es no-op (0 requests cited_by) cuando no hay seeds aceptadas;
+   ``data["enrichment"]`` queda vacío ``{}``.
+4. ``enrich`` suelto sigue funcionando idéntico (delega en el helper
+   ``enrich_corpus`` de ``cli._enrich``).
+5. ``data["enrichment"]`` es un bloque ADITIVO en chain y build:
+   nunca rompe el envelope ``schema="1"``.
+6. El helper ``enrich_corpus`` soporta ``pass_name`` inválido con ``ValueError``.
+7. Co-citación: tras ``build`` con seeds aceptadas, ``Networks.quick``
+   produce 5 redes (co-citación incluida).
+
+Todos los tests son ``unit``: usan ``tmp_path`` + ``httpx.MockTransport``
+(sin red real).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pyarrow as pa
+import pytest
+
+from bib2graph.constants import CurationStatus
+from bib2graph.corpus import Corpus
+from bib2graph.schemas import CORPUS_SCHEMA
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Helpers compartidos
+# ---------------------------------------------------------------------------
+
+
+def _row(
+    id: str,
+    *,
+    source_id: str | None = None,
+    is_seed: bool = True,
+    curation_status: str = CurationStatus.CANDIDATE,
+    references_id: list[str] | None = None,
+    cited_by_id: list[str] | None = None,
+    authors_id: list[str] | None = None,
+    institutions_id: list[str] | None = None,
+    keywords_id: list[str] | None = None,
+) -> dict[str, Any]:
+    """Fila mínima compatible con el schema canónico."""
+    return {
+        "id": id,
+        "source_id": source_id,
+        "doi": None,
+        "title": f"Paper {id}",
+        "year": 2020,
+        "abstract": None,
+        "source": None,
+        "language": "en",
+        "publisher": None,
+        "research_areas": None,
+        "is_seed": is_seed,
+        "curation_status": curation_status,
+        "provenance": None,
+        "authors_raw": None,
+        "authors_id": authors_id or ["AUTH_A", "AUTH_B"],
+        "authors_affiliations": None,
+        "keywords_raw": None,
+        "keywords_id": keywords_id or ["KW_1"],
+        "institutions_raw": None,
+        "institutions_id": institutions_id or ["INST_1"],
+        "references_id": references_id,
+        "references_doi": None,
+        "cited_by_id": cited_by_id,
+    }
+
+
+def _corpus_from_rows(rows: list[dict[str, Any]]) -> Corpus:
+    table = pa.Table.from_pylist(rows, schema=CORPUS_SCHEMA)
+    return Corpus.from_arrow(table)
+
+
+def _store_with_corpus(tmp_path: Path, rows: list[dict[str, Any]]) -> Path:
+    """Crea un DuckDBStore temporal con el corpus dado y retorna su ruta."""
+    from bib2graph.stores.duckdb import DuckDBStore
+
+    db_path = tmp_path / "test.duckdb"
+    corpus = _corpus_from_rows(rows)
+    store = DuckDBStore(db_path)
+    store.persist(corpus)
+    store.close()
+    return db_path
+
+
+# ---------------------------------------------------------------------------
+# Mocks HTTP para DOI resolution y cited_by
+# ---------------------------------------------------------------------------
+
+
+def _make_doi_transport(ref_id_to_doi: dict[str, str]) -> httpx.MockTransport:
+    """Transport que responde a ``openalex_id:`` con los DOIs dados."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        url_str = str(request.url)
+        results = []
+        if "openalex_id" in url_str:
+            for short_id, doi in ref_id_to_doi.items():
+                if short_id in url_str:
+                    results.append(
+                        {
+                            "id": f"https://openalex.org/{short_id}",
+                            "doi": f"https://doi.org/{doi}",
+                        }
+                    )
+        body = {
+            "results": results,
+            "meta": {"count": len(results), "next_cursor": None},
+        }
+        return httpx.Response(
+            200,
+            json=body,
+            headers={"x-openalex-api-version": "2026-05-01"},
+        )
+
+    return httpx.MockTransport(handler)
+
+
+def _make_cited_by_transport(
+    citing_works: list[dict[str, Any]],
+) -> httpx.MockTransport:
+    """Transport que responde a ``cites:`` con los works dados."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        url_str = str(request.url)
+        if "cites" in url_str:
+            body = {
+                "results": citing_works,
+                "meta": {"count": len(citing_works), "next_cursor": None},
+            }
+        else:
+            body = {"results": [], "meta": {"count": 0, "next_cursor": None}}
+        return httpx.Response(
+            200,
+            json=body,
+            headers={"x-openalex-api-version": "2026-05-01"},
+        )
+
+    return httpx.MockTransport(handler)
+
+
+def _make_counting_transport(
+    doi_map: dict[str, str] | None = None,
+    citing_works: list[dict[str, Any]] | None = None,
+) -> tuple[httpx.MockTransport, dict[str, list[int]]]:
+    """Transport que cuenta llamadas por tipo y devuelve datos mockeados."""
+    doi_map = doi_map or {}
+    citing_works = citing_works or []
+    counters: dict[str, list[int]] = {"doi": [0], "citing": [0], "other": [0]}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        url_str = str(request.url)
+        if "openalex_id" in url_str:
+            counters["doi"][0] += 1
+            results = [
+                {"id": f"https://openalex.org/{k}", "doi": f"https://doi.org/{v}"}
+                for k, v in doi_map.items()
+                if k in url_str
+            ]
+            body: dict[str, Any] = {
+                "results": results,
+                "meta": {"count": len(results), "next_cursor": None},
+            }
+        elif "cites" in url_str:
+            counters["citing"][0] += 1
+            body = {
+                "results": citing_works,
+                "meta": {"count": len(citing_works), "next_cursor": None},
+            }
+        else:
+            counters["other"][0] += 1
+            body = {"results": [], "meta": {"count": 0, "next_cursor": None}}
+        return httpx.Response(
+            200,
+            json=body,
+            headers={"x-openalex-api-version": "2026-05-01"},
+        )
+
+    return httpx.MockTransport(handler), counters
+
+
+def _citing_work(citer_oa_id: str, cites_ids: list[str]) -> dict[str, Any]:
+    """Work de OpenAlex que cita los seeds dados."""
+    return {
+        "id": f"https://openalex.org/{citer_oa_id}",
+        "doi": None,
+        "title": f"Citante {citer_oa_id}",
+        "display_name": f"Citante {citer_oa_id}",
+        "publication_year": 2023,
+        "language": "en",
+        "abstract_inverted_index": None,
+        "authorships": [],
+        "keywords": [],
+        "referenced_works": [f"https://openalex.org/{oa_id}" for oa_id in cites_ids],
+        "primary_location": None,
+        "type": "article",
+    }
+
+
+# ---------------------------------------------------------------------------
+# 1. chain ejecuta la pasada refs→DOI automáticamente
+# ---------------------------------------------------------------------------
+
+
+def test_chain_resuelve_references_doi(tmp_path: Path) -> None:
+    """``run_chain`` aplica la pasada refs→DOI sobre el corpus mergeado+dedup."""
+    from bib2graph.cli.commands.chain import run_chain
+    from bib2graph.stores.duckdb import DuckDBStore
+
+    # Corpus con una semilla que tiene references_id pero references_doi vacío
+    rows = [_row("P1", references_id=["W1111"], is_seed=True)]
+    db_path = _store_with_corpus(tmp_path, rows)
+
+    # Mock: W1111 → DOI 10.1000/test
+    transport, counters = _make_counting_transport(doi_map={"W1111": "10.1000/test"})
+    run_chain(db_path, direction="backward", transport=transport)
+
+    # Verificar que references_doi se pobló
+    store = DuckDBStore(db_path)
+    corpus = store.load()
+    table = corpus.to_arrow()  # leer ANTES de cerrar la conexión DuckDB
+    store.close()
+    refs_doi = table.column("references_doi").to_pylist()[0]
+
+    assert refs_doi is not None, "references_doi debe estar poblado"
+    assert "10.1000/test" in refs_doi, f"DOI esperado no encontrado: {refs_doi}"
+    # Se hizo al menos una request de DOI resolution
+    assert counters["doi"][0] >= 1, "Debe haber llamadas de resolución DOI"
+
+
+def test_chain_data_tiene_bloque_enrichment(tmp_path: Path) -> None:
+    """``run_chain`` retorna ``data['enrichment']`` con métricas de refs→DOI."""
+    from bib2graph.cli.commands.chain import run_chain
+
+    rows = [_row("P1", references_id=["W1111"], is_seed=True)]
+    db_path = _store_with_corpus(tmp_path, rows)
+
+    transport = _make_doi_transport({"W1111": "10.1000/test"})
+    data = run_chain(db_path, direction="backward", transport=transport)
+
+    assert "enrichment" in data, "data debe tener clave 'enrichment'"
+    enrichment = data["enrichment"]
+    assert isinstance(enrichment, dict), "enrichment debe ser un dict"
+    assert "refs_resolved" in enrichment, "enrichment debe tener 'refs_resolved'"
+    assert "refs_total_unique" in enrichment, (
+        "enrichment debe tener 'refs_total_unique'"
+    )
+    assert enrichment["refs_resolved"] == 1
+    assert enrichment["refs_total_unique"] == 1
+
+
+def test_chain_sin_referencias_enrichment_cero(tmp_path: Path) -> None:
+    """``run_chain`` con corpus sin referencias retorna enrichment con 0."""
+    from bib2graph.cli.commands.chain import run_chain
+
+    rows = [_row("P1", references_id=None)]
+    db_path = _store_with_corpus(tmp_path, rows)
+
+    transport, counters = _make_counting_transport()
+    data = run_chain(db_path, direction="backward", transport=transport)
+
+    assert data["enrichment"].get("refs_resolved", 0) == 0
+    assert counters["doi"][0] == 0, "Sin referencias no debe hacer requests DOI"
+
+
+# ---------------------------------------------------------------------------
+# 2. build ejecuta la pasada cited_by cuando hay seeds aceptadas
+# ---------------------------------------------------------------------------
+
+
+def test_build_dispara_cited_by_con_seeds_aceptadas(tmp_path: Path) -> None:
+    """``run_build`` corre cited_by y popula co-citación cuando hay seeds aceptadas."""
+    from bib2graph.cli.commands.build import run_build
+
+    # 2 seeds aceptadas con source_id
+    rows = [
+        _row(
+            "P1",
+            source_id="W100",
+            is_seed=True,
+            curation_status=CurationStatus.ACCEPTED,
+        ),
+        _row(
+            "P2",
+            source_id="W200",
+            is_seed=True,
+            curation_status=CurationStatus.ACCEPTED,
+        ),
+    ]
+    db_path = _store_with_corpus(tmp_path, rows)
+    out_dir = tmp_path / "networks"
+
+    # Mock: C1 cita a W100 y W200 → co-citación
+    citing = [_citing_work("C1", ["W100", "W200"])]
+    transport, counters = _make_counting_transport(citing_works=citing)
+
+    data = run_build(db_path, out_dir=out_dir, transport=transport)
+
+    # Se hicieron requests de cited_by
+    assert counters["citing"][0] >= 1, "Debe haber requests cited_by"
+    # El enrichment block está presente
+    assert "enrichment" in data
+    assert data["enrichment"].get("citing_new", 0) >= 1
+    assert data["enrichment"].get("citing_targets", 0) == 2
+
+
+def test_build_co_citacion_en_redes_tras_cited_by(tmp_path: Path) -> None:
+    """Tras la pasada cited_by en build, Networks.quick produce co-citación."""
+    from bib2graph.cli.commands.build import run_build
+
+    rows = [
+        _row(
+            "P1",
+            source_id="W100",
+            is_seed=True,
+            curation_status=CurationStatus.ACCEPTED,
+        ),
+        _row(
+            "P2",
+            source_id="W200",
+            is_seed=True,
+            curation_status=CurationStatus.ACCEPTED,
+        ),
+    ]
+    db_path = _store_with_corpus(tmp_path, rows)
+    out_dir = tmp_path / "networks"
+
+    citing = [_citing_work("C1", ["W100", "W200"])]
+    transport = _make_cited_by_transport(citing)
+
+    data = run_build(db_path, out_dir=out_dir, transport=transport)
+
+    kinds = {n["kind"] for n in data["networks"]}
+    assert "cocitation" in kinds, (
+        f"Co-citación debe estar en redes tras cited_by. Redes: {kinds}"
+    )
+    assert data["networks_built"] == 5, (
+        f"Deben ser 5 redes con co-citación. Fueron: {data['networks_built']}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3. build es no-op (sin requests) cuando no hay seeds aceptadas
+# ---------------------------------------------------------------------------
+
+
+def test_build_noop_sin_seeds_aceptadas(tmp_path: Path) -> None:
+    """``run_build`` no hace requests cited_by cuando no hay seeds aceptadas."""
+    from bib2graph.cli.commands.build import run_build
+
+    # Solo candidatos — sin seeds aceptadas
+    rows = [
+        _row("P1", is_seed=True, curation_status=CurationStatus.CANDIDATE),
+        _row("P2", is_seed=True, curation_status=CurationStatus.CANDIDATE),
+    ]
+    db_path = _store_with_corpus(tmp_path, rows)
+    out_dir = tmp_path / "networks"
+
+    transport, counters = _make_counting_transport()
+    data = run_build(db_path, out_dir=out_dir, transport=transport)
+
+    # Sin seeds aceptadas → 0 requests de cited_by
+    assert counters["citing"][0] == 0, (
+        f"Sin seeds aceptadas no debe hacer requests cited_by; "
+        f"hizo {counters['citing'][0]}"
+    )
+    # El enrichment block existe pero está vacío
+    assert "enrichment" in data
+    assert data["enrichment"] == {}, (
+        f"Sin seeds aceptadas, enrichment debe ser vacío: {data['enrichment']}"
+    )
+
+
+def test_build_4_redes_sin_seeds_aceptadas(tmp_path: Path) -> None:
+    """Sin seeds aceptadas build produce 4 redes (sin co-citación) y exit 0."""
+    from bib2graph.cli.commands.build import run_build
+
+    rows = [
+        _row(
+            f"P{i}",
+            is_seed=True,
+            curation_status=CurationStatus.CANDIDATE,
+            authors_id=[f"AUTH_{i}", "AUTH_SHARED"],
+            keywords_id=[f"KW_{i}", "KW_SHARED"],
+            institutions_id=[f"INST_{i}"],
+            references_id=[f"REF_{i}", "REF_SHARED"],
+        )
+        for i in range(3)
+    ]
+    db_path = _store_with_corpus(tmp_path, rows)
+    out_dir = tmp_path / "networks"
+
+    transport, counters = _make_counting_transport()
+    data = run_build(db_path, out_dir=out_dir, transport=transport)
+
+    assert counters["citing"][0] == 0
+    kinds = {n["kind"] for n in data["networks"]}
+    assert "cocitation" not in kinds, "Sin cited_by_id no debe haber co-citación"
+    # 4 redes base (bibliographic_coupling, coauthorship, cooccurrence, keyword)
+    assert len(data["networks"]) == 4 or data["networks_built"] == 4, (
+        f"Sin co-citación deben ser 4 redes; fueron {data['networks_built']}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 4. enrich suelto sigue funcionando idéntico
+# ---------------------------------------------------------------------------
+
+
+def test_enrich_suelto_sigue_funcionando(tmp_path: Path) -> None:
+    """``run_enrich`` (alias) delega en el helper y produce el mismo resultado."""
+    from bib2graph.cli.commands.enrich import run_enrich
+
+    rows = [
+        _row(
+            "P1",
+            source_id="W100",
+            is_seed=True,
+            curation_status=CurationStatus.ACCEPTED,
+            references_id=["W999"],
+        )
+    ]
+    db_path = _store_with_corpus(tmp_path, rows)
+
+    citing = [_citing_work("C1", ["W100"])]
+    transport, _ = _make_counting_transport(
+        doi_map={"W999": "10.1000/ref"},
+        citing_works=citing,
+    )
+
+    data = run_enrich(db_path, transport=transport)
+
+    # Claves estables del contrato original
+    assert "refs_resolved" in data
+    assert "refs_total_unique" in data
+    assert "citing_new" in data
+    assert "citing_targets" in data
+    assert "total_papers" in data
+    assert isinstance(data["refs_resolved"], int)
+    assert isinstance(data["total_papers"], int)
+
+
+def test_enrich_suelto_claves_numericas(tmp_path: Path) -> None:
+    """``run_enrich`` retorna exactamente las 5 claves requeridas (contrato original)."""
+    from bib2graph.cli.commands.enrich import run_enrich
+    from bib2graph.stores.duckdb import DuckDBStore
+
+    rows = [_row("P1", references_id=["W111"])]
+    db_path = tmp_path / "e.duckdb"
+    store = DuckDBStore(db_path)
+    store.persist(_corpus_from_rows(rows))
+    store.close()
+
+    transport = _make_doi_transport({"W111": "10.1000/xyz"})
+    data = run_enrich(db_path, transport=transport)
+
+    required = {
+        "refs_resolved",
+        "refs_total_unique",
+        "citing_new",
+        "citing_targets",
+        "total_papers",
+    }
+    assert required.issubset(data.keys()), (
+        f"Faltan claves en data: {required - set(data.keys())}"
+    )
+    assert data["total_papers"] == 1
+    assert data["refs_resolved"] == 1
+    assert data["refs_total_unique"] == 1
+    assert data["citing_new"] == 0  # sin seeds aceptadas → 0
+    assert data["citing_targets"] == 0
+
+
+# ---------------------------------------------------------------------------
+# 5. data["enrichment"] es aditivo y no rompe schema="1"
+# ---------------------------------------------------------------------------
+
+
+def test_chain_enrichment_no_rompe_schema(tmp_path: Path) -> None:
+    """``data['enrichment']`` es un dict plano y no cambia el envelope schema."""
+    from bib2graph.cli._envelope import build_envelope
+    from bib2graph.cli.commands.chain import run_chain
+
+    rows = [_row("P1", references_id=["W1111"])]
+    db_path = _store_with_corpus(tmp_path, rows)
+
+    transport = _make_doi_transport({"W1111": "10.1000/test"})
+    data = run_chain(db_path, direction="backward", transport=transport)
+
+    envelope = build_envelope(command="chain", ok=True, data=data, exit_code=0)
+    assert envelope["schema"] == "1", f"schema debe ser '1', es '{envelope['schema']}'"
+    assert isinstance(data["enrichment"], dict)
+
+
+def test_build_enrichment_no_rompe_schema(tmp_path: Path) -> None:
+    """``data['enrichment']`` en build es un dict plano; schema='1' intacto."""
+    from bib2graph.cli._envelope import build_envelope
+    from bib2graph.cli.commands.build import run_build
+
+    rows = [_row("P1", is_seed=True, curation_status=CurationStatus.CANDIDATE)]
+    db_path = _store_with_corpus(tmp_path, rows)
+    out_dir = tmp_path / "networks"
+
+    transport, _ = _make_counting_transport()
+    data = run_build(db_path, out_dir=out_dir, transport=transport)
+
+    envelope = build_envelope(command="build", ok=True, data=data, exit_code=0)
+    assert envelope["schema"] == "1"
+    assert "enrichment" in data
+    assert isinstance(data["enrichment"], dict)
+
+
+# ---------------------------------------------------------------------------
+# 6. Helper enrich_corpus: pass_name inválido → ValueError
+# ---------------------------------------------------------------------------
+
+
+def test_enrich_corpus_pass_name_invalido() -> None:
+    """``enrich_corpus`` con ``pass_name`` desconocido lanza ``ValueError``."""
+    from bib2graph.cli._enrich import enrich_corpus
+    from bib2graph.sources.openalex import OpenAlexSource
+
+    corpus = _corpus_from_rows([_row("P1")])
+    source = OpenAlexSource()
+
+    with pytest.raises(ValueError, match="pass_name desconocido"):
+        enrich_corpus(corpus, source, pass_name="invalid_pass")
+
+
+# ---------------------------------------------------------------------------
+# 7. Helper enrich_corpus: métricas correctas por pasada
+# ---------------------------------------------------------------------------
+
+
+def test_enrich_corpus_refs_doi_solo() -> None:
+    """``enrich_corpus(pass_name='refs_doi')`` retorna métricas de refs→DOI."""
+    from bib2graph.cli._enrich import enrich_corpus
+    from bib2graph.sources.openalex import OpenAlexSource
+
+    corpus = _corpus_from_rows([_row("P1", references_id=["W111"])])
+    transport = _make_doi_transport({"W111": "10.1000/x"})
+    source = OpenAlexSource(transport=transport)
+
+    enriched, metrics = enrich_corpus(corpus, source, pass_name="refs_doi")
+
+    assert "refs_resolved" in metrics
+    assert "refs_total_unique" in metrics
+    # cited_by keys no deben estar si no se ejecutó esa pasada
+    assert "citing_new" not in metrics
+    assert "citing_targets" not in metrics
+    # Corpus gana el DOI
+    refs_doi = enriched.to_arrow().column("references_doi").to_pylist()[0]
+    assert refs_doi is not None
+    assert "10.1000/x" in refs_doi
+
+
+def test_enrich_corpus_cited_by_solo() -> None:
+    """``enrich_corpus(pass_name='cited_by')`` retorna métricas de cited_by."""
+    from bib2graph.cli._enrich import enrich_corpus
+    from bib2graph.sources.openalex import OpenAlexSource
+
+    corpus = _corpus_from_rows(
+        [_row("P1", source_id="W100", curation_status=CurationStatus.ACCEPTED)]
+    )
+    citing = [_citing_work("C1", ["W100"])]
+    transport = _make_cited_by_transport(citing)
+    source = OpenAlexSource(transport=transport)
+
+    enriched, metrics = enrich_corpus(corpus, source, pass_name="cited_by")
+
+    assert "citing_new" in metrics
+    assert "citing_targets" in metrics
+    # refs_doi keys no deben estar si no se ejecutó esa pasada
+    assert "refs_resolved" not in metrics
+    # Corpus gana el citante
+    cited_by = enriched.to_arrow().column("cited_by_id").to_pylist()[0]
+    assert cited_by is not None
+    assert "C1" in cited_by
+
+
+def test_enrich_corpus_both_tiene_todas_las_claves() -> None:
+    """``enrich_corpus(pass_name='both')`` retorna todas las métricas."""
+    from bib2graph.cli._enrich import enrich_corpus
+    from bib2graph.sources.openalex import OpenAlexSource
+
+    corpus = _corpus_from_rows(
+        [
+            _row(
+                "P1",
+                source_id="W100",
+                curation_status=CurationStatus.ACCEPTED,
+                references_id=["W999"],
+            )
+        ]
+    )
+    citing = [_citing_work("C1", ["W100"])]
+    transport, _ = _make_counting_transport(
+        doi_map={"W999": "10.1000/ref"}, citing_works=citing
+    )
+    source = OpenAlexSource(transport=transport)
+
+    _enriched, metrics = enrich_corpus(corpus, source, pass_name="both")
+
+    assert "refs_resolved" in metrics
+    assert "refs_total_unique" in metrics
+    assert "citing_new" in metrics
+    assert "citing_targets" in metrics
+
+
+# ---------------------------------------------------------------------------
+# 8. build: max_citing controla el tope de citantes por seed
+# ---------------------------------------------------------------------------
+
+
+def test_build_max_citing_limita_citantes(tmp_path: Path) -> None:
+    """``run_build(max_citing=1)`` limita cited_by_id a 1 citante por seed."""
+    from bib2graph.cli.commands.build import run_build
+    from bib2graph.stores.duckdb import DuckDBStore
+
+    rows = [
+        _row(
+            "P1",
+            source_id="W100",
+            is_seed=True,
+            curation_status=CurationStatus.ACCEPTED,
+        )
+    ]
+    db_path = _store_with_corpus(tmp_path, rows)
+    out_dir = tmp_path / "networks"
+
+    # 5 citantes de W100
+    citing = [_citing_work(f"C{i}", ["W100"]) for i in range(1, 6)]
+    transport = _make_cited_by_transport(citing)
+
+    run_build(db_path, out_dir=out_dir, transport=transport, max_citing=1)
+
+    # Verificar que cited_by_id tiene ≤ 1 elemento
+    store = DuckDBStore(db_path)
+    corpus = store.load()
+    rows_out = corpus.to_arrow().to_pylist()  # leer ANTES de cerrar
+    store.close()
+    p1 = next(r for r in rows_out if r["id"] == "P1")
+    cited = p1.get("cited_by_id") or []
+    assert len(cited) <= 1, f"max_citing=1 debe limitar a ≤1 citante; hay {len(cited)}"


### PR DESCRIPTION
Closes #162. Sub-issue del epic #167 (ADR 0038/0025).

## Qué
- **enrich absorbido en el ciclo:** pasada **refs→DOI en `chain`** (automática, tras normalize+dedup), pasada **cited_by en `build`** (automática SOLO si hay seeds aceptadas; **no-op graceful** si no → 4 redes vs 5).
- **Fuente única** `cli/_enrich.py:enrich_corpus(corpus, source, *, max_citing, pass_name)` opera sobre el corpus en memoria dentro de la transacción (sin doble-abrir el store); `pass_name ∈ {refs_doi, cited_by, both}`; métricas sparse.
- `enrichers/openalex.py` expone `enrich_references_doi`/`enrich_cited_by` (Protocol preservado). **`enrich` suelto INTACTO** pero delega en `enrich_corpus` (su retiro es #165). Sin flag `--enrich`.
- Métricas aditivas `data["enrichment"]`. `build` suma opciones `email`/`--max-citing`.

## ⚠️ build-puro (ADR 0025)
`build` ahora hace requests de red cuando hay seeds aceptadas → **rompe el invariante "build puro" del ADR 0025** (decisión PO). La **enmienda al ADR 0025** se consolida en #166. Sin aceptadas: cero requests (verificado).

## Tests
`tests/unit/test_enrich_absorb.py` (16 tests): 2 pasadas, no-op sin aceptadas, enrich-suelto (5 keys), sparse, pass_name inválido, max_citing. Verifier: **PASA** (no-op sin requests, fuente única, FSM intacto confirmados). Gate verde: ruff+mypy limpios, 1185 passed.

## Docs
Contrato (enrich absorbido + enmienda ADR 0025) se consolida en **#166**. NO toca el FSM (ENRICHED no existe).

## Invariante
Envelope `schema="1"`, exit codes intactos; `data["enrichment"]` aditivo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
