### PR TITLE
feat(skill): salida agéntica explícita en `skill add` (ruta + cómo opera + leelo)

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -560,8 +560,12 @@ llegó a ~20 subcomandos) se **consolidó** en una superficie que mapea 1:1 el c
   (comando meta global, no requiere `workspace.json` ni resolución de ambiente) y **emite el envelope
   `--json` `schema="1"` SIN transición de FSM** (ortogonal al lazo, igual que `gui`/`resolve`). La
   skill es **markdown sin dependencias Python** (no usa IA en el producto, ADR 0022: la IA está en el
-  Claude Code del usuario). *(El `data` emitido es `{install_path, scope, installed,
-  already_present}`, `schema="1"` intacto.)*
+  Claude Code del usuario). **Salida agéntica (AgenticExperience):** tanto la salida humana como el
+  envelope son **explícitos sobre dónde está el artículo y piden leerlo**, para que un agente de
+  **cualquier** proveedor pueda auto-onboardearse aunque no use el descubrimiento de Claude Code. *(El
+  `data` emitido es `{install_path, scope, installed, already_present, skill_md, reference_dir,
+  how_to}`, `schema="1"` intacto: `skill_md` es la ruta al `SKILL.md` y `how_to` el resumen a grandes
+  rasgos.)*
 - **`resolve`** (issues #110/#112, AS-BUILT, ADR
   [0035](decisiones/0035-ingesta-multipuerta-resolucion-doi.md), 20° subcomando): **resuelve los DOIs del
   corpus a IDs de OpenAlex (`source_id`)** — cierra el **GAP-1** del flujo BibTeX e2e. Los papers

--- a/docs/decisiones/0039-skill-comando-meta-distribucion.md
+++ b/docs/decisiones/0039-skill-comando-meta-distribucion.md
@@ -103,8 +103,13 @@ un comando **meta/distribución**, NO un paso del ciclo de investigación. El co
   - **Funciona sin workspace:** es un comando **meta global**, no requiere `workspace.json` ni
     resolución de ambiente (como `init` al crear, o como `gui`/`resolve` que no transicionan).
   - **Emite el envelope `--json` `schema="1"` SIN transición de FSM** (igual que `gui`/`resolve`):
