### PR TITLE
fix(export): escribir CSV en utf-8-sig (BOM) para Excel-Windows

### DIFF
--- a/src/bib2graph/exporters/csv.py
+++ b/src/bib2graph/exporters/csv.py
@@ -50,7 +50,8 @@ class CsvExporter:
 
     def _write_aristas(self, g: _Graph, out_path: Path) -> None:
         """Escribe aristas.csv con columnas source,target,weight (D5)."""
-        with open(out_path / "aristas.csv", "w", newline="", encoding="utf-8") as f:
+        # utf-8-sig (BOM) para que Excel-Windows autodetecte UTF-8 y no rompa tildes (#214)
+        with open(out_path / "aristas.csv", "w", newline="", encoding="utf-8-sig") as f:
             writer = csv.writer(f)
             writer.writerow(["source", "target", "weight"])
             # Orden determinista: aristas ordenadas por (source, target)
@@ -85,7 +86,8 @@ class CsvExporter:
         metric_cols = sorted(metric_keys)
         header = ["id", "label", *attr_cols, *metric_cols]
 
-        with open(out_path / "nodos.csv", "w", newline="", encoding="utf-8") as f:
+        # utf-8-sig (BOM) para que Excel-Windows autodetecte UTF-8 y no rompa tildes (#214)
+        with open(out_path / "nodos.csv", "w", newline="", encoding="utf-8-sig") as f:
             writer = csv.writer(f)
             writer.writerow(header)
             # Orden determinista: nodos ordenados por id como string

--- a/tests/unit/test_exporters.py
+++ b/tests/unit/test_exporters.py
@@ -148,6 +148,30 @@ def test_csv_aristas_columnas_correctas(
     """aristas.csv tiene columnas source,target,weight (D5)."""
     CsvExporter().export(simple_graph, results_dict, tmp_path)
 
-    content = (tmp_path / "aristas.csv").read_text(encoding="utf-8")
+    content = (tmp_path / "aristas.csv").read_text(encoding="utf-8-sig")
     header = content.splitlines()[0]
     assert header == "source,target,weight"
+
+
+@pytest.mark.unit
+def test_csv_escribe_con_bom_utf8_para_excel(tmp_path: Path) -> None:
+    """Los CSV se escriben en utf-8-sig (BOM) para Excel-Windows (#214).
+
+    Sin BOM, Excel asume cp1252 y rompe las tildes (Valoración → ValoraciÃ³n).
+    Regresión: el export debe empezar con el BOM UTF-8 y las tildes deben
+    sobrevivir el round-trip.
+    """
+    g = nx.Graph()
+    g.add_node("doi:abc", label="Valoración estética (Müller, 1987)")
+    g.add_node("doi:def", label="Crítica de la razón")
+    g.add_edge("doi:abc", "doi:def", weight=3)
+
+    CsvExporter().export(g, {"grado": dict(g.degree())}, tmp_path)
+
+    for name in ("nodos.csv", "aristas.csv"):
+        raw = (tmp_path / name).read_bytes()
+        assert raw.startswith(b"\xef\xbb\xbf"), f"{name} debe empezar con BOM UTF-8"
+
+    # Las tildes sobreviven el round-trip leyendo utf-8-sig
+    nodos = (tmp_path / "nodos.csv").read_text(encoding="utf-8-sig")
+    assert "Valoración estética (Müller, 1987)" in nodos


### PR DESCRIPTION
## Qué

`CsvExporter` escribía los CSV en UTF-8 **sin BOM**. Excel en Windows, ante un CSV sin BOM, asume cp1252 → mojibake en tildes/eñes (`Valoración` → `ValoraciÃ³n`, `Müller` → `MÃ¼ller`).

## Fix

Las dos escrituras (`aristas.csv`, `nodos.csv`) pasan a `encoding="utf-8-sig"` (UTF-8 con BOM), que es lo que Excel autodetecta. `src/bib2graph/exporters/csv.py`.

## Test de regresión

`test_csv_escribe_con_bom_utf8_para_excel`: clava que ambos CSV empiezan con el BOM (`EF BB BF`) y que las tildes sobreviven el round-trip. Se ajustó `test_csv_aristas_columnas_correctas` a leer con `utf-8-sig` (forma correcta de leer un archivo con BOM).

## Gate

`ruff` ✓ · `ruff format` ✓ · `mypy` ✓ · `pytest` ✓ (módulo exporters + bibtex verdes).

Alto impacto para el **lanzamiento hispano**. Split del bug de encoding desde #203 (que queda con campos+URL para 0.11.0).

Closes #214.
