### PR TITLE
docs(adr): cerrar drifts de trazabilidad de supersesión ADR↔código (#222)

### DIFF
--- a/docs/decisiones/0005-dependencias-extras.md
+++ b/docs/decisiones/0005-dependencias-extras.md
@@ -3,6 +3,10 @@
 - **Estado:** Aceptada
 - **Fecha:** 2026-06-14
 - **Relacionada con:** [0002](0002-modelo-agnostico-backend.md), [0003](0003-persistencia-opcional.md), [0004](0004-enriquecimiento-opcional.md)
+- **Núcleo reencuadrado (pandas→Arrow) por [0006](0006-tabla-canonica-y-networkspec.md):** el
+  cuerpo lista `pandas` en el «Núcleo (siempre)»; la tabla canónica pasó a **Arrow/`pyarrow`**
+  (0006), así que `pandas` ya no es la dependencia de núcleo que describe el cuerpo. Ese listado
+  queda como historia.
 
 ## Contexto
 

--- a/docs/decisiones/0013-identidad-hash-merge-corpus.md
+++ b/docs/decisiones/0013-identidad-hash-merge-corpus.md
@@ -16,6 +16,13 @@
   `DuckDBBackend` en SQL `UPDATE`/`MERGE` por `id`). El `corpus_hash` (D2) se computa siempre
   sobre el contenido (`corpus.to_arrow()`), nunca sobre detalles del backend. D4 (`provenance`
   como log append-only), D5/D6 (Manifest) no cambian.
+- **Precedencia de D1 invertida (2026-06-22, AS-BUILT 0.8) por
+  [0036](0036-identidad-source-id-agnostica-doi-ancla.md):** la precedencia de la fuente del
+  `valor` del `id` (D1) deja de ser `openalex_id`-first y pasa a **`doi:` > `source_id` (`src:`) >
+  `tt:`**: el DOI es el ancla universal y `openalex_id` se renombra a `source_id` genérico (motor
+  de extracción intercambiable, tabla lateral `external_ids`). El cuerpo de D1 (más abajo) describe
+  la precedencia **original** (`oa:`/`openalex_id`-first) y **queda como historia**; el AS-BUILT es
+  `_compute_id` en `corpus.py` (`doi` > `source_id` > `title|year`). D2/D3/D4 no cambian.
 
 ## Contexto
 

--- a/docs/decisiones/0021-cli-agente-native-contrato.md
+++ b/docs/decisiones/0021-cli-agente-native-contrato.md
@@ -14,6 +14,12 @@
 - **Toca:** [0009](0009-biblioteca-viva-duckdb.md) (el estado vive en el archivo `.duckdb`, no en
   la sesión), [0020](0020-metodo-forrajeo-scent-filtros-reject.md) (comando `filter` y los
   filtros que marcan `rejected`).
+- **Superficie consolidada (12→10 verbos) por [0037](0037-superficie-cli-10-verbos-ciclo.md) y
+  [0038](0038-destino-verbos-huerfanos-0037.md):** el cuerpo y sus enmiendas hablan de **11/12
+  subcomandos**; la superficie 0.10.0 se consolida a **10 verbos agents-first** (`monitor`/`inspect`/
+  `networks` absorbidos; `curate`/`read` noun-verb; aliases de retrocompat cierran en 0.11.0). El
+  **envelope `schema="1"`, los exit codes (§D) y la FSM (§F) quedan intactos**. El conteo de
+  subcomandos del cuerpo queda como historia.
 
 ## Contexto
 

--- a/docs/decisiones/0023-capa-constants-modelos-schema.md
+++ b/docs/decisiones/0023-capa-constants-modelos-schema.md
@@ -66,3 +66,15 @@ Se **mantiene** "`Paper`/`Author`/… = vistas derivadas, no tipos del modelo".
 > doble verdad: `kind: NetworkKind` (`spec.py`), y `facade._projector_for_kind` compara contra los
 > miembros del enum (`NetworkKind.BIBLIOGRAPHIC_COUPLING`, …) en vez de string-literals. **`NetworkKind`
 > es ahora la fuente única real** (no validada por test de paridad: validada por el type-checker).
+>
+> **AS-BUILT (enmienda, 2026-06-22) — la dirección de autoridad del schema (§3) es la INVERSA.** El
+> §3 de la Decisión declara **`PaperRow` (Pydantic) autoritativa** y dice que `CORPUS_SCHEMA` (Arrow)
+> se "**deriva/verifica**" de ella. El AS-BUILT invierte la autoridad: **`CORPUS_SCHEMA` (Arrow) es la
+> definición autoritativa** y **`PaperRow` se alinea campo a campo**. De las dos vías que el §3
+> mencionaba, el AS-BUILT conserva la **verificación** y descarta la **derivación**: el invariante "no
+> driftean" se sostiene por **paridad verificada por test** (`assert_schema_parity()` en `schemas.py`,
+> que falla si los nombres/orden de campo divergen — comentario explícito: "`CORPUS_SCHEMA` sigue
+> siendo la definición Arrow autoritativa; `PaperRow` se alinea"), no por generar uno desde el otro.
+> **El fin anti-drift del §3 se cumple** (una sola verdad, imposible de driftear sin que falle el
+> test/type-check); lo que cambia es la *dirección* de autoridad (`PaperRow` → `CORPUS_SCHEMA`). El
+> texto del §3 queda como historia.

