### PR TITLE
test: poda de la suite — epic #184 (consolidación + retiro de duplicados)

### DIFF
--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -440,35 +440,8 @@ def test_post_curate_decision_invalida_422(tmp_path: Path) -> None:
     assert body["exit_code"] == 2
 
 
-# ---------------------------------------------------------------------------
-# 6. Neutralidad — el núcleo no importa fastapi
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.unit
-def test_nucleo_no_importa_fastapi() -> None:
-    """Importar bib2graph.service no requiere fastapi instalado."""
-    import ast
-    import importlib
-    import pathlib
-
-    # Verificar que service/__init__.py no importa fastapi en top-level
-    mod = importlib.import_module("bib2graph.service")
-    source_file = mod.__file__
-    assert source_file is not None
-    tree = ast.parse(pathlib.Path(source_file).read_text(encoding="utf-8"))
-
-    forbidden = {"fastapi"}
-    for node in ast.walk(tree):
-        if isinstance(node, ast.Import):
-            for alias in node.names:
-                assert alias.name.split(".")[0] not in forbidden, (
-                    f"service importa '{alias.name}' — viola neutralidad"
-                )
-        elif isinstance(node, ast.ImportFrom):
-            assert (node.module or "").split(".")[0] not in forbidden, (
-                f"service importa de '{node.module}' — viola neutralidad"
-            )
+# Neutralidad del núcleo (service no importa fastapi): consolidada en
+# test_service.py::test_service_modulo_neutral_de_transporte (epic #184).
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_build_absorber_networks.py
+++ b/tests/unit/test_build_absorber_networks.py
@@ -664,33 +664,10 @@ class TestNoDivergencia:
 class TestJsonOutput:
     """--json: stdout una línea JSON, warnings en envelope, data.empty_networks."""
 
-    def test_json_stdout_una_sola_linea(self, tmp_path: Path) -> None:
-        """--json: stdout es exactamente 1 línea JSON (stdout puro, ADR 0021 §C)."""
-        from click.testing import CliRunner
-
-        from bib2graph.cli import b2g
-        from bib2graph.workspace import Workspace
-
-        ws_dir = tmp_path / "ws"
-        ws = Workspace.init(ws_dir, "test")
-        _seed_store(ws.library_path, _rows_con_referencias())
-
-        runner = CliRunner()
-        result = runner.invoke(
-            b2g,
-            ["--workspace", str(ws_dir), "build", "--json"],
-        )
-
-        assert result.exit_code == 0, f"Error: {result.output}"
-        # result.stdout = solo stdout (Click 8.4.1 separa stdout/stderr).
-        # En modo --json no hay prints a stderr (warnings van en envelope.warnings).
-        stdout_lines = [line for line in result.stdout.splitlines() if line.strip()]
-        assert len(stdout_lines) == 1, (
-            f"stdout debe tener exactamente 1 línea JSON, tiene {len(stdout_lines)}: "
-            f"{result.stdout!r}"
-        )
-        # Debe ser JSON válido
-        json.loads(stdout_lines[0])
+    # stdout de 1 línea JSON (camino de éxito) lo cubre
+    # test_json_warnings_en_envelope_no_en_stdout (asserta len==1 + colocación de
+    # warnings); el camino de error lo cubre el guard de test_cli_json_option
+    # (build en _CMDS_NO_WORKSPACE). Epic #184, sub-tarea 2.
 
     def test_json_schema_1(self, tmp_path: Path) -> None:
         """--json: envelope tiene schema='1'."""

--- a/tests/unit/test_cli_read.py
+++ b/tests/unit/test_cli_read.py
@@ -947,57 +947,8 @@ def test_cli_read_sin_subcomando_imprime_ayuda() -> None:
     assert "show" in result.output
 
 
-# ---------------------------------------------------------------------------
-# 9. stdout puro — una sola línea JSON
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.unit
-def test_cli_read_list_stdout_una_linea_json(tmp_path: Path) -> None:
-    """read list --json: stdout es exactamente una línea no-vacía."""
-    ws = _init_workspace(tmp_path)
-    _seed_store(ws, [_row(id="P1")])
-
-    runner = CliRunner()
-    result = runner.invoke(
-        b2g,
-        ["--workspace", str(ws.root), "read", "list", "--json"],
-        catch_exceptions=False,
-    )
-    lineas = [ln for ln in result.stdout.splitlines() if ln.strip()]
-    assert len(lineas) == 1
-
-
-@pytest.mark.unit
-def test_cli_read_show_stdout_una_linea_json(tmp_path: Path) -> None:
-    """read show --json (error o éxito): stdout es exactamente una línea."""
-    ws = _init_workspace(tmp_path)
-    _seed_store(ws, [_row(id="P1")])
-
-    runner = CliRunner()
-    result = runner.invoke(
-        b2g,
-        ["--workspace", str(ws.root), "read", "show", "--id", "P1", "--json"],
-        catch_exceptions=False,
-    )
-    lineas = [ln for ln in result.stdout.splitlines() if ln.strip()]
-    assert len(lineas) == 1
-
-
-@pytest.mark.unit
-def test_cli_read_stats_stdout_una_linea_json(tmp_path: Path) -> None:
-    """read stats --json: stdout es exactamente una línea."""
-    ws = _init_workspace(tmp_path)
-    _seed_store(ws, [_row(id="P1", curation_status="candidate")])
-
-    runner = CliRunner()
-    result = runner.invoke(
-        b2g,
-        ["--workspace", str(ws.root), "read", "stats", "--json"],
-        catch_exceptions=False,
-    )
-    lineas = [ln for ln in result.stdout.splitlines() if ln.strip()]
-    assert len(lineas) == 1
+# stdout de 1 línea JSON (list/show/stats): ya garantizado por _assert_one_json_line
+# en los tests *_envelope_forma de cada comando (epic #184, sub-tarea 2).
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_cli_read.py
+++ b/tests/unit/test_cli_read.py
@@ -509,40 +509,8 @@ def test_get_paper_devuelve_catorce_campos(tmp_path: Path) -> None:
         assert key in result, f"Falta clave: {key}"
 
 
