### PR TITLE
chore(proceso): bakear lecciones del epic 0.10.0 + comando /retro-ciclo

### DIFF
--- a/.claude/agents/coder.md
+++ b/.claude/agents/coder.md
@@ -34,10 +34,23 @@ todo verificable: otro agente (`verifier`) va a auditar tu diff.
 - Lee `docs/API.md` (contrato), `docs/ARCHITECTURE.md` y el `docs/ROADMAP/` del hito antes de
   escribir lógica nueva.
 
-## El gate (corrélo, reportá la salida real)
-```
-uv run ruff check . && uv run ruff format --check . && uv run mypy src && uv run pytest
-```
+## Testing: iterá con el subconjunto, dejá el suite completo para el cierre
+El suite completo (`uv run pytest`) tarda **~4-8 min en esta máquina** — NO lo uses como bucle de
+feedback. (Lección del epic #167: correr el suite entero para triagear un fallo de UN archivo fue
+**~la mitad** del tiempo perdido de los coders.)
+
+- **En el loop:** corré SOLO los tests pertinentes a lo que tocás —
+  `uv run pytest tests/unit/test_X.py::TestY --tb=short` (7-60 s). Si un test falla, re-corré **ese
+  node id**, no el suite entero con flags distintos.
+- **Antes de chequear formato/lint:** auto-formateá primero —
+  `uv run ruff format . && uv run ruff check --fix .` — y recién después `ruff check`/`format --check`.
+  Evita el gate/CI rojo **solo por formato**.
+- **Cierre (una sola vez):** `uv run ruff check . && uv run ruff format --check . && uv run mypy src`
+  + `uv run pytest` acotado a los archivos/áreas que tocaste. El **suite completo lo corren el
+  `verifier` y el CI** — no necesitás repetirlo en loop; reportá qué subconjunto corriste.
+- **Timeout:** poné `timeout` ≥ 600000 ms en cualquier corrida larga de pytest (el default de 2 min
+  mata el suite completo).
+
 Markers: `unit` (default, sin red), `integration` (DuckDB/red, en el gate), `network` (API real
 de OpenAlex, **fuera** del gate — `-m "not network"`). TDD selectivo: test antes del código en
 el núcleo; no testees wrappers finos ni plumbing de Click.

--- a/.claude/agents/verifier.md
+++ b/.claude/agents/verifier.md
@@ -13,12 +13,15 @@ Sos el **verificador** de bib2graph. Revisás el trabajo del `coder` con ojo adv
 tenés Write/Edit a propósito:** tu única salida es un veredicto honesto y hallazgos accionables.
 Si algo está mal, lo marcás — no lo arreglás (arreglar destruiría tu independencia).
 
-## El gate (corrélo, pegá la salida real)
+## El gate (corrélo COMPLETO, pegá la salida real)
 ```
 uv run ruff check . && uv run ruff format --check . && uv run mypy src && uv run pytest
 ```
-Markers: `unit` (sin red), `integration` (DuckDB/red, en el gate), `network` (API real, **fuera**
-del gate — no lo exijas). `git diff`/`git status` para ver el cambio.
+**Vos sos el dueño del gate completo.** El `coder` itera con **subconjuntos** de tests (el suite
+entero tarda ~6 min), así que tu corrida del **suite completo** es la red de seguridad real — corrélo
+entero siempre, con `timeout` ≥ 600000 ms. Si tarda más que el límite, corré por lotes pero **cubrí
+todo** y reportá honesto qué corriste. Markers: `unit` (sin red), `integration` (DuckDB/red, en el
+gate), `network` (API real, **fuera** del gate — no lo exijas). `git diff`/`git status` para ver el cambio.
 
 ## Qué revisás (default a la sospecha)
 1. **Correctitud:** ¿hace lo que la tarea pedía? ¿bugs, casos borde, regresiones? Buscá por qué

