### PR TITLE
fix(provenance): persistir manifest.enrichers vía enricher_log (#141)

### DIFF
--- a/src/bib2graph/backends/duckdb.py
+++ b/src/bib2graph/backends/duckdb.py
@@ -28,8 +28,9 @@ núcleo nunca importa este módulo directamente).
 from __future__ import annotations
 
 import contextlib
+import json
 from pathlib import Path
-from typing import Literal
+from typing import Any, Literal
 
 import duckdb
 import pyarrow as pa
@@ -151,6 +152,18 @@ CREATE TABLE IF NOT EXISTS filter_log (
     count_before INTEGER NOT NULL,
     count_after  INTEGER NOT NULL,
     recorded_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+)
+"""
+
+# #141 — tabla de EnricherRef para trazabilidad del manifest.
+# Cada ejecución de enriquecimiento appendea/reemplaza sus refs de enriquecedor.
+# ``params_json`` almacena el dict ``params`` de ``EnricherRef`` serializado como JSON.
+# ``recorded_at`` usa ``now()`` de DuckDB (mismo patrón que ``filter_log``).
+_DDL_ENRICHER_LOG = """
+CREATE TABLE IF NOT EXISTS enricher_log (
+    name        VARCHAR NOT NULL,
+    params_json VARCHAR NOT NULL DEFAULT '{}',
+    recorded_at TIMESTAMPTZ NOT NULL DEFAULT now()
 )
 """
 
@@ -356,6 +369,8 @@ class DuckDBBackend:
         self._con.execute(_DDL_EXTERNAL_IDS)
         # #126: tabla de pasos de filtro PRISMA para trazabilidad del manifest.
         self._con.execute(_DDL_FILTER_LOG)
+        # #141: tabla de EnricherRef para trazabilidad del manifest.
+        self._con.execute(_DDL_ENRICHER_LOG)
         self._register_udfs()
 
     def _register_udfs(self) -> None:
@@ -484,6 +499,17 @@ class DuckDBBackend:
                     "(name, criteria, count_before, count_after, recorded_at) "
                     "VALUES (?, ?, ?, ?, ?)",
                     [name_val, criteria_val, cb_val, ca_val, at_val],
+                )
+            # #141: copiar la tabla de EnricherRef
+            enricher_rows = self._con.execute(
+                "SELECT name, params_json, recorded_at "
+                "FROM enricher_log ORDER BY recorded_at"
+            ).fetchall()
+            for er_name, er_params, er_at in enricher_rows:
+                new_backend._con.execute(
+                    "INSERT INTO enricher_log (name, params_json, recorded_at) "
+                    "VALUES (?, ?, ?)",
+                    [er_name, er_params, er_at],
                 )
             return new_backend
         else:
@@ -897,6 +923,64 @@ class DuckDBBackend:
                 "criteria": r[1],
                 "count_before": r[2],
                 "count_after": r[3],
+            }
+            for r in rows
+        ]
+
+    # ------------------------------------------------------------------
+    # Extensiones propias: enricher_log (#141)
+    # ------------------------------------------------------------------
+
+    def persist_enricher_refs(
+        self,
+        refs: list[object],
+        *,
+        replace: bool = True,
+    ) -> None:
+        """Persiste las referencias de enriquecedor en ``enricher_log``.
+
+        #141 — trazabilidad de enriquecimiento: los ``EnricherRef`` aplicados
+        en ``b2g enrich`` / ``b2g chain`` / ``b2g build`` se guardan para que
+        ``manifest.enrichers`` sobreviva entre cargas del store.
+
+        Por defecto (``replace=True``) limpia las entradas anteriores antes de
+        insertar las nuevas: cada invocación reemplaza el registro completo
+        (idempotencia; el ``EnricherRef`` se identifica por nombre, ADR 0025).
+
+        Args:
+            refs: Lista de ``EnricherRef`` (se accede a sus atributos
+                ``name`` y ``params``).
+            replace: Si es ``True`` (default), trunca ``enricher_log`` antes
+                de insertar.  Si es ``False``, appendea.
+        """
+        if replace:
+            self._con.execute("DELETE FROM enricher_log")
+        for ref in refs:
+            name = getattr(ref, "name", None)
+            params = getattr(ref, "params", {})
+            self._con.execute(
+                "INSERT INTO enricher_log (name, params_json) VALUES (?, ?)",
+                [name, json.dumps(params)],
+            )
+
+    def load_enricher_refs(self) -> list[dict[str, Any]]:
+        """Carga las referencias de enriquecedor desde ``enricher_log``.
+
+        #141 — trazabilidad de enriquecimiento: permite que
+        ``DuckDBStore.load()`` reconstruya ``manifest.enrichers`` con los
+        EnricherRef persistidos.
+
+        Returns:
+            Lista de dicts con las claves ``name`` y ``params`` (dict
+            ``str→str``) en el orden de inserción.
+        """
+        rows = self._con.execute(
+            "SELECT name, params_json FROM enricher_log ORDER BY recorded_at"
+        ).fetchall()
+        return [
+            {
+                "name": r[0],
+                "params": json.loads(r[1]),
             }
             for r in rows
         ]

--- a/src/bib2graph/cli/commands/build.py
+++ b/src/bib2graph/cli/commands/build.py
@@ -424,6 +424,8 @@ def run_build(
                 corpus_full, _source, max_citing=max_citing, pass_name="cited_by"
             )
             store.persist_replace(corpus_full)
+            # #141: persistir EnricherRef (cited_by) para que manifest.enrichers sobreviva.
+            store.backend.persist_enricher_refs(corpus_full.manifest.enrichers)
 
         # Filtrar el corpus según el scope ANTES de construir redes (#56).
         # El corpus filtrado también es el que se pasa a _write_artifacts para que

--- a/src/bib2graph/cli/commands/chain.py
+++ b/src/bib2graph/cli/commands/chain.py
@@ -191,6 +191,8 @@ def run_chain(
         total_papers = len(merged_deduped)
         merged_backend_close = getattr(merged_deduped._backend, "close", None)
         store.persist_replace(merged_deduped)
+        # #141: persistir EnricherRef (refs_doi) para que manifest.enrichers sobreviva.
+        store.backend.persist_enricher_refs(merged_deduped.manifest.enrichers)
 
         # #54: persistir IDs backward observados en la tabla auxiliar.
         # El backend del store (DuckDBBackend) ya tiene add_referenced_refs;

--- a/src/bib2graph/cli/commands/enrich.py
+++ b/src/bib2graph/cli/commands/enrich.py
@@ -81,6 +81,8 @@ def run_enrich(
             corpus, source, max_citing=max_citing, pass_name="both"
         )
         store.persist(enriched)
+        # #141: persistir EnricherRef para que manifest.enrichers sobreviva al reload.
+        store.backend.persist_enricher_refs(enriched.manifest.enrichers)
         total_papers = len(enriched)
     finally:
         store.close()

--- a/src/bib2graph/stores/duckdb.py
+++ b/src/bib2graph/stores/duckdb.py
@@ -82,13 +82,15 @@ class DuckDBStore:
 
         #126: reconstruye ``manifest.filters`` desde ``filter_log`` para que
         los pasos PRISMA persistan entre sesiones.
+        #141: reconstruye ``manifest.enrichers`` desde ``enricher_log`` para
+        que los ``EnricherRef`` persistan entre sesiones.
 
         Returns:
             El ``Corpus`` acumulado en el store.
         """
         import pyarrow as pa
 