-    es ortogonal al lazo. *(El `data` emitido es `{install_path, scope, installed, already_present}`,
-    `schema="1"` intacto; documentado en `docs/API.md`.)*
+    es ortogonal al lazo. *(El `data` emitido es `{install_path, scope, installed, already_present,
+    skill_md, reference_dir, how_to}`, `schema="1"` intacto; documentado en `docs/API.md`.)*
+  - **Salida agéntica (AgenticExperience):** la salida —humana y `--json`— es **explícita sobre dónde
+    quedó el `SKILL.md` y pide leerlo**, con un resumen `how_to` de cómo opera bib2graph a grandes
+    rasgos. Esto vuelve la skill **auto-descubrible por un agente de cualquier proveedor** (no solo
+    Claude Code) sin depender del mecanismo de descubrimiento del cliente — el primer puente hacia la
+    distribución agnóstica del 0.11.0 ([#193](https://github.com/complexluise/bib2graph/issues/193)).
 
 ### La historia de uso (cómo llega la skill al investigador)
 
@@ -139,7 +144,7 @@ legible para un agente.
 - **`docs/API.md` documenta una 2.ª excepción meta**: `skill` con `skill add` y sus flags, la
   reconciliación del conteo ("10 + gui + skill") y la nota de empaquetado (la skill entra por
   `packages`, **no** por `force-include`). El `data` del envelope es `{install_path, scope, installed,
-  already_present}` (`schema="1"` intacto).
+  already_present, skill_md, reference_dir, how_to}` (`schema="1"` intacto).
 - **El wheel engorda con la skill** (markdown, peso menor); al ser fuente del paquete entra por
   `packages` sin config extra. *(`pyproject.toml`/CI son del `coder`.)*
 - **Mantener la skill al día con el ciclo.** Si el ciclo del 0037 cambia (futuro ADR), la skill

--- a/src/bib2graph/cli/commands/skill.py
+++ b/src/bib2graph/cli/commands/skill.py
@@ -105,6 +105,40 @@ def _trees_identical(a: Path, b: Path) -> bool:
     return all(_trees_identical(a / sub, b / sub) for sub in cmp.common_dirs)
 
 
+# Resumen "a grandes rasgos" de cómo opera bib2graph, para que un agente de
+# CUALQUIER proveedor (no solo Claude Code) sepa qué es esto y vaya al SKILL.md.
+# (La integración real depende del cliente; esto la hace auto-descubrible: la
+# salida del CLI dice dónde está el artículo y pide leerlo. Ver #193 para la
+# distribución agnóstica al proveedor de 0.11.0.)
+_HOW_IT_WORKS = (
+    "bib2graph entrevista al investigador y corre el ciclo de forrajeo "
+    "seed→chain→build→read (one-shot o profundizando), priorizando candidatos "
+    "por estructura de citación (determinista, sin IA). El SKILL.md trae la "
+    "entrevista y cómo operar cada paso."
+)
+
+
+def _build_result(
+    dest: Path, scope: str, *, installed: bool, already_present: bool
+) -> dict[str, Any]:
+    """Arma el dict de resultado de ``skill add``.
+
+    Incluye las rutas que un agente necesita para **leer** la skill —``skill_md``
+    y ``reference_dir``— y el resumen ``how_to``, de modo que un agente agnóstico
+    al proveedor pueda auto-onboardearse desde la salida ``--json`` sin depender
+    del mecanismo de descubrimiento de Claude Code.
+    """
+    return {
+        "install_path": str(dest),
+        "scope": scope,
+        "installed": installed,
+        "already_present": already_present,
+        "skill_md": str(dest / "SKILL.md"),
+        "reference_dir": str(dest / "reference"),
+        "how_to": _HOW_IT_WORKS,
+    }
+
+
 def run_skill_add(
     *,
     scope: str,
@@ -124,9 +158,10 @@ def run_skill_add(
               default: ``Path.home()``).
 
     Returns:
-        Dict con ``"install_path"`` (ruta absoluta), ``"scope"``, ``"installed"``
-        (``True`` si copió/pisó, ``False`` si fue no-op) y ``"already_present"``
-        (``True`` si la versión vendida ya estaba instalada).
+        Dict con ``install_path``, ``scope``, ``installed`` (``True`` si
+        copió/pisó, ``False`` si fue no-op), ``already_present`` (``True`` si la
+        versión vendida ya estaba), y —para que un agente sepa dónde leerla—
+        ``skill_md`` (ruta al SKILL.md), ``reference_dir`` y ``how_to`` (resumen).
 
     Raises:
         UsageError: Si el destino existe, **difiere** de la versión vendida y
@@ -145,12 +180,7 @@ def run_skill_add(
 
     # Idempotencia: si ya está exactamente la versión vendida → no-op.
     if dest.exists() and _trees_identical(source, dest):
-        return {
-            "install_path": str(dest),
-            "scope": scope,
-            "installed": False,
-            "already_present": True,
-        }
+        return _build_result(dest, scope, installed=False, already_present=True)
 
     # Existe pero difiere (edición del usuario u otra versión): exige --force.
     if dest.exists() and not force:
@@ -164,12 +194,7 @@ def run_skill_add(
 
     shutil.copytree(source, dest)
 
-    return {
-        "install_path": str(dest),
-        "scope": scope,
-        "installed": True,
-        "already_present": False,
-    }
+    return _build_result(dest, scope, installed=True, already_present=False)
 
 
 # ---------------------------------------------------------------------------
@@ -248,10 +273,22 @@ def add_cmd(
             exit_code=0,
         )
         emit(envelope)
-    elif data["already_present"]:
-        emit_human(
-            f"Skill ya instalada (versión vendida) en: {data['install_path']} "
-            "— nada que hacer."
-        )
     else:
-        emit_human(f"Skill instalada en: {data['install_path']}")
+        estado = (
+            "Skill ya instalada (versión vendida)"
+            if data["already_present"]
+            else "Skill instalada"
+        )
+        # Salida explícita y agnóstica al proveedor: dónde quedó el artículo,
+        # cómo opera bib2graph a grandes rasgos, y la instrucción de leerlo
+        # (cualquier agente, no solo Claude Code, puede auto-onboardearse así).
+        emit_human(
+            f"{estado} en: {data['install_path']}\n"
+            "\n"
+            "Cómo opera bib2graph (a grandes rasgos):\n"
+            f"  {data['how_to']}\n"
+            "\n"
+            "Agente (cualquier proveedor): leé este archivo para operar bib2graph →\n"
+            f"  {data['skill_md']}\n"
+            f"  (marco teórico en {data['reference_dir']}/ciclo.md)"
+        )

--- a/tests/unit/test_skill_add.py
+++ b/tests/unit/test_skill_add.py
@@ -347,6 +347,10 @@ def test_skill_add_json_envelope_valido(tmp_path: Path, runner: CliRunner) -> No
     assert "install_path" in data, f"data no contiene 'install_path': {data!r}"
     assert "scope" in data, f"data no contiene 'scope': {data!r}"
     assert data["scope"] == "user"
+    # Campos agénticos: un agente agnóstico se onboardea desde el --json.
+    assert "skill_md" in data, f"data no contiene 'skill_md': {data!r}"
+    assert data["skill_md"].endswith("SKILL.md")
+    assert "how_to" in data, f"data no contiene 'how_to': {data!r}"
 
 
 # ---------------------------------------------------------------------------
@@ -476,3 +480,46 @@ def test_skill_md_anti_drift_comandos_en_cli() -> None:
                 f"registrado. Subcomandos de '{cmd}': {sorted(sub_cmds.keys())}. "
                 "Actualizá SKILL.md o registrá el subcomando."
             )
+
+
+# ---------------------------------------------------------------------------
+# 12. Salida agéntica (AgenticExperience) — explícita y agnóstica al proveedor
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_skill_add_data_incluye_rutas_agenticas(tmp_path: Path) -> None:
+    """El ``data`` trae skill_md, reference_dir y how_to (auto-onboarding agnóstico)."""
+    data = run_skill_add(scope="user", force=False, home=tmp_path)
+    install = tmp_path / ".claude" / "skills" / "bib2graph"
+
+    assert data["skill_md"] == str(install / "SKILL.md")
+    assert data["reference_dir"] == str(install / "reference")
+    assert "seed→chain→build→read" in data["how_to"], (
+        "how_to debe resumir el ciclo a grandes rasgos."
+    )
+    # Las rutas apuntan a archivos realmente instalados.
+    assert Path(data["skill_md"]).exists()
+
+
+@pytest.mark.unit
+def test_skill_add_salida_humana_es_explicita(
+    tmp_path: Path, runner: CliRunner
+) -> None:
+    """La salida humana dice dónde está el SKILL.md y pide leerlo.
+
+    Es la pieza que vuelve la skill usable por un agente de **cualquier**
+    proveedor (no solo Claude Code): el CLI es explícito sobre el artículo a leer.
+    """
+    with patch.object(Path, "home", return_value=tmp_path):
+        result = runner.invoke(b2g, ["skill", "add", "--user"], catch_exceptions=False)
+
+    assert result.exit_code == 0
+    out = result.output
+    assert "SKILL.md" in out, "La salida debe nombrar el SKILL.md."
+    assert "leé" in out.lower() or "lee" in out.lower(), (
+        "La salida debe pedirle al agente que lea el artículo."
+    )
+    assert "seed→chain→build→read" in out or "ciclo" in out.lower(), (
+        "La salida debe explicar a grandes rasgos cómo opera bib2graph."
+    )


### PR DESCRIPTION
Follow-up de #192 (skill 0.10.0). Hace la **AgenticExperience** explícita: para que un agente de **cualquier** proveedor pueda operar bib2graph, la salida del CLI dice **dónde** quedó el `SKILL.md`, explica **a grandes rasgos** cómo funciona, y pide **leerlo** — sin depender del mecanismo de descubrimiento de skills de Claude Code.

## Qué cambia
- **Salida humana** de `skill add`: ruta de instalación + resumen "cómo opera bib2graph" (entrevista + ciclo `seed→chain→build→read`) + instrucción explícita "Agente (cualquier proveedor): leé este archivo → `<path>/SKILL.md`".
- **Envelope** `data` gana campos **aditivos**: `skill_md` (ruta al SKILL.md), `reference_dir`, `how_to` (resumen). `schema="1"` intacto → un agente se auto-onboardea desde el `--json`.
- **Docs**: `API.md` + ADR 0039 (sección AgenticExperience).
- **Tests**: `data` agéntico (rutas + how_to) y salida humana explícita (nombra SKILL.md, pide leerlo, explica el ciclo).

## Por qué
Es el **primer puente** hacia la distribución agnóstica al proveedor (0.11.0, #193): aunque la *instalación* siga apuntando a `~/.claude/skills/` en 0.10.0, el CLI ya es **auto-descriptivo** sobre el artículo a leer, así cualquier agente puede entender cómo operar bib2graph.

Gate local: ruff + mypy + tests de la skill verde (CI corre la suite completa).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