--- a/.claude/commands/retro-ciclo.md
+++ b/.claude/commands/retro-ciclo.md
@@ -1,0 +1,71 @@
+---
+description: >-
+  Retrospectiva metacognitiva de fin de ciclo — mide dónde se fue el tiempo (examina
+  los transcripts de los subagentes), reflexiona sobre la estrategia y APLICA mejoras al
+  proceso (.claude/agents/, AGENTS.md, hooks). Usala al cerrar un epic, un feature-cycle
+  grande, un release o una sesión con mucho fan-out. Cierra el lazo de aprendizaje.
+argument-hint: "[qué ciclo cerrás: epic #N / release / sesión]"
+---
+
+# /retro-ciclo — retrospectiva del proceso de los agentes
+
+Sos el **orquestador/tech-lead**. Acaba de cerrarse un ciclo de trabajo
+($ARGUMENTS). Corré la retrospectiva **del proceso de los agentes** (no del producto:
+eso es `/cosechar-sesion`) para responder con DATOS: *¿qué nos tardó más? ¿la forma de
+trabajar fue la correcta? ¿en qué falla hoy y cómo lo mejoramos?* — y dejar el proceso
+mejor que como lo encontraste.
+
+## Procedimiento
+
+1. **Medí — datos duros, no impresiones.** Los transcripts de los subagentes de esta
+   sesión están como JSONL en el task dir (`…/tasks/<agentId>.output`). **NO los leas
+   enteros** (overflow). Despachá un subagente `general-purpose` que los procese con
+   Bash/python línea por línea y devuelva **métricas, no dumps**:
+   - Wall-clock por agente (`duration_ms` de las notificaciones) y por rol
+     (coder/verifier/architect).
+   - Para los coders más lentos: #Bash/#Edit/#Read; **cuántas veces corrió el suite
+     completo de pytest vs subconjuntos**; ruff/mypy/uv sync; y **qué fracción del tiempo
+     fue esperando tests** (gaps tras `pytest`).
+   - Reintentos, loops editar→test→fallar, errores de formato/CRLF/encoding, timeouts,
+     conflictos de merge, y **trabajo perdido/rehecho** (p.ej. agentes que escribieron en
+     el worktree equivocado).
+   - **Avisá si faltan transcripts** (vacíos / no capturados): punto ciego de auditoría.
+
+2. **Reflexioná — honesto, incluí tus propios errores de orquestación.**
+   - ¿Cuál fue el cuello de botella dominante? Cuantificalo.
+   - ¿La estrategia fue la correcta? ¿hubo cambio (p.ej. secuencial→paralelo) y valió la
+     pena? ¿qué fricción introdujo?
+   - Separá **desperdicio** de **inversión valiosa** (el rework que nace de un verifier que
+     cazó un bug real NO es desperdicio).
+   - Clasificá las lecciones: (a) generales, (b) específicas del repo (suite lento,
+     archivos calientes como `build.py`/`cli/__init__.py`), (c) errores puntuales de la sesión.
+
+3. **Traé el veredicto al PO y esperá su OK.** Top 3 cuellos de botella con evidencia +
+   3-5 mejoras accionables. No cambies el proceso sin confirmar el rumbo.
+
+4. **Aplicá las mejoras DONDE VIVEN** (una retro que no cambia nada es un informe, no una
+   mejora):
+   - **Comportamiento de un rol** (cómo testea el coder, qué corre el verifier) →
+     `.claude/agents/<rol>.md`.
+   - **Convención de orquestación** (paralelizar con prudencia, worktrees, batchear
+     decisiones) → `AGENTS.md` §"Ejecución concurrente y testing".
+   - **Mapa/fases del flujo** → la skill `flujo`.
+   - **Guardarraíl** que conviene volver imposible de violar → `.claude/hooks/`.
+   - Va por **PR a `dev`** (`chore(proceso): …`), porque `.claude/agents/`,
+     `.claude/commands/` y `AGENTS.md` están versionados.
+
+5. **Cerrá con seguimientos.** Lo que no se baka ahora → issue (no nota suelta). Si una
+   lección amerita decisión de fondo → ADR vía `/graduar-adr`.
+
+## No-negociables
+- **Datos antes de opinar.** Cuantificá el cuello de botella.
+- **Honestidad sobre los errores de orquestación** — la fuente más rica de mejora.
+- **La retro debe cambiar algo** (bakear ≥1 lección o abrir seguimiento), o no terminó.
+- No leas transcripts enteros en tu contexto; delegá la medición.
+
+## Lecciones ya bakeadas (extender, no re-litigar)
+- **Epic 0.10.0 / #167:** el suite completo de pytest (~6 min) usado como bucle de
+  feedback fue ~50% del tiempo de los coders → testing por capas (coder con subconjunto;
+  verifier+CI con el suite) en `.claude/agents/coder.md` y `verifier.md`. Paralelizar solo
+  archivos disjuntos; los agentes escriben en el worktree de la sesión, no en la ruta del
+  prompt → `AGENTS.md` §"Ejecución concurrente y testing".

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -325,8 +325,12 @@ una idea; el commit/PR sigue Conventional Commits (abajo); no bumpear versión n
 
 El repo versiona su propia config de Claude Code para que **el equipo herede los roles y los
 guardarraíles** al clonar (project-level **gana** sobre la config de usuario). Se versiona