-# ---------------------------------------------------------------------------
-# 4. Neutralidad de transporte — service/reads.py sigue siendo neutral
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.unit
-def test_service_reads_sigue_siendo_neutral_despues_de_nuevas_funciones() -> None:
-    """list_papers y corpus_stats no rompen la neutralidad de service.reads."""
-    import ast
-    import importlib
-    import pathlib
-
-    mod = importlib.import_module("bib2graph.service.reads")
-    source_file = mod.__file__
-    assert source_file is not None
-    tree = ast.parse(pathlib.Path(source_file).read_text(encoding="utf-8"))
-
-    forbidden = {"click", "fastapi"}
-    for node in ast.walk(tree):
-        if isinstance(node, ast.Import):
-            for alias in node.names:
-                assert alias.name.split(".")[0] not in forbidden
-        elif isinstance(node, ast.ImportFrom):
-            assert (node.module or "").split(".")[0] not in forbidden
-        elif isinstance(node, ast.Call):
-            if (
-                isinstance(node.func, ast.Attribute)
-                and isinstance(node.func.value, ast.Name)
-                and node.func.value.id == "sys"
-                and node.func.attr == "exit"
-            ):
-                raise AssertionError("service.reads llama a sys.exit")
-            if isinstance(node.func, ast.Name) and node.func.id == "print":
-                raise AssertionError("service.reads llama a print()")
+# Neutralidad de transporte de service.reads: consolidada en
+# test_service.py::test_service_modulo_neutral_de_transporte (epic #184).
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_cli_read_top.py
+++ b/tests/unit/test_cli_read_top.py
@@ -634,41 +634,5 @@ def test_cli_read_top_stdout_una_linea_json_cocitacion_vacia(
     assert len(lineas) == 1
 
 
-# ---------------------------------------------------------------------------
-# 11. Neutralidad de transporte — get_top no viola service.reads
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.unit
-def test_service_reads_sigue_siendo_neutral_con_get_top() -> None:
-    """service.reads con get_top no importa click, fastapi, print ni sys.exit."""
-    import ast
-    import importlib
-    import pathlib
-
-    mod = importlib.import_module("bib2graph.service.reads")
-    source_file = mod.__file__
-    assert source_file is not None
-    tree = ast.parse(pathlib.Path(source_file).read_text(encoding="utf-8"))
-
-    forbidden = {"click", "fastapi"}
-    for node in ast.walk(tree):
-        if isinstance(node, ast.Import):
-            for alias in node.names:
-                assert alias.name.split(".")[0] not in forbidden, (
-                    f"service.reads importa '{alias.name}' — viola neutralidad"
-                )
-        elif isinstance(node, ast.ImportFrom):
-            assert (node.module or "").split(".")[0] not in forbidden, (
-                f"service.reads importa de '{node.module}' — viola neutralidad"
-            )
-        elif isinstance(node, ast.Call):
-            if (
-                isinstance(node.func, ast.Attribute)
-                and isinstance(node.func.value, ast.Name)
-                and node.func.value.id == "sys"
-                and node.func.attr == "exit"
-            ):
-                raise AssertionError("service.reads llama a sys.exit")
-            if isinstance(node.func, ast.Name) and node.func.id == "print":
-                raise AssertionError("service.reads llama a print()")
+# Neutralidad de transporte de service.reads (incl. get_top): consolidada en
+# test_service.py::test_service_modulo_neutral_de_transporte (epic #184).

--- a/tests/unit/test_cli_read_top.py
+++ b/tests/unit/test_cli_read_top.py
@@ -592,46 +592,8 @@ def test_cli_read_top_kind_invalido_exit_nonzero(tmp_path: Path) -> None:
     assert result.exit_code != 0
 
 
-# ---------------------------------------------------------------------------
-# 10. stdout puro — exactamente una línea JSON (#151)
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.unit
-def test_cli_read_top_stdout_una_linea_json(tmp_path: Path) -> None:
-    """read top --json: stdout es exactamente una línea no-vacía."""
-    ws = _init_workspace(tmp_path)
-    _seed_store(ws, _bib_coupling_rows())
-
-    runner = CliRunner()
-    result = runner.invoke(
-        b2g,
-        ["--workspace", str(ws.root), "read", "top", "--json"],
-        catch_exceptions=False,
-    )
-    lineas = [ln for ln in result.stdout.splitlines() if ln.strip()]
-    assert len(lineas) == 1, (
-        f"Se esperaba exactamente 1 línea en stdout, se obtuvieron {len(lineas)}:\n"
-        f"{result.stdout!r}"
-    )
-
-
-@pytest.mark.unit
-def test_cli_read_top_stdout_una_linea_json_cocitacion_vacia(
-    tmp_path: Path,
-) -> None:
-    """read top --json con co-citación vacía: sigue siendo 1 línea JSON."""
-    ws = _init_workspace(tmp_path)
-    _seed_store(ws, _bib_coupling_rows())
-
-    runner = CliRunner()
-    result = runner.invoke(
-        b2g,
-        ["--workspace", str(ws.root), "read", "top", "--json"],
-        catch_exceptions=False,
-    )
-    lineas = [ln for ln in result.stdout.splitlines() if ln.strip()]
-    assert len(lineas) == 1
+# stdout de 1 línea JSON (#151) para read top: ya garantizado por
+# _assert_one_json_line en test_cli_read_top_json_envelope_forma (epic #184, sub-tarea 2).
 
 
 # Neutralidad de transporte de service.reads (incl. get_top): consolidada en

--- a/tests/unit/test_deprecation_aliases.py
+++ b/tests/unit/test_deprecation_aliases.py
@@ -1,11 +1,13 @@
 """Tests de los alias deprecados y el entry-point ``bib2graph`` (ADR 0038, #165).
 
+Poda epic #184: solo se conserva la verificación del aviso de deprecación.
+La delegación funcional y el contrato de schema/stdout se cubren en los tests
+del verbo canónico (test_cli.py y sus homólogos).
+
 Casos cubiertos por alias:
-  1. El alias corre sin error y delega correctamente (exit 0).
-  2. El aviso de deprecación va a **stderr** (result.stderr contiene "AVISO").
-  3. En modo ``--json``, stdout es JSON puro parseable (exactamente 1 línea).
-  4. ``envelope["warnings"]`` contiene el mensaje de deprecación.
-  5. ``envelope["schema"] == "1"`` (invariante de contrato).
+  1. El aviso de deprecación va a **stderr** (result.stderr contiene "AVISO").
+  2. En modo ``--json``, ``envelope["warnings"]`` contiene el mensaje de deprecación
+     (el helper _assert_one_json_stdout también verifica stdout==1 línea y schema=="1").
 
 Comandos deprecados testeados:
   - ``b2g accept``       → ``b2g curate accept``
@@ -13,6 +15,7 @@ Comandos deprecados testeados:
   - ``b2g filter``       → ``b2g curate filter``
   - ``b2g inspect``      → ``b2g read show`` / ``b2g status``
   - ``b2g restore``      → ``b2g snapshot restore``
+  - ``b2g networks``     → ``b2g build --spec``
 
 Casos de error (sin workspace → error envelope en stdout, aviso igual a stderr):
   - ``b2g monitor --json``   → error envelope, pero aviso sigue en stderr
@@ -203,20 +206,11 @@ class TestEmitDeprecation:
 
 
 class TestAcceptDeprecado:
-    """b2g accept emite aviso de deprecación y delega en curate accept."""
+    """b2g accept emite aviso de deprecación y delega en curate accept.
 
-    def test_corre_y_delega(self, tmp_path: Path) -> None:
-        """b2g accept sigue funcionando: exit 0 y accepted_count correcto."""
-        ws = _init_workspace(tmp_path)
-        _seed_store(ws, [_row(id="P1")])
-
-        runner = CliRunner()
-        result = runner.invoke(
-            b2g,
-            ["--workspace", str(ws.root), "accept", "--ids", "P1"],
-            catch_exceptions=False,
-        )
-        assert result.exit_code == 0, result.output
+    Delegación funcional y contrato schema/stdout se cubren en los tests de
+    'b2g curate accept' (test_cli.py). Aquí solo se conserva el aviso (epic #184).
+    """
 
     def test_aviso_va_a_stderr(self, tmp_path: Path) -> None:
         """b2g accept emite aviso de deprecación a stderr."""
@@ -234,20 +228,6 @@ class TestAcceptDeprecado:
         )
         assert "curate accept" in result.stderr.lower()
 
-    def test_json_stdout_puro_una_linea(self, tmp_path: Path) -> None:
-        """b2g accept --json: stdout es exactamente 1 línea JSON puro (#151)."""
-        ws = _init_workspace(tmp_path)
-        _seed_store(ws, [_row(id="P1")])
-
-        runner = CliRunner()
-        result = runner.invoke(
-            b2g,
-            ["--workspace", str(ws.root), "accept", "--ids", "P1", "--json"],
-            catch_exceptions=False,
-        )
-        assert result.exit_code == 0
-        _assert_one_json_stdout(result)
-
     def test_json_warnings_contiene_deprecacion(self, tmp_path: Path) -> None:
         """b2g accept --json: envelope['warnings'] contiene el aviso de deprecación."""
         ws = _init_workspace(tmp_path)
@@ -264,20 +244,6 @@ class TestAcceptDeprecado:
         assert any("deprecad" in w.lower() for w in envelope["warnings"])
         assert any("curate accept" in w.lower() for w in envelope["warnings"])
 
-    def test_schema_1_intacto(self, tmp_path: Path) -> None:
-        """b2g accept --json: envelope['schema'] == '1' (invariante)."""
-        ws = _init_workspace(tmp_path)
-        _seed_store(ws, [_row(id="P1")])
-
-        runner = CliRunner()
-        result = runner.invoke(
-            b2g,
-            ["--workspace", str(ws.root), "accept", "--ids", "P1", "--json"],
-            catch_exceptions=False,
-        )
-        envelope = _assert_one_json_stdout(result)
-        assert envelope["schema"] == "1"
-
 
 # ---------------------------------------------------------------------------
 # Tests b2g reject (alias deprecado → b2g curate reject)
@@ -285,20 +251,11 @@ class TestAcceptDeprecado:
 
 
 class TestRejectDeprecado:
-    """b2g reject emite aviso de deprecación y delega en curate reject."""
+    """b2g reject emite aviso de deprecación y delega en curate reject.
 
-    def test_corre_y_delega(self, tmp_path: Path) -> None:
-        """b2g reject sigue funcionando: exit 0 y rejected_count correcto."""
-        ws = _init_workspace(tmp_path)
-        _seed_store(ws, [_row(id="P1")])
-
-        runner = CliRunner()
-        result = runner.invoke(
-            b2g,
-            ["--workspace", str(ws.root), "reject", "--ids", "P1"],
-            catch_exceptions=False,
-        )
-        assert result.exit_code == 0, result.output
+    Delegación funcional y contrato schema/stdout se cubren en los tests de
+    'b2g curate reject' (test_cli.py). Aquí solo se conserva el aviso (epic #184).
+    """
 
     def test_aviso_va_a_stderr(self, tmp_path: Path) -> None:
         """b2g reject emite aviso de deprecación a stderr."""
@@ -313,20 +270,6 @@ class TestRejectDeprecado:
         )
         assert "deprecad" in result.stderr.lower()
         assert "curate reject" in result.stderr.lower()
-
-    def test_json_stdout_puro_una_linea(self, tmp_path: Path) -> None:
-        """b2g reject --json: stdout es exactamente 1 línea JSON puro."""
-        ws = _init_workspace(tmp_path)
-        _seed_store(ws, [_row(id="P1")])
-
-        runner = CliRunner()
-        result = runner.invoke(
-            b2g,
-            ["--workspace", str(ws.root), "reject", "--ids", "P1", "--json"],
-            catch_exceptions=False,
-        )
-        assert result.exit_code == 0
-        _assert_one_json_stdout(result)
 
     def test_json_warnings_contiene_deprecacion(self, tmp_path: Path) -> None:
         """b2g reject --json: envelope['warnings'] contiene el aviso."""
@@ -343,19 +286,6 @@ class TestRejectDeprecado:
         assert envelope["warnings"]
         assert any("curate reject" in w.lower() for w in envelope["warnings"])
 
-    def test_schema_1_intacto(self, tmp_path: Path) -> None:
-        """b2g reject --json: schema == '1'."""
-        ws = _init_workspace(tmp_path)
-        _seed_store(ws, [_row(id="P1")])
-
-        runner = CliRunner()
-        result = runner.invoke(
-            b2g,
-            ["--workspace", str(ws.root), "reject", "--ids", "P1", "--json"],
-            catch_exceptions=False,
-        )
-        assert _assert_one_json_stdout(result)["schema"] == "1"
-
 
 # ---------------------------------------------------------------------------
 # Tests b2g filter (alias deprecado → b2g curate filter)
@@ -363,20 +293,11 @@ class TestRejectDeprecado:
 
 
 class TestFilterDeprecado:
-    """b2g filter emite aviso de deprecación y delega en curate filter."""
+    """b2g filter emite aviso de deprecación y delega en curate filter.
 
-    def test_corre_y_delega(self, tmp_path: Path) -> None:
-        """b2g filter sigue funcionando: exit 0."""
-        ws = _init_workspace(tmp_path)
-        _seed_store(ws, [_row(id="P1", year=2020)])
-
-        runner = CliRunner()
-        result = runner.invoke(
-            b2g,
-            ["--workspace", str(ws.root), "filter", "--year-gte", "1900"],
-            catch_exceptions=False,
-        )
-        assert result.exit_code == 0, result.output
+    Delegación funcional y contrato schema/stdout se cubren en los tests de
+    'b2g curate filter' (test_cli.py). Aquí solo se conserva el aviso (epic #184).
+    """
 
     def test_aviso_va_a_stderr(self, tmp_path: Path) -> None:
         """b2g filter emite aviso de deprecación a stderr."""
@@ -391,20 +312,6 @@ class TestFilterDeprecado:
         )
         assert "deprecad" in result.stderr.lower()
         assert "curate filter" in result.stderr.lower()
-
-    def test_json_stdout_puro_una_linea(self, tmp_path: Path) -> None:
-        """b2g filter --json: stdout es exactamente 1 línea JSON puro."""
-        ws = _init_workspace(tmp_path)
-        _seed_store(ws, [_row(id="P1", year=2020)])
-
-        runner = CliRunner()
-        result = runner.invoke(
-            b2g,
-            ["--workspace", str(ws.root), "filter", "--year-gte", "1900", "--json"],
-            catch_exceptions=False,
-        )
-        assert result.exit_code == 0
-        _assert_one_json_stdout(result)
 
     def test_json_warnings_contiene_deprecacion(self, tmp_path: Path) -> None:
         """b2g filter --json: envelope['warnings'] contiene el aviso."""
@@ -421,19 +328,6 @@ class TestFilterDeprecado:
         assert envelope["warnings"]
         assert any("curate filter" in w.lower() for w in envelope["warnings"])
 
-    def test_schema_1_intacto(self, tmp_path: Path) -> None:
-        """b2g filter --json: schema == '1'."""
-        ws = _init_workspace(tmp_path)
-        _seed_store(ws, [_row(id="P1", year=2020)])
-
-        runner = CliRunner()
-        result = runner.invoke(
-            b2g,
-            ["--workspace", str(ws.root), "filter", "--year-gte", "1900", "--json"],
-            catch_exceptions=False,
-        )
-        assert _assert_one_json_stdout(result)["schema"] == "1"
-
 
 # ---------------------------------------------------------------------------
 # Tests b2g inspect (alias deprecado → b2g read show / b2g status)
@@ -441,7 +335,12 @@ class TestFilterDeprecado:
 
 
 class TestInspectDeprecado:
-    """b2g inspect emite aviso de deprecación y delega en read show / status."""
+    """b2g inspect emite aviso de deprecación y delega en read show / status.
+
+    Delegación funcional y contrato schema/stdout se cubren en los tests de
+    'b2g read show' y 'b2g status' (test_cli.py). Aquí solo se conserva el aviso
+    (epic #184).
+    """
 
     def test_aviso_va_a_stderr_sin_id(self, tmp_path: Path) -> None:
         """b2g inspect sin --id avisa 'b2g status' en stderr."""
@@ -473,20 +372,6 @@ class TestInspectDeprecado:
         assert "deprecad" in result.stderr.lower()
         assert "read show" in result.stderr.lower()
 
-    def test_json_stdout_puro_una_linea(self, tmp_path: Path) -> None:
-        """b2g inspect --json: stdout es exactamente 1 línea JSON puro."""
-        ws = _init_workspace(tmp_path)
-        _seed_store(ws, [_row(id="P1")])
-
-        runner = CliRunner()
-        result = runner.invoke(
-            b2g,
-            ["--workspace", str(ws.root), "inspect", "--json"],
-            catch_exceptions=False,
-        )
-        assert result.exit_code == 0
-        _assert_one_json_stdout(result)
-
     def test_json_warnings_contiene_deprecacion(self, tmp_path: Path) -> None:
         """b2g inspect --json: envelope['warnings'] contiene el aviso."""
         ws = _init_workspace(tmp_path)
@@ -502,19 +387,6 @@ class TestInspectDeprecado:
         assert envelope["warnings"]
         assert any("deprecad" in w.lower() for w in envelope["warnings"])
 
-    def test_schema_1_intacto(self, tmp_path: Path) -> None:
-        """b2g inspect --json: schema == '1'."""
-        ws = _init_workspace(tmp_path)
-        _seed_store(ws, [_row(id="P1")])
-
-        runner = CliRunner()
-        result = runner.invoke(
-            b2g,
-            ["--workspace", str(ws.root), "inspect", "--json"],
-            catch_exceptions=False,
-        )
-        assert _assert_one_json_stdout(result)["schema"] == "1"
-
 
 # ---------------------------------------------------------------------------
 # Tests b2g restore (alias deprecado → b2g snapshot restore)
@@ -522,26 +394,11 @@ class TestInspectDeprecado:
 
 
 class TestRestoreDeprecado:
-    """b2g restore emite aviso de deprecación y delega en snapshot restore."""
+    """b2g restore emite aviso de deprecación y delega en snapshot restore.
 
-    def test_corre_y_delega(self, tmp_path: Path) -> None:
-        """b2g restore sigue funcionando: exit 0 y papers_loaded correcto."""
-        ws = _init_workspace(tmp_path)
-        parquet_path = _make_parquet(tmp_path / "corpus.parquet")
-
-        runner = CliRunner()
-        result = runner.invoke(
-            b2g,
-            [
-                "--workspace",
-                str(ws.root),
-                "restore",
-                "--from-corpus",
-                str(parquet_path),
-            ],
-            catch_exceptions=False,
-        )
-        assert result.exit_code == 0, result.output
+    Delegación funcional y contrato schema/stdout se cubren en los tests de
+    'b2g snapshot restore' (test_cli.py). Aquí solo se conserva el aviso (epic #184).
+    """
 
     def test_aviso_va_a_stderr(self, tmp_path: Path) -> None:
         """b2g restore emite aviso de deprecación a stderr."""
@@ -562,27 +419,6 @@ class TestRestoreDeprecado:
         )
         assert "deprecad" in result.stderr.lower()
         assert "snapshot restore" in result.stderr.lower()