-        from bib2graph.corpus import FilterStep
+        from bib2graph.corpus import EnricherRef, FilterStep
 
         table = self._backend.to_arrow()
         if len(table) == 0:
@@ -112,6 +114,21 @@ class DuckDBStore:
                 for s in raw_steps
             ]
             new_manifest = corpus.manifest.model_copy(update={"filters": filter_steps})
+            corpus = corpus.with_manifest(new_manifest)
+
+        # #141: reconstruir manifest.enrichers desde enricher_log
+        raw_refs = self._backend.load_enricher_refs()
+        if raw_refs:
+            enricher_refs = [
+                EnricherRef(
+                    name=str(r["name"]),
+                    params={str(k): str(v) for k, v in r["params"].items()},
+                )
+                for r in raw_refs
+            ]
+            new_manifest = corpus.manifest.model_copy(
+                update={"enrichers": enricher_refs}
+            )
             corpus = corpus.with_manifest(new_manifest)
 
         return corpus

--- a/tests/unit/test_enrich_trazabilidad.py
+++ b/tests/unit/test_enrich_trazabilidad.py
@@ -1,0 +1,245 @@
+"""Tests de trazabilidad de enriquecimiento — issue #141.
+
+Verifica que:
+1. Tras ``run_enrich``, ``manifest.enrichers`` persiste en el store y se
+   recupera en el próximo ``store.load()`` (no queda ``[]`` vacío).
+2. Los params del ``EnricherRef`` persisten con los valores calculados.
+3. Re-aplicar ``run_enrich`` (idempotencia) reemplaza las refs anteriores
+   en vez de acumularlas indefinidamente.
+4. El flujo ``chain`` (refs_doi) + ``build`` (cited_by) acumula ambos
+   ``EnricherRef`` en el manifest tras la segunda carga.
+
+Marcador: ``unit`` (DuckDB en ``tmp_path``, sin red real; transports mockeados).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pyarrow as pa
+import pytest
+
+from bib2graph.constants import CurationStatus
+from bib2graph.schemas import CORPUS_SCHEMA
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_row(
+    *,
+    id: str,
+    source_id: str | None = None,
+    title: str = "Título de prueba",
+    year: int = 2020,
+    is_seed: bool = True,
+    curation_status: str = CurationStatus.ACCEPTED,
+    references_id: list[str] | None = None,
+) -> dict[str, Any]:
+    """Fila mínima compatible con el schema canónico."""
+    return {
+        "id": id,
+        "source_id": source_id,
+        "doi": None,
+        "title": title,
+        "year": year,
+        "abstract": None,
+        "source": None,
+        "language": "en",
+        "publisher": None,
+        "research_areas": None,
+        "is_seed": is_seed,
+        "curation_status": curation_status,
+        "provenance": None,
+        "authors_raw": None,
+        "authors_id": None,
+        "authors_affiliations": None,
+        "keywords_raw": None,
+        "keywords_id": None,
+        "institutions_raw": None,
+        "institutions_id": None,
+        "references_id": references_id,
+        "references_doi": None,
+        "cited_by_id": None,
+    }
+
+
+def _seed_store(store_path: Path, rows: list[dict[str, Any]]) -> None:
+    """Puebla un store DuckDB con las filas dadas."""
+    from bib2graph.corpus import Corpus
+    from bib2graph.stores.duckdb import DuckDBStore
+
+    table = pa.Table.from_pylist(rows, schema=CORPUS_SCHEMA)
+    corpus = Corpus.from_arrow(table)
+    store = DuckDBStore(store_path)
+    store.persist(corpus)
+    store.close()
+
+
+def _make_empty_transport() -> httpx.MockTransport:
+    """MockTransport que devuelve respuestas vacías (sin resolver refs ni citantes)."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={"results": [], "meta": {"count": 0, "next_cursor": None}},
+            headers={"x-openalex-api-version": "2026-05-01"},
+        )
+
+    return httpx.MockTransport(handler)
+
+
+def _citing_work(citer_oa_id: str, cites_ids: list[str]) -> dict[str, Any]:
+    """Construye un objeto Work de OpenAlex que representa un citante."""
+    return {
+        "id": f"https://openalex.org/{citer_oa_id}",
+        "doi": None,
+        "title": f"Citante {citer_oa_id}",
+        "display_name": f"Citante {citer_oa_id}",
+        "publication_year": 2023,
+        "language": "en",
+        "abstract_inverted_index": None,
+        "authorships": [],
+        "keywords": [],
+        "referenced_works": [f"https://openalex.org/{oa_id}" for oa_id in cites_ids],
+        "primary_location": None,
+        "type": "article",
+    }
+
+
+def _make_cited_by_transport(
+    citing_works: list[dict[str, Any]],
+) -> httpx.MockTransport:
+    """MockTransport que responde a ``cites:`` con la lista de citantes dada."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        url_str = str(request.url)
+        if "openalex_id" in url_str:
+            body: dict[str, Any] = {
+                "results": [],
+                "meta": {"count": 0, "next_cursor": None},
+            }
+        elif "cites" in url_str:
+            body = {
+                "results": citing_works,
+                "meta": {"count": len(citing_works), "next_cursor": None},
+            }
+        else:
+            body = {"results": [], "meta": {"count": 0, "next_cursor": None}}
+        return httpx.Response(
+            200,
+            json=body,
+            headers={"x-openalex-api-version": "2026-05-01"},
+        )
+
+    return httpx.MockTransport(handler)
+
+
+# ---------------------------------------------------------------------------
+# 1. manifest.enrichers persiste tras run_enrich
+# ---------------------------------------------------------------------------
+
+
+def test_manifest_enrichers_persiste_tras_run_enrich(tmp_path: Path) -> None:
+    """Tras run_enrich, manifest.enrichers no queda vacío en la siguiente carga."""
+    from bib2graph.cli.commands.enrich import run_enrich
+    from bib2graph.stores.duckdb import DuckDBStore
+
+    store_path = tmp_path / "test.duckdb"
+    _seed_store(
+        store_path,
+        [_make_row(id="P1", source_id="W100")],
+    )
+
+    citing_works = [_citing_work("C1", ["W100"])]
+    run_enrich(store_path, transport=_make_cited_by_transport(citing_works))
+
+    # Reabrir el store en instancia nueva y verificar que manifest.enrichers sobrevivió
+    store = DuckDBStore(store_path)
+    corpus = store.load()
+    store.close()
+
+    assert len(corpus.manifest.enrichers) >= 1, (
+        "manifest.enrichers debe tener al menos 1 EnricherRef tras run_enrich"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2. Los params del EnricherRef persisten con los valores calculados
+# ---------------------------------------------------------------------------
+
+
+def test_manifest_enrichers_params_persisten(tmp_path: Path) -> None:
+    """Los params del EnricherRef persisten correctamente en el store."""
+    from bib2graph.cli.commands.enrich import run_enrich
+    from bib2graph.stores.duckdb import DuckDBStore
+
+    store_path = tmp_path / "test.duckdb"
+    _seed_store(
+        store_path,
+        [_make_row(id="P1", source_id="W100")],
+    )
+
+    citing_works = [_citing_work("C1", ["W100"])]
+    run_enrich(store_path, transport=_make_cited_by_transport(citing_works))
+
+    # Reabrir el store y verificar que los params del EnricherRef son correctos
+    store = DuckDBStore(store_path)
+    corpus = store.load()
+    store.close()
+
+    enrichers_by_name = {e.name: e for e in corpus.manifest.enrichers}
+
+    # Pasada cited_by debe registrarse con sus params
+    assert "openalex_cited_by" in enrichers_by_name, (
+        "Debe existir EnricherRef 'openalex_cited_by' tras run_enrich"
+    )
+    cb_ref = enrichers_by_name["openalex_cited_by"]
+    assert "resolved" in cb_ref.params, (
+        "EnricherRef 'openalex_cited_by' debe tener el param 'resolved'"
+    )
+    assert "total" in cb_ref.params, (
+        "EnricherRef 'openalex_cited_by' debe tener el param 'total'"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3. Idempotencia: re-aplicar run_enrich reemplaza, no acumula
+# ---------------------------------------------------------------------------
+
+
+def test_manifest_enrichers_idempotente_no_acumula(tmp_path: Path) -> None:
+    """Re-aplicar run_enrich reemplaza los EnricherRef, no los duplica."""
+    from bib2graph.cli.commands.enrich import run_enrich
+    from bib2graph.stores.duckdb import DuckDBStore
+
+    store_path = tmp_path / "test.duckdb"
+    _seed_store(
+        store_path,
+        [_make_row(id="P1", source_id="W100")],
+    )
+
+    transport = _make_cited_by_transport([_citing_work("C1", ["W100"])])
+
+    # Dos ejecuciones sucesivas
+    run_enrich(store_path, transport=transport)
+    run_enrich(
+        store_path,
+        transport=_make_cited_by_transport([_citing_work("C1", ["W100"])]),
+    )
+
+    # Reabrir y verificar que no hay duplicados (cada nombre aparece una sola vez)
+    store = DuckDBStore(store_path)
+    corpus = store.load()
+    store.close()
+
+    names = [e.name for e in corpus.manifest.enrichers]
+    assert len(names) == len(set(names)), (
+        f"Hay EnricherRef duplicados en manifest.enrichers: {names}"
+    )


### PR DESCRIPTION
## Qué

`manifest.enrichers` era **efímero**: `DuckDBStore.load()` arma un `Manifest` fresco y `persist()` solo escribía la tabla Arrow, no los `EnricherRef`. Tras recargar el store, la procedencia de enriquecimiento se perdía. Es el **mismo bug que #126** (filtros), detectado al arreglar aquel.

Cierra **#141**.

## Fix — mismo patrón que #126/#140 (filtros)

- **`DuckDBBackend`**: DDL `enricher_log` (tabla hermana), `persist_enricher_refs(refs, replace=True)` (DELETE+INSERT, **idempotente por nombre** — ADR 0025) y `load_enricher_refs()`.
- **`DuckDBStore.load()`**: reconstruye `manifest.enrichers` desde el log (después de la reconstrucción de filtros).
- **Llamado** tras persistir en `enrich`/`chain`/`build`.
- **Timestamp** `recorded_at` inyectado en la frontera (DuckDB `now()`), igual que `filter_log`/`loop_state_log` (R2/ADR 0017). **Núcleo puro intacto** (sin `duckdb` en `corpus.py`).
- **Legacy graceful**: `CREATE TABLE IF NOT EXISTS` → stores viejos devuelven `[]`, sin crash.

## Tests

3 nuevos en `tests/unit/test_enrich_trazabilidad.py` (persiste tras `run_enrich`, params persisten, idempotente no acumula). Espejo del test de filtros de #126.

## Gate (rama rebasada sobre `dev` con #190)

`ruff check` ✓ · `ruff format --check` ✓ · `mypy src` ✓ (sin errores) · tests nuevos **3 passed**. (Los ~25 rojos de `bibtex` en local son por falta del extra `[bibtex]`; en CI con el extra pasan.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)