-`.claude/settings.json` + `.claude/agents/` + `.claude/hooks/`; queda ignorado el estado local
-(`settings.local.json`, `worktrees/`, `System_prompt.md`).
+`.claude/settings.json` + `.claude/agents/` + `.claude/hooks/` + `.claude/commands/`; queda ignorado
+el estado local (`settings.local.json`, `worktrees/`, `System_prompt.md`).
+
+**Comandos de proyecto** (`.claude/commands/*.md`, slash commands del equipo): `/retro-ciclo` —
+retrospectiva metacognitiva de fin de ciclo que mide dónde se fue el tiempo y **baka las lecciones**
+en el proceso (ver §"Ejecución concurrente y testing").
 
 **Subagentes** (`.claude/agents/*.md`), afinados a bib2graph y con **una frontera dura por rol**
 ("cada uno es responsable de sus artefactos"):
@@ -353,6 +357,28 @@ bypass**, son más fuertes que los permisos). Se invocan con `uv run --no-sync -
 su frontmatter no toma efecto hasta reiniciar). Los **hooks de `settings.json` sí recargan en
 caliente**. Si un guardarraíl bloquea algo legítimo, se afloja editando el script en
 `.claude/hooks/`.
+
+### Ejecución concurrente y testing — lecciones del epic 0.10.0 (#167)
+
+Destiladas del giro de superficie 0.10.0 (medición forense: **~50% del tiempo de cada `coder` se
+fue esperando el suite completo de tests**). Las captura y actualiza el comando **`/retro-ciclo`**
+(`.claude/commands/`) al cerrar cada ciclo.
+
+- **Testing por capas.** El `coder` itera con **tests pertinentes** (`pytest test_X.py::test_Y`,
+  7-60 s) y auto-formatea (`ruff format` + `ruff check --fix`) antes de gatear; el **gate completo
+  (`pytest` entero, ~6 min) lo corren el `verifier` y el CI**, no el coder en loop. Elimina una de
+  las 3 corridas redundantes del suite por sub-issue.
+- **Paralelizar con prudencia (archivos disjuntos).** Fan-out de varios sub-issues a la vez **solo
+  si tocan archivos disjuntos**. Ramas que comparten un archivo caliente (`build.py`,
+  `cli/__init__.py`) → **serializar** (mergear una, rebasar la siguiente) para no pagar el baile de
+  conflictos. Batchear los encuadres y resolver las decisiones del PO en **una sola ronda** es
+  ganancia neta sin riesgo.
+- **Confiabilidad de worktrees.** Los `Edit`/`Write` de un subagente se aíslan al worktree de la
+  **sesión**, no a la ruta que se le pase en el prompt. Para trabajo sobre una rama: tenerla
+  **checked out en el worktree de la sesión** (o recuperar el trabajo vía `git diff`/patch). No
+  asumir que el agente escribe en la ruta del prompt.
+- **Windows:** evitar rutas con acentos en Git Bash (rompe el quoting); preferir PowerShell para
+  operaciones de filesystem. Reservar Bash para comandos POSIX simples.
 
 ## Comandos de build / lint / test
 


### PR DESCRIPTION
Incorpora al proceso de agentes la retroalimentación del giro de superficie 0.10.0 (#167). Medición forense: **~50% del tiempo de cada `coder` se fue esperando el suite completo de tests**.

## Cambios
- **`.claude/agents/coder.md`** — testing por capas: iterar con **tests pertinentes** (`pytest test_X::test_Y`, 7-60 s), **auto-formatear** antes de gatear, dejar el **suite completo al verifier+CI**, `timeout` alto en corridas largas.
- **`.claude/agents/verifier.md`** — el verifier es **dueño del gate completo** (red de seguridad mientras el coder itera con subconjuntos).
- **`AGENTS.md` §"Ejecución concurrente y testing"** — paralelizar **solo ramas con archivos disjuntos** (serializar las que comparten `build.py`/`cli/__init__.py`); los `Edit`/`Write` de un subagente se **aíslan al worktree de la sesión** (no a la ruta del prompt); batchear decisiones del PO; evitar rutas con acentos en Git Bash.
- **`.claude/commands/retro-ciclo.md`** — nuevo comando **`/retro-ciclo`**: retrospectiva metacognitiva de fin de ciclo que **mide con datos** (delega el análisis de transcripts a un subagente), reflexiona sobre la estrategia y **bakea las lecciones donde viven**. Cierra el lazo de aprendizaje (autorreferencial: este PR es su primer output).

## Por qué
Una retro que no cambia nada es un informe. Esto convierte el aprendizaje en proceso ejecutable y repetible al final de cada ciclo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