-
-    def test_json_stdout_puro_una_linea(self, tmp_path: Path) -> None:
-        """b2g restore --json: stdout es exactamente 1 línea JSON puro."""
-        ws = _init_workspace(tmp_path)
-        parquet_path = _make_parquet(tmp_path / "corpus.parquet")
-
-        runner = CliRunner()
-        result = runner.invoke(
-            b2g,
-            [
-                "--workspace",
-                str(ws.root),
-                "restore",
-                "--from-corpus",
-                str(parquet_path),
-                "--json",
-            ],
-            catch_exceptions=False,
-        )
-        assert result.exit_code == 0
-        _assert_one_json_stdout(result)
 
     def test_json_warnings_contiene_deprecacion(self, tmp_path: Path) -> None:
         """b2g restore --json: envelope['warnings'] contiene el aviso."""
@@ -605,26 +441,6 @@ class TestRestoreDeprecado:
         envelope = _assert_one_json_stdout(result)
         assert envelope["warnings"]
         assert any("snapshot restore" in w.lower() for w in envelope["warnings"])
-
-    def test_schema_1_intacto(self, tmp_path: Path) -> None:
-        """b2g restore --json: schema == '1'."""
-        ws = _init_workspace(tmp_path)
-        parquet_path = _make_parquet(tmp_path / "corpus.parquet")
-
-        runner = CliRunner()
-        result = runner.invoke(
-            b2g,
-            [
-                "--workspace",
-                str(ws.root),
-                "restore",
-                "--from-corpus",
-                str(parquet_path),
-                "--json",
-            ],
-            catch_exceptions=False,
-        )
-        assert _assert_one_json_stdout(result)["schema"] == "1"
 
 
 # ---------------------------------------------------------------------------