--- a/src/bib2graph/cli/__init__.py
+++ b/src/bib2graph/cli/__init__.py
@@ -7,12 +7,18 @@ Entry points en ``pyproject.toml``:
     b2g      = "bib2graph.cli:main"
     bib2graph = "bib2graph.cli:main_bib2graph_alias"  # deprecado, #165
 
-Subcomandos planos (17):
-    init, seed, chain, filter, build, enrich, monitor, export,
-    status, validate, accept, reject, networks, restore (shim #163),
-    resolve.
+Superficie (ADR 0037/0038/0040): 10 verbos del ciclo + ``skill`` (meta) +
+9 aliases deprecados. En total se registran 16 subcomandos planos + 4 grupos.
 
-    inspect: absorbido por ``read show`` (#156); permanece como alias.
+Verbos del ciclo (10) — planos: init, seed, chain, build, export, status,
+    validate; grupos (abajo): read, curate, snapshot.
+Meta (1): skill — distribución de la skill de Claude Code (ADR 0039), fuera
+    de los 10 del ciclo.
+Aliases deprecados (9) — la ventana de retrocompat cierra en 0.11.0 (ADR 0037/0038):
+    accept→curate accept, reject→curate reject, filter→curate filter,
+    enrich→chain/build, inspect→read show (#156), monitor→chain --since,
+    networks→build --spec, resolve→seed --resolve, restore→snapshot restore.
+    (``gui`` fue RETIRADO de la librería por el ADR 0040; ya no se registra.)
 
 Grupos noun-verb (4):
     read     [list|stats|show|top] — lecturas read-only del corpus (#156/#157).
@@ -115,12 +121,11 @@ def b2g(ctx: click.Context, workspace: str | None) -> None:
     Si no hay ninguno, los comandos que necesitan la biblioteca emiten un
     error accionable (exit 1) que sugiere 'b2g init' o '--workspace'.
 
-    Subcomandos: init, seed, chain, filter, build, enrich, monitor, export,
-    status, validate, accept, reject, networks, restore (shim),
-    resolve,
-    read [list|stats|show|top], curate [dump|apply|accept|reject|filter],
-    snapshot [create|restore] (ADR 0038),
-    skill [add] (Epic #188).
+    Verbos del ciclo (ADR 0037): init, seed, chain, build, export, status,
+    validate, read [list|stats|show|top], curate [dump|apply|accept|reject|filter],
+    snapshot [create|restore]. Meta: skill [add] (Epic #188).
+    Aliases deprecados (cierran en 0.11.0, ADR 0038): accept, reject, filter,
+    enrich, monitor, inspect, networks, resolve, restore.
 
     Ejemplo:
         b2g init mi-investigacion


### PR DESCRIPTION
Cierra #222.

## Qué y por qué

Auditoría de los 40 ADRs contra código/`pyproject`/CLI (2026-06-29): la traducción ADR→código es **sólida** — no hay decisiones-adorno; incluso el 0040 (BREAKING, retiro GUI de ayer) está ejecutado punto por punto en `fa19291`. El único defecto recurrente es **trazabilidad de supersesión**: headers/cuerpos que no apuntan hacia adelante al ADR que los reemplazó, así que el documento engaña si se lee aislado.

Este PR cierra esos drifts. **Solo documentación/comentarios; sin cambio de comportamiento.** Respeta la inmutabilidad del registro (README §registro): no se reescribe ningún cuerpo de ADR aceptado — solo anotaciones de header / bloques de enmienda fechados.

## Commits (uno por punto)

1. **`docs(adr)` 0013** — D1 (precedencia del `id`) fue invertida por **0036** (`doi: > source_id(src:) > tt:`, `corpus.py:90-103`); el header no lo enlazaba. Nota de supersesión fechada.
2. **`docs(adr)` 0023** — el §3 declara `PaperRow` autoritativa; el AS-BUILT invierte la dirección: `CORPUS_SCHEMA` (Arrow) autoritativa, `PaperRow` se alinea por paridad verificada (`assert_schema_parity()`). Enmienda AS-BUILT fechada.
3. **`docs(cli)`** — el docstring de `cli/__init__.py` decía "Subcomandos planos (17)" desfasado. Corregido a la taxonomía real verificada contra `add_command`/`emit_deprecation`: **16 planos + 4 grupos** = 10 verbos del ciclo + `skill` (meta) + 9 aliases deprecados; `gui` retirado (0040).
4. **`docs(adr)` 0005/0021** — punteros hacia adelante (0005 `pandas`→Arrow por 0006; 0021 12→10 verbos por 0037/0038).

## Ciclo architect → verifier

- **architect**: encuadró cada punto y redactó las anotaciones de docs respetando la inmutabilidad.
- **verifier**: **APROBADO**. Gate `ruff`/`mypy` limpios; `pytest` verde con extras (las fallas locales eran ambientales por el extra `bibtex` no sincronizado en el worktree). Verificó cada afirmación contra el código. Detectó una imprecisión menor en la enmienda de 0023 (caracterizaba el §3 como "derivación pura" cuando dice "deriva/verifica") → **corregida y fundida en el commit del punto 2** antes del push.

## Fuera de alcance (a propósito)

- `git clean` de restos GUI sin trackear (`gui/static/`, `frontend/node_modules/`, `api/__pycache__`): no commiteables y la limpieza profunda ya es de #191.
- Extras vacíos `[s2]/[neo4j]/[viz]`: honestos (futuro declarado), no drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