@@ -814,19 +630,11 @@ def _write_spec(tmp_path: Path) -> Path:
 
 
 class TestNetworksDeprecado:
-    """b2g networks emite aviso de deprecacion y delega en build --spec."""
+    """b2g networks emite aviso de deprecacion y delega en build --spec.
 
-    def test_corre_y_delega(self, tmp_path: Path) -> None:
-        ws = _init_workspace(tmp_path)
-        _seed_store(ws, [_row(id="P1", year=2020)])
-        spec = _write_spec(tmp_path)
-        runner = CliRunner()
-        result = runner.invoke(
-            b2g,
-            ["--workspace", str(ws.root), "networks", "--spec", str(spec)],
-            catch_exceptions=False,
-        )
-        assert result.exit_code == 0, result.output
+    Delegación funcional y contrato schema/stdout se cubren en los tests de
+    'b2g build --spec' (test_cli.py). Aquí solo se conserva el aviso (epic #184).
+    """
 
     def test_aviso_va_a_stderr(self, tmp_path: Path) -> None:
         ws = _init_workspace(tmp_path)
@@ -840,19 +648,6 @@ class TestNetworksDeprecado:
         )
         assert "deprecad" in result.stderr.lower()
         assert "build --spec" in result.stderr.lower()
-
-    def test_json_stdout_puro_una_linea(self, tmp_path: Path) -> None:
-        ws = _init_workspace(tmp_path)
-        _seed_store(ws, [_row(id="P1", year=2020)])
-        spec = _write_spec(tmp_path)
-        runner = CliRunner()
-        result = runner.invoke(
-            b2g,
-            ["--workspace", str(ws.root), "networks", "--spec", str(spec), "--json"],
-            catch_exceptions=False,
-        )
-        assert result.exit_code == 0
-        _assert_one_json_stdout(result)
 
     def test_json_warnings_contiene_deprecacion(self, tmp_path: Path) -> None:
         ws = _init_workspace(tmp_path)

--- a/tests/unit/test_enrichers_8b.py
+++ b/tests/unit/test_enrichers_8b.py
@@ -323,24 +323,8 @@ def test_reatribucion_citante_sin_referencias_no_se_asigna() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.unit
-def test_enrich_cited_by_idempotente() -> None:
-    """Re-enrich no duplica en cited_by_id."""
-    corpus = _corpus_from_rows([_make_row(id="P1", source_id="W100")])
-    citing_works = [_citing_work("C1", ["W100"])]
-    transport = _make_cited_by_transport(citing_works)
-
-    enricher = _make_enricher(transport)
-    once = enricher.enrich(corpus)
-    twice = enricher.enrich(once)
-
-    table = twice.to_arrow()
-    rows_data = table.to_pylist()
-    cited_by = rows_data[0].get("cited_by_id") or []
-
-    # No duplicados
-    assert len(cited_by) == len(set(cited_by)), "cited_by_id no debe tener duplicados"
-    assert "C1" in cited_by
+# Eliminado epic #184: cubierto por test_enrich_cocitacion_integrado.py::test_run_enrich_idempotente_corpus_hash_y_cocitacion
+# (verificación de corpus_hash más fuerte que conteo de cited_by_id).
 
 
 @pytest.mark.unit
@@ -363,21 +347,8 @@ def test_enrich_cited_by_enricher_ref_no_duplica() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.unit
-def test_tope_max_citing_per_paper() -> None:
-    """max_citing_per_paper=2 trunca cited_by_id a 2 citantes por paper."""
-    corpus = _corpus_from_rows([_make_row(id="P1", source_id="W100")])
-    # 5 citantes que citan a W100
-    citing_works = [_citing_work(f"C{i}", ["W100"]) for i in range(1, 6)]
-    transport = _make_cited_by_transport(citing_works)
-
-    enricher = _make_enricher(transport, max_citing_per_paper=2)
-    result = enricher.enrich(corpus)
-
-    table = result.to_arrow()
-    rows_data = table.to_pylist()
-    cited_by = rows_data[0].get("cited_by_id") or []
-    assert len(cited_by) <= 2, f"Debe haber ≤2 citantes, hay {len(cited_by)}"
+# Eliminado epic #184: cubierto por test_enrich_cocitacion_integrado.py::test_run_enrich_max_citing_acota_cited_by_id
+# y test_enrich_absorb.py::test_build_max_citing_limita_citantes.
 
 
 @pytest.mark.unit
@@ -466,179 +437,24 @@ def test_candidato_no_se_enriquece() -> None:
 
 
 # ---------------------------------------------------------------------------
-# 6. Networks.quick sin cited_by_id → 4 redes, sin fallo (regresión)
+# 6. Networks.quick sin cited_by_id → 4 redes (regresión)
+# Eliminado epic #184: cubierto por test_enrich_absorb.py::test_build_4_redes_sin_seeds_aceptadas.
 # ---------------------------------------------------------------------------
-
-
-@pytest.mark.unit
-def test_networks_quick_sin_cited_by_omite_cocitacion_sin_fallar() -> None:
-    """Networks.quick con cited_by_id vacío → 4 redes, sin error."""
-    rows = [
-        {
-            "id": f"P{i}",
-            "source_id": None,
-            "doi": None,
-            "title": f"Paper {i}",
-            "year": 2020,
-            "abstract": None,
-            "source": None,
-            "language": None,
-            "publisher": None,
-            "research_areas": None,
-            "is_seed": True,
-            "curation_status": "candidate",
-            "provenance": None,
-            "authors_raw": None,
-            "authors_id": [f"AUTH_{i}", "AUTH_0"],
-            "authors_affiliations": None,
-            "keywords_raw": None,
-            "keywords_id": [f"KW_{i}", "KW_SHARED"],
-            "institutions_raw": None,
-            "institutions_id": [f"INST_{i}"],
-            "references_id": [f"REF_{i}", "REF_SHARED"],
-            "references_doi": None,
-            "cited_by_id": None,  # sin citantes
-        }
-        for i in range(3)
-    ]
-    table = pa.Table.from_pylist(rows, schema=CORPUS_SCHEMA)
-    corpus = Corpus.from_arrow(table)
-
-    # No debe lanzar excepción
-    artifacts = Networks.quick(corpus)
-
-    assert len(artifacts) == 4, "Sin cited_by_id debe haber exactamente 4 redes"
-    kinds = {a.spec.kind for a in artifacts}
-    assert "cocitation" not in kinds
-
 
 # ---------------------------------------------------------------------------
 # 7. Networks.quick con cited_by_id → 5 redes
+# Eliminado epic #184: cubierto por test_enrich_absorb.py::test_build_co_citacion_en_redes_tras_cited_by
+# y test_enrich_cocitacion_integrado.py::test_run_enrich_produce_red_cocitacion_con_arista_esperada.
 # ---------------------------------------------------------------------------
-
-
-@pytest.mark.unit
-def test_networks_quick_con_cited_by_incluye_cocitacion() -> None:
-    """Networks.quick con cited_by_id poblado → 5 redes, incluyendo cocitation."""
-    rows = [
-        {
-            "id": "P1",
-            "source_id": "W100",
-            "doi": None,
-            "title": "Paper 1",
-            "year": 2020,
-            "abstract": None,
-            "source": None,
-            "language": None,
-            "publisher": None,
-            "research_areas": None,
-            "is_seed": True,
-            "curation_status": "accepted",
-            "provenance": None,
-            "authors_raw": None,
-            "authors_id": ["AUTH_1"],
-            "authors_affiliations": None,
-            "keywords_raw": None,
-            "keywords_id": ["KW_1"],
-            "institutions_raw": None,
-            "institutions_id": ["INST_1"],
-            "references_id": None,
-            "references_doi": None,
-            "cited_by_id": ["C1"],  # ya tiene citante
-        },
-        {
-            "id": "P2",
-            "source_id": "W200",
-            "doi": None,
-            "title": "Paper 2",
-            "year": 2020,
-            "abstract": None,
-            "source": None,
-            "language": None,
-            "publisher": None,
-            "research_areas": None,
-            "is_seed": True,
-            "curation_status": "accepted",
-            "provenance": None,
-            "authors_raw": None,
-            "authors_id": ["AUTH_2"],
-            "authors_affiliations": None,
-            "keywords_raw": None,
-            "keywords_id": ["KW_2"],
-            "institutions_raw": None,
-            "institutions_id": ["INST_2"],
-            "references_id": None,
-            "references_doi": None,
-            "cited_by_id": ["C1"],  # mismo citante → co-cita P1 y P2
-        },
-    ]
-    table = pa.Table.from_pylist(rows, schema=CORPUS_SCHEMA)
-    corpus = Corpus.from_arrow(table)
-
-    artifacts = Networks.quick(corpus)
-    kinds = {a.spec.kind for a in artifacts}
-
-    assert "cocitation" in kinds
-    assert len(artifacts) == 5
-
 
 # ---------------------------------------------------------------------------
 # 8. No pierde papers; corpus sin seeds aceptados → 0 fetch, sin error
+# Eliminado epic #184: test_corpus_sin_seeds_aceptados_0_fetch cubierto por
+#   test_enrich_cocitacion_integrado.py::test_run_enrich_sin_seeds_aceptadas_no_altera_corpus
+#   y test_enrich_absorb.py::test_build_noop_sin_seeds_aceptadas.
+# Eliminado epic #184: test_enrich_no_pierde_papers_con_semillas cubierto por
+#   test_enrichers.py::test_enrich_no_pierde_papers.
 # ---------------------------------------------------------------------------
-
-
-@pytest.mark.unit
-def test_corpus_sin_seeds_aceptados_0_fetch() -> None:
-    """Corpus sin seeds aceptados → 0 requests a cited_by, sin error."""
-    corpus = _corpus_from_rows(
-        [
-            _make_row(
-                id="P1",
-                source_id="W100",
-                curation_status=CurationStatus.CANDIDATE,
-            ),
-            _make_row(
-                id="P2",
-                source_id="W200",
-                is_seed=False,
-                curation_status=CurationStatus.ACCEPTED,
-            ),
-        ]
-    )
-
-    transport, counters = _make_counting_cited_by_transport([])
-    enricher = _make_enricher(transport)
-    result = enricher.enrich(corpus)
-
-    # No se hicieron requests de cited_by (ninguna seed aceptada)
-    assert counters["citing"][0] == 0, (
-        "Sin seeds aceptadas no debe hacer requests citing"
-    )
-    # No pierde papers
-    assert len(result) == len(corpus)
-
-
-@pytest.mark.unit
-def test_enrich_no_pierde_papers_con_semillas() -> None:
-    """El corpus enriquecido tiene exactamente los mismos papers que el original."""
-    corpus = _corpus_from_rows(
-        [
-            _make_row(id="P1", source_id="W100"),
-            _make_row(
-                id="P2",
-                source_id="W200",
-                curation_status=CurationStatus.CANDIDATE,
-            ),
-            _make_row(id="P3", source_id=None),
-        ]
-    )
-    citing_works = [_citing_work("C1", ["W100"])]
-    transport = _make_cited_by_transport(citing_works)
-
-    enricher = _make_enricher(transport)
-    result = enricher.enrich(corpus)
-
-    assert len(result) == len(corpus), "No debe perder ni agregar papers"
 
 
 # ---------------------------------------------------------------------------
@@ -706,33 +522,9 @@ def test_papers_sin_openalex_id_no_son_objetivo() -> None:
 
 # ---------------------------------------------------------------------------
 # 11. run_enrich expone claves citing_new y citing_targets
+# Eliminado epic #184: cubierto por test_enrich_absorb.py::test_enrich_suelto_claves_numericas
+# (contrato completo de 5 claves con valores numéricos concretos).
 # ---------------------------------------------------------------------------
-
-
-@pytest.mark.unit
-def test_run_enrich_8b_claves_en_salida(tmp_path: Any) -> None:
-    """``run_enrich`` devuelve las nuevas claves citing_new y citing_targets."""
-    from bib2graph.cli.commands.enrich import run_enrich
-    from bib2graph.stores.duckdb import DuckDBStore
-
-    rows = [_make_row(id="P1", source_id="W100")]
-    table = pa.Table.from_pylist(rows, schema=CORPUS_SCHEMA)
-    corpus = Corpus.from_arrow(table)
-    store = DuckDBStore(tmp_path / "test.duckdb")
-    store.persist(corpus)
-
-    citing_works = [_citing_work("C1", ["W100"])]
-    transport = _make_cited_by_transport(citing_works)
-
-    data = run_enrich(tmp_path / "test.duckdb", transport=transport)
-
-    assert "citing_new" in data, "Debe incluir clave citing_new"
-    assert "citing_targets" in data, "Debe incluir clave citing_targets"
-    assert isinstance(data["citing_new"], int)
-    assert isinstance(data["citing_targets"], int)
-    assert data["citing_targets"] == 1  # 1 seed aceptada
-    assert data["citing_new"] == 1  # 1 nuevo citante
-
 
 # ---------------------------------------------------------------------------
 # 12. EnricherRef openalex_cited_by en Manifest

--- a/tests/unit/test_equation_spec.py
+++ b/tests/unit/test_equation_spec.py
@@ -321,32 +321,9 @@ equation:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.unit
-def test_seed_sin_modo_lanza_usage_error(tmp_path: Path) -> None:
-    """b2g seed sin ningún modo → UsageError accionable (exit 1)."""
-    from click.testing import CliRunner
-
-    from bib2graph.cli import b2g
-    from bib2graph.workspace import Workspace
-
-    ws_dir = tmp_path / "ws"
-    Workspace.init(ws_dir, "test")
-
-    runner = CliRunner()
-    result = runner.invoke(
-        b2g,
-        [
-            "--workspace",
-            str(ws_dir),
-            "seed",
-            "--json",
-        ],
-    )
-
-    assert result.exit_code == 1, f"Se esperaba exit 1, salida: {result.output}"
-    envelope = json.loads(result.output)
-    assert envelope["ok"] is False
-    assert envelope["error"]["code"] == "USAGE_ERROR"
+# "seed sin ningún modo → UsageError" es idéntico a
+# test_seed_from_bib.py::test_seed_sin_modo_usage_error (mismo invocar, mismo assert);
+# se conserva allí. Epic #184, sub-tarea 7.
 
 
 @pytest.mark.unit

--- a/tests/unit/test_idempotencia_pipeline_bitabit.py
+++ b/tests/unit/test_idempotencia_pipeline_bitabit.py
@@ -22,7 +22,8 @@ Casos cubiertos:
    parquet (coherencia entre el path DuckDB y el path Arrow puro).
 
 Sin red. El parquet congelado en ``examples/valoraciones/corpus.parquet``
-sirve de input. Si no existe, los tests se saltean con ``pytest.skip``.
+sirve de input. Está commiteado; si falta, los tests FALLAN (no se saltean):
+es una regresión de reproducibilidad, no una condición a tolerar.
 
 Marcador: ``unit`` (sin red; el parquet es local, ≤200 KB; DuckDB en tmp_path).
 """
@@ -52,14 +53,17 @@ _EXAMPLES_PARQUET = (
 # ---------------------------------------------------------------------------
 
 
-def _skip_if_no_parquet() -> None:
-    """Saltea el test si el parquet del ejemplo no existe."""
-    if not _EXAMPLES_PARQUET.exists():
-        pytest.skip(
-            f"No se encontró el parquet del ejemplo en {_EXAMPLES_PARQUET}. "
-            "Para regenerarlo (con red): ver §Armado desde cero en "
-            "examples/valoraciones/README.md."
-        )
+def _require_parquet() -> None:
+    """Falla (no saltea) si el parquet del ejemplo no existe.
+
+    El parquet está commiteado en examples/valoraciones/; si falta es una
+    regresión de reproducibilidad, no una condición a saltear. Coherente con
+    test_example_r2_gate.py::test_parquet_existe_y_carga (epic #184, sub-tarea 8)."""
+    assert _EXAMPLES_PARQUET.exists(), (
+        f"No se encontró el parquet del ejemplo en {_EXAMPLES_PARQUET}. "
+        "Debe estar commiteado en examples/valoraciones/. Para regenerarlo "
+        "(con red): ver §Armado desde cero en examples/valoraciones/README.md."
+    )
 
 
 def _load_parquet_slice(n: int = 20) -> pa.Table:
@@ -93,7 +97,7 @@ def test_corpus_hash_identico_en_dos_cargas_arrow() -> None:
     (excluyendo provenance y timestamps) y que Arrow no introduce
     variabilidad al deserializar.
     """
-    _skip_if_no_parquet()
+    _require_parquet()
 
     from bib2graph.corpus import Corpus
     from bib2graph.schemas import CORPUS_SCHEMA
@@ -132,7 +136,7 @@ def test_run_restore_corpus_hash_identico_entre_dos_runs(tmp_path: Path) -> None
     Usa un slice de 10 filas para mantener el test ágil; el comportamiento
     del pipeline es independiente del tamaño del corpus.
     """
-    _skip_if_no_parquet()
+    _require_parquet()
 
     slice_table = _load_parquet_slice(10)
     slice_parquet = tmp_path / "slice.parquet"
@@ -180,7 +184,7 @@ def test_comunidades_identicas_entre_dos_runs_pipeline(tmp_path: Path) -> None:
     es el mismo → la partición es determinista e independiente de
     ``PYTHONHASHSEED`` (Python no usa ``hash()`` para Louvain).
     """
-    _skip_if_no_parquet()
+    _require_parquet()
 
     # Usar un slice del parquet real con suficiente contenido para tener
     # al menos una red de acoplamiento bibliográfico con comunidades.
@@ -255,7 +259,7 @@ def test_corpus_hash_coherente_store_vs_arrow_puro(tmp_path: Path) -> None:
     Esta coherencia garantiza que el formato de persistencia no altera el
     content-hash del corpus (R2: identidad es del contenido, no del transporte).
     """
-    _skip_if_no_parquet()
+    _require_parquet()
 
     slice_table = _load_parquet_slice(10)
     slice_parquet = tmp_path / "slice.parquet"

--- a/tests/unit/test_maturity.py
+++ b/tests/unit/test_maturity.py
@@ -284,33 +284,9 @@ class TestBuildMaturity:
         assert "maturity" in data, "data debe tener clave 'maturity'"
         _assert_maturity_shape(data["maturity"])
 
-    def test_maturity_curated_false_en_build_todo_candidate(
-        self, tmp_path: Path
-    ) -> None:
-        """run_build con corpus de puros candidates → maturity.curated=False."""
-        from bib2graph.cli.commands.build import run_build
-
-        store_path = tmp_path / "lib.duckdb"
-        _seed_store(store_path, _rows_bib_coupling())  # todos candidate
-
-        data = run_build(store_path, out_dir=tmp_path / "nets")
-
-        assert data["maturity"]["curated"] is False
-
-    def test_maturity_curated_true_en_build_con_accepted(self, tmp_path: Path) -> None:
-        """run_build con ≥1 accepted → maturity.curated=True."""
-        from bib2graph.cli.commands.build import run_build
-
-        store_path = tmp_path / "lib.duckdb"
-        rows = [
-            _row("P1", curation_status="accepted", references_id=["R1", "R2"]),
-            _row("P2", curation_status="candidate", references_id=["R1", "R3"]),
-        ]
-        _seed_store(store_path, rows)
-
-        data = run_build(store_path, out_dir=tmp_path / "nets")
-
-        assert data["maturity"]["curated"] is True
+    # Semántica curated=False/True eliminada aquí (epic #184):
+    # la invariante vive en TestComputeMaturity::test_curated_false_todo_candidate
+    # y test_curated_true_con_accepted; este archivo solo verifica presencia y forma.
 
     def test_maturity_scope_coincide_con_data_scope(self, tmp_path: Path) -> None:
         """maturity.scope coincide con data['scope']."""
@@ -356,16 +332,8 @@ class TestBuildMaturity:
                 f"maturity.empty_networks debe contener strings, no dicts: {item!r}"
             )
 
-    def test_maturity_saturated_false_en_build(self, tmp_path: Path) -> None:
-        """maturity.saturated siempre False en build."""
-        from bib2graph.cli.commands.build import run_build
-
-        store_path = tmp_path / "lib.duckdb"
-        _seed_store(store_path, _rows_bib_coupling())
-
-        data = run_build(store_path, out_dir=tmp_path / "nets")
-
-        assert data["maturity"]["saturated"] is False
+    # Semántica saturated=False eliminada aquí (epic #184):
+    # la invariante vive en TestComputeMaturity::test_saturated_siempre_false.
 
     def test_maturity_presente_en_early_return_corpus_vacio(
         self, tmp_path: Path
@@ -500,44 +468,8 @@ class TestSnapshotMaturity:
 
         assert data["maturity"]["empty_networks"] == []
 
-    def test_snapshot_maturity_curated_false_todo_candidate(
-        self, tmp_path: Path
-    ) -> None:
-        """snapshot con corpus de candidates → maturity.curated=False."""
-        from bib2graph.cli.commands.snapshot import run_snapshot
-
-        store_path = tmp_path / "lib.duckdb"
-        _seed_store(store_path, _rows_bib_coupling())
-
-        data = run_snapshot(store_path, out_dir=tmp_path / "snaps")
-
-        assert data["maturity"]["curated"] is False
-
-    def test_snapshot_maturity_curated_true_con_accepted(self, tmp_path: Path) -> None:
-        """snapshot con ≥1 accepted → maturity.curated=True."""
-        from bib2graph.cli.commands.snapshot import run_snapshot
-
-        store_path = tmp_path / "lib.duckdb"
-        rows = [
-            _row("P1", curation_status="accepted"),
-            _row("P2", curation_status="candidate"),
-        ]
-        _seed_store(store_path, rows)
-
-        data = run_snapshot(store_path, out_dir=tmp_path / "snaps")
-
-        assert data["maturity"]["curated"] is True
-
-    def test_snapshot_maturity_saturated_false(self, tmp_path: Path) -> None:
-        """snapshot: maturity.saturated=False."""
-        from bib2graph.cli.commands.snapshot import run_snapshot
-
-        store_path = tmp_path / "lib.duckdb"
-        _seed_store(store_path, _rows_bib_coupling())
-
-        data = run_snapshot(store_path, out_dir=tmp_path / "snaps")
-
-        assert data["maturity"]["saturated"] is False
+    # Semántica curated=False/True y saturated=False eliminada aquí (epic #184):
+    # las invariantes viven en TestComputeMaturity; aquí solo se verifica wiring.
 
     def test_snapshot_schema_1_intacto(self, tmp_path: Path) -> None:
         """snapshot --json: schema='1' intacto después de agregar maturity."""
@@ -621,44 +553,8 @@ class TestReadTopMaturity:
 
         assert result["maturity"]["empty_networks"] == []
 
-    def test_read_top_maturity_curated_false_todo_candidate(
-        self, tmp_path: Path
-    ) -> None:
-        """read top con corpus de candidates → maturity.curated=False."""
-        from bib2graph.service.reads import get_top
-
-        ws = _init_workspace(tmp_path)
-        _seed_workspace(ws, _rows_bib_coupling())
-
-        result = get_top(ws, n=3)
-
-        assert result["maturity"]["curated"] is False
-
-    def test_read_top_maturity_curated_true_con_accepted(self, tmp_path: Path) -> None:
-        """read top con ≥1 accepted → maturity.curated=True."""
-        from bib2graph.service.reads import get_top
-
-        ws = _init_workspace(tmp_path)
-        rows = [
-            _row("P1", curation_status="accepted", references_id=["R1", "R2"]),
-            _row("P2", curation_status="candidate", references_id=["R1", "R3"]),
-        ]
-        _seed_workspace(ws, rows)
-
-        result = get_top(ws, n=3)
-
-        assert result["maturity"]["curated"] is True
-
-    def test_read_top_maturity_saturated_false(self, tmp_path: Path) -> None:
-        """read top: maturity.saturated=False."""
-        from bib2graph.service.reads import get_top
-
-        ws = _init_workspace(tmp_path)
-        _seed_workspace(ws, _rows_bib_coupling())
-
-        result = get_top(ws, n=3)
-
-        assert result["maturity"]["saturated"] is False
+    # Semántica curated=False/True y saturated=False eliminada aquí (epic #184):
+    # las invariantes viven en TestComputeMaturity; aquí solo se verifica wiring.
 
     def test_read_top_schema_1_intacto_con_maturity(self, tmp_path: Path) -> None:
         """read top --json: schema='1' intacto después de agregar maturity."""

--- a/tests/unit/test_r3_commands_domain.py
+++ b/tests/unit/test_r3_commands_domain.py
@@ -20,6 +20,13 @@ import pytest
 from bib2graph.cycle import CycleState, apply_transition
 from bib2graph.schemas import CORPUS_SCHEMA
 
+# Targets de patch: el método en su CLASE DE DEFINICIÓN (robusto al import-path del
+# SUT — se parchea el objeto-clase compartido, no un alias). Centralizados acá para
+# que un eventual movimiento de módulo de Forager/Networks se actualice en un solo
+# lugar (epic #184, sub-tarea 8).
+_PATCH_FORAGER_CHAIN = "bib2graph.foraging.forager.Forager.chain"
+_PATCH_NETWORKS_QUICK = "bib2graph.networks.facade.Networks.quick"
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -168,7 +175,7 @@ def test_estado_persistido_es_dictado_por_cycle(
         from bib2graph.cli.commands.chain import run_chain
 
         with patch(
-            "bib2graph.foraging.forager.Forager.chain",
+            _PATCH_FORAGER_CHAIN,
             return_value=_make_empty_forage_result(),
         ):
             run_chain(store_path, transport=_make_noop_transport())
@@ -180,7 +187,7 @@ def test_estado_persistido_es_dictado_por_cycle(
         from bib2graph.cli.commands.build import run_build
 
         with patch(
-            "bib2graph.networks.facade.Networks.quick",
+            _PATCH_NETWORKS_QUICK,
             return_value=[],
         ):
             run_build(store_path)

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -163,14 +163,28 @@ def test_code_for_excepcion_no_mapeada_lanza_typeerror() -> None:
 # ---------------------------------------------------------------------------
 
 
+def _service_module_names() -> list[str]:
+    """Todos los módulos del paquete service/ (auto-descubrimiento: cubre módulos
+    futuros sin tocar el test). Fuente única del contrato de neutralidad ADR 0028.
+    Consolida las copias que vivían en test_service_reads, test_api, test_cli_read
+    y test_cli_read_top (epic #184)."""
+    import importlib
+    import pkgutil
+
+    pkg = importlib.import_module("bib2graph.service")
+    names = ["bib2graph.service"]
+    names += [
+        f"bib2graph.service.{info.name}" for info in pkgutil.iter_modules(pkg.__path__)
+    ]
+    return sorted(names)
+
+
 @pytest.mark.unit
-@pytest.mark.parametrize(
-    "module_name", ["bib2graph.service.envelope", "bib2graph.service.errors"]
-)
+@pytest.mark.parametrize("module_name", _service_module_names())
 def test_service_modulo_neutral_de_transporte(module_name: str) -> None:
-    """Los módulos de service/ son agnósticos de transporte (ADR 0028): no importan
-    click/fastapi ni hacen sys.exit/print. Detección por AST real (no substrings),
-    sobre TODOS los módulos del contrato (no solo envelope)."""
+    """Cada módulo de service/ es agnóstico de transporte (ADR 0028): no importa
+    click/fastapi ni hace sys.exit/print. Detección por AST real (no substrings),
+    sobre TODO el paquete service/ (no solo envelope/errors)."""
     import ast
     import importlib
     import pathlib

--- a/tests/unit/test_service_reads.py
+++ b/tests/unit/test_service_reads.py
@@ -543,41 +543,5 @@ def test_get_scent_paper_inexistente_lanza_dataerror(tmp_path: Path) -> None:
         get_scent(ws, "no-existe")
 
 
-# ---------------------------------------------------------------------------
-# 5. Neutralidad de transporte — service/reads.py es agnóstico
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.unit
-def test_service_reads_es_neutral_de_transporte() -> None:
-    """service/reads.py no importa click, fastapi, sys.exit ni print (ADR 0028)."""
-    import ast
-    import importlib
-    import pathlib
-
-    mod = importlib.import_module("bib2graph.service.reads")
-    source_file = mod.__file__
-    assert source_file is not None
-    tree = ast.parse(pathlib.Path(source_file).read_text(encoding="utf-8"))
-
-    forbidden = {"click", "fastapi"}
-    for node in ast.walk(tree):
-        if isinstance(node, ast.Import):
-            for alias in node.names:
-                assert alias.name.split(".")[0] not in forbidden, (
-                    f"service.reads importa '{alias.name}' — viola neutralidad"
-                )
-        elif isinstance(node, ast.ImportFrom):
-            assert (node.module or "").split(".")[0] not in forbidden, (
-                f"service.reads importa de '{node.module}' — viola neutralidad"
-            )
-        elif isinstance(node, ast.Call):
-            if (
-                isinstance(node.func, ast.Attribute)
-                and isinstance(node.func.value, ast.Name)
-                and node.func.value.id == "sys"
-                and node.func.attr == "exit"
-            ):
-                raise AssertionError("service.reads llama a sys.exit")
-            if isinstance(node.func, ast.Name) and node.func.id == "print":
-                raise AssertionError("service.reads llama a print()")
+# Neutralidad de transporte de service.reads: consolidada en
+# test_service.py::test_service_modulo_neutral_de_transporte (epic #184).

--- a/tests/unit/test_sources.py
+++ b/tests/unit/test_sources.py
@@ -334,58 +334,10 @@ def test_seed_executed_query_wrapping() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.unit
-def test_bibtex_load_sin_keyerror() -> None:
-    """``BibtexSource.load`` sobre .bib con campos faltantes → sin KeyError."""
-    from bib2graph.sources.bibtex import BibtexSource
-
-    source = BibtexSource()
-    # No debe lanzar KeyError ni ninguna excepción
-    corpus = source.load(str(MINIMAL_BIB_PATH))
-    assert len(corpus) > 0
-
-
-@pytest.mark.unit
-def test_bibtex_load_is_seed_true() -> None:
-    """Todos los papers cargados desde .bib tienen ``is_seed=True``."""
-    from bib2graph.sources.bibtex import BibtexSource
-
-    source = BibtexSource()
-    corpus = source.load(str(MINIMAL_BIB_PATH))
-
-    table = corpus.to_arrow()
-    is_seed_col = table.column("is_seed").to_pylist()
-    assert all(v is True for v in is_seed_col)
-
-
-@pytest.mark.unit
-def test_bibtex_load_curation_status_candidate() -> None:
-    """Todos los papers BibTeX tienen ``curation_status='candidate'``."""
-    from bib2graph.sources.bibtex import BibtexSource
-
-    source = BibtexSource()
-    corpus = source.load(str(MINIMAL_BIB_PATH))
-
-    table = corpus.to_arrow()
-    status_col = table.column("curation_status").to_pylist()
-    assert all(s == "candidate" for s in status_col)
-
-
-@pytest.mark.unit
-def test_bibtex_load_campos_faltantes_none() -> None:
-    """Entradas sin doi/abstract/journal → None (sin error)."""
-    from bib2graph.sources.bibtex import BibtexSource
-
-    source = BibtexSource()
-    corpus = source.load(str(MINIMAL_BIB_PATH))
-
-    table = corpus.to_arrow()
-    titles = table.column("title").to_pylist()
-    dois = table.column("doi").to_pylist()
-
-    # "Deuda ecológica del Perú" no tiene doi
-    idx = next(i for i, t in enumerate(titles) if "Per" in (t or ""))
-    assert dois[idx] is None
+# El contrato de campos de BibtexSource.load (is_seed=True, curation_status="candidate",
+# campos faltantes → None, sin KeyError) vive en test_bibtex_source_contrato.py
+# (test_campos_title_autores_anio_keywords_persisten) y se ejercita end-to-end en
+# test_seed_from_bib.py (run_seed_from_bib usa BibtexSource.load). Epic #184, sub-tarea 7.
 
 
 @pytest.mark.unit
@@ -764,49 +716,13 @@ def test_translate_exclusion_none_sin_efecto() -> None:
     assert executed_sin == executed_con
 
 
-@pytest.mark.unit
-def test_seed_exclude_en_query_ejecutada() -> None:
-    """``seed(..., exclude=[...])`` refleja cláusulas NOT dentro del paréntesis de búsqueda."""
-    works = _load_fixture_works()
-    transport = _make_handler(works)
-    source = OpenAlexSource(transport=transport)
-
-    result = source.seed("sistémico", exclude=["machine learning"])
-
-    # El campo NO se repite: exactamente un "title_and_abstract.search:" en la query
-    assert result.executed_query.count("title_and_abstract.search:") == 1
-    assert 'AND NOT "machine learning"' in result.executed_query
-    assert "AND NOT title_and_abstract.search:" not in result.executed_query
-
-
-@pytest.mark.unit
-def test_seed_exclude_multiples_en_query_ejecutada() -> None:
-    """Múltiples términos excluidos aparecen todos dentro del paréntesis en la query ejecutada."""
-    works = _load_fixture_works()
-    transport = _make_handler(works)
-    source = OpenAlexSource(transport=transport)
-
-    terms = ["machine learning", "algorithm"]
-    result = source.seed("sujeto", exclude=terms)
-
-    # El campo NO se repite: exactamente un "title_and_abstract.search:"
-    assert result.executed_query.count("title_and_abstract.search:") == 1
-    assert "AND NOT title_and_abstract.search:" not in result.executed_query
-    for term in terms:
-        assert f'AND NOT "{term}"' in result.executed_query
-
-
-@pytest.mark.unit
-def test_seed_exclude_en_translation_report() -> None:
-    """Los términos excluidos se mencionan en el ``translation_report``."""
-    works = _load_fixture_works()
-    transport = _make_handler(works)
-    source = OpenAlexSource(transport=transport)
-
-    result = source.seed("complejidad", exclude=["machine learning"])
-
-    combined = " ".join(result.translation_report)
-    assert "machine learning" in combined
+# La forma de la query con exclusiones (campo no repetido, AND NOT dentro del
+# paréntesis, exclusiones en el report) está cubierta por los tests PUROS de
+# _translate (test_translate_con_una_exclusion / _con_multiples_exclusiones /
+# _exclusiones_en_translation_report), que corren en el gate; el comportamiento
+# REAL contra la API (count>0) lo cubre el test @network
+# tests/integration/test_openalex_exclude_integration.py. Estos tests seed+mock
+# solo re-verificaban que seed() expone la salida de _translate. Epic #184, sub-tarea 6.
 
 
 @pytest.mark.unit

--- a/tests/unit/test_status_10.py
+++ b/tests/unit/test_status_10.py
@@ -396,18 +396,9 @@ class TestRunStatusCamposAditivos:
         assert "total_papers" in data
         assert "referenced_not_fetched" in data
 
-    def test_next_best_action_sin_estado_es_seed(self, tmp_path: Path) -> None:
-        """Sin estado previo (store vacío), next_best_action='seed'."""
-        from bib2graph.cli.commands.status import run_status
-        from bib2graph.stores.duckdb import DuckDBStore
-
-        store_path = tmp_path / "empty.duckdb"
-        DuckDBStore(store_path)  # solo inicializa tablas
-
-        data = run_status(store_path)
-
-        assert data["next_best_action"] == "seed"
-
+    # Semántica del FSM (None→seed, FORAGED→build, BUILT→read) eliminada aquí (epic #184):
+    # las invariantes viven en TestNextBestAction; este smoke verifica que run_status
+    # expone el campo con el valor correcto para un estado representativo.
     def test_next_best_action_seeded_es_chain(self, tmp_path: Path) -> None:
         """Tras seed (SEEDED), next_best_action='chain'."""
         from bib2graph.cli.commands.status import run_status
@@ -418,28 +409,6 @@ class TestRunStatusCamposAditivos:
         data = run_status(store_path)
 
         assert data["next_best_action"] == "chain"
-
-    def test_next_best_action_foraged_es_build(self, tmp_path: Path) -> None:
-        """Tras chain (FORAGED), next_best_action='build'."""
-        from bib2graph.cli.commands.status import run_status
-
-        store_path = tmp_path / "foraged.duckdb"
-        _seed_store_with_state(store_path, [_row("P1")], CycleState.FORAGED)
-
-        data = run_status(store_path)
-
-        assert data["next_best_action"] == "build"
-
-    def test_next_best_action_built_es_read(self, tmp_path: Path) -> None:
-        """Tras build (BUILT), next_best_action='read'."""
-        from bib2graph.cli.commands.status import run_status
-
-        store_path = tmp_path / "built.duckdb"
-        _seed_store_with_state(store_path, [_row("P1")], CycleState.BUILT)
-
-        data = run_status(store_path)
-
-        assert data["next_best_action"] == "read"
 
     def test_build_preview_tiene_cinco_entradas(self, tmp_path: Path) -> None:
         """build_preview incluye siempre las 5 redes posibles."""

--- a/tests/unit/test_status_10.py
+++ b/tests/unit/test_status_10.py
@@ -31,6 +31,13 @@ from bib2graph.schemas import CORPUS_SCHEMA
 
 pytestmark = pytest.mark.unit
 
+# Comandos de arreglo (fix_command) esperados, en un solo lugar: si cambia el copy
+# user-facing se edita acá y no en ~10 asserts dispersos (epic #184, sub-tarea 8).
+# Espejan los literales de networks/facade.py (_predict/_empty_network_entry).
+FIX_RESOLVE = "b2g seed --resolve"
+FIX_ENRICH = "b2g enrich"
+FIX_THESAURUS = "b2g build --thesaurus <archivo>"
+
 # ---------------------------------------------------------------------------
 # Helpers de fixture
 # ---------------------------------------------------------------------------
@@ -222,31 +229,31 @@ class TestPredictBuildPreview:
         bc = by_kind[NetworkKind.BIBLIOGRAPHIC_COUPLING]
         assert bc["would_be_empty"] is True
         assert "references_id" in str(bc["reason"])
-        assert bc["fix_command"] == "b2g seed --resolve"
+        assert bc["fix_command"] == FIX_RESOLVE
 
         # cocitation vacía: sin cited_by_id
         coc = by_kind[NetworkKind.COCITATION]
         assert coc["would_be_empty"] is True
         assert "cited_by_id" in str(coc["reason"])
-        assert coc["fix_command"] == "b2g enrich"
+        assert coc["fix_command"] == FIX_ENRICH
 
         # author_collab vacía: sin authors_id
         ac = by_kind[NetworkKind.AUTHOR_COLLAB]
         assert ac["would_be_empty"] is True
         assert "authors_id" in str(ac["reason"])
-        assert ac["fix_command"] == "b2g seed --resolve"
+        assert ac["fix_command"] == FIX_RESOLVE
 
         # institution_collab vacía: sin institutions_id
         ic = by_kind[NetworkKind.INSTITUTION_COLLAB]
         assert ic["would_be_empty"] is True
         assert "institutions_id" in str(ic["reason"])
-        assert ic["fix_command"] == "b2g seed --resolve"
+        assert ic["fix_command"] == FIX_RESOLVE
 
         # keyword_cooccurrence vacía: keywords_raw tiene datos pero keywords_id no
         # Fix debe ser build --thesaurus (puede generarlos sin red)
         kw = by_kind[NetworkKind.KEYWORD_COOCCURRENCE]
         assert kw["would_be_empty"] is True
-        assert kw["fix_command"] == "b2g build --thesaurus <archivo>"
+        assert kw["fix_command"] == FIX_THESAURUS
 
     def test_keywords_id_poblado_produce_red_no_vacia(self) -> None:
         """Con keywords_id >= 2 por paper, keyword_cooccurrence sale no-vacía.
@@ -335,7 +342,7 @@ class TestPredictBuildPreview:
         by_kind = {str(e["kind"]): e for e in preview}
         kw = by_kind[NetworkKind.KEYWORD_COOCCURRENCE]
         assert kw["would_be_empty"] is True
-        assert kw["fix_command"] == "b2g build --thesaurus <archivo>"
+        assert kw["fix_command"] == FIX_THESAURUS
 
     def test_fix_seed_resolve_cuando_no_hay_keywords_raw(self) -> None:
         """Sin keywords_raw, fix_command para keyword_cooccurrence='b2g seed --resolve'."""
@@ -344,7 +351,7 @@ class TestPredictBuildPreview:
         by_kind = {str(e["kind"]): e for e in preview}
         kw = by_kind[NetworkKind.KEYWORD_COOCCURRENCE]
         assert kw["would_be_empty"] is True
-        assert kw["fix_command"] == "b2g seed --resolve"
+        assert kw["fix_command"] == FIX_RESOLVE
 
     def test_kinds_son_strings_de_networkkind(self) -> None:
         """El campo kind de cada entrada es un string válido de NetworkKind."""
@@ -547,16 +554,13 @@ class TestCasoCanonicoNota20:
         assert by_kind[NetworkKind.COCITATION]["would_be_empty"] is True
 
         # Fix para citación/colaboración = seed --resolve
-        assert (
-            by_kind[NetworkKind.BIBLIOGRAPHIC_COUPLING]["fix_command"]
-            == "b2g seed --resolve"
-        )
-        assert by_kind[NetworkKind.COCITATION]["fix_command"] == "b2g enrich"
+        assert by_kind[NetworkKind.BIBLIOGRAPHIC_COUPLING]["fix_command"] == FIX_RESOLVE
+        assert by_kind[NetworkKind.COCITATION]["fix_command"] == FIX_ENRICH
 
         # Keyword fix = build --thesaurus (hay keywords_raw pero no keywords_id)
         kw = by_kind[NetworkKind.KEYWORD_COOCCURRENCE]
         assert kw["would_be_empty"] is True
-        assert kw["fix_command"] == "b2g build --thesaurus <archivo>"
+        assert kw["fix_command"] == FIX_THESAURUS
 
     def test_bibtex_con_thesaurus_keyword_no_vacia(self, tmp_path: Path) -> None:
         """Tras thesaurus, keywords_id se puebla → keyword_cooccurrence no-vacía.


### PR DESCRIPTION
PR consolidado del **epic #184** (poda de la suite de tests). Un commit por sub-tarea.

Criterio del PO: optimizar **funciones de test + fragilidad** (no conteo de instancias); **defensa en profundidad selectiva** (corpus_hash/FSM protegidos); deprecación cerrada; mocks de red → @network.

Sub-tareas (ver checklist en #184):
1. ✅ Consolidar neutralidad-AST (5 funciones → 1 parametrizado sobre service/).
2. Colapsar "stdout 1 línea JSON" (#151) y schema=="1" al guard canónico.
3. Maturity + next_best_action → semántica en helper puro + 1 presencia/forma por superficie.
4. Familia enrich → concentrar co-citación, recortar enrichers_8b.
5. Retiro de deprecación noun-verb (corre_y_delega), conservar solo el aviso.
6. Mocks de red OpenAlex → adelgazar + promover a @network.
7. Contrato BibtexSource.load → quitar subconjunto estricto + mutua-exclusión duplicada.
8. Refactor de fragilidad: constantes para asserts de copy, des-acoplar patch(), resolver r2_gate/idempotencia (hard-fail).

Gate verde + cobertura no baja en cada paso. Cierra #184 al mergear.