### PR TITLE
fix(sources): error accionable ante 429 de OpenAlex en seed y chaining (#210)

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -851,7 +851,7 @@ def load_equation_spec(path: str | Path) -> EquationSpec:
 
 | Implementación | Estado | Notas |
 |----------------|--------|-------|
-| `OpenAlexSource` | **v1** | **Referencia/backbone**, sobre `httpx`. Entrega mínimo + enriquecimiento (refs inline + afiliaciones per-autor + instituciones; `cited_by_id` lo puebla el chaining/Enricher, no el seed). Traducción **passthrough**: envuelve la ecuación en `title_and_abstract.search:(...)` y **reporta** los límites WoS (NEAR/comodín/tags) sin traducirlos. Flag `native=True` (query cruda). **Negaciones (`exclude`):** cada `AND NOT "<término>"` se inyecta **dentro** de la única expresión `search:((query) AND NOT "<término>")` (campo no repetido; el filtro de año queda como predicado separado por coma, fuera del `search`) y se reporta en el `translation_report`; ignorado con `native`. Credenciales inyectadas (arg → `OPENALEX_API_KEY` → `~/.openalex/credentials` → polite pool; ADR 0012). Cursor paging con tope `max_results` (default 200). Puebla `Manifest.openalex_version` (ADR 0017). `transport` inyectable (tests sin red). |
+| `OpenAlexSource` | **v1** | **Referencia/backbone**, sobre `httpx`. Entrega mínimo + enriquecimiento (refs inline + afiliaciones per-autor + instituciones; `cited_by_id` lo puebla el chaining/Enricher, no el seed). Traducción **passthrough**: envuelve la ecuación en `title_and_abstract.search:(...)` y **reporta** los límites WoS (NEAR/comodín/tags) sin traducirlos. Flag `native=True` (query cruda). **Negaciones (`exclude`):** cada `AND NOT "<término>"` se inyecta **dentro** de la única expresión `search:((query) AND NOT "<término>")` (campo no repetido; el filtro de año queda como predicado separado por coma, fuera del `search`) y se reporta en el `translation_report`; ignorado con `native`. Credenciales inyectadas (arg → `OPENALEX_API_KEY` → `~/.openalex/credentials` → polite pool; ADR 0012). Cursor paging con tope `max_results` (default 200). Puebla `Manifest.openalex_version` (ADR 0017). `transport` inyectable (tests sin red). Un **429** (rate limit del pool anónimo) en `seed()` → `NetworkError` (exit 4) con mensaje **accionable**: declarar `--email` mueve la petición al polite pool (remedio primario); api_key opcional (ADR 0012, #210). |
 | `BibtexSource` | **v1, secundaria** | Sembrar desde *pearls* vía `load()`. Extra **`[bibtex]`** (import perezoso de `bibtexparser`); acceso defensivo (campos faltantes sin `KeyError`). Mínimo universal. `seed()` lanza `NotImplementedError`. `.bib` con error grave → `ValueError`; sin entradas válidas → `UserWarning` (no no-op silencioso). Carga bulk con `from_arrow`. |
 | `ScieloSource` / `RedalycSource` / `LaReferenciaSource` | futuro | Fuentes regionales, mínimo universal. Declaradas, no implementadas (ADR 0018). |
 | `RisSource` / `CsvSource` | futuro | No implementados. |
@@ -860,7 +860,9 @@ def load_equation_spec(path: str | Path) -> EquationSpec:
 el `Forager` y el `Enricher`):
 
 - **`fetch_citing(openalex_id) -> list[dict]`** (singular, forward chaining): `GET works?filter=cites:`,
-  con retry/backoff ante 429/5xx.
+  con retry/backoff ante 429/5xx. Al **agotar** los reintentos con **429** → `NetworkError` (exit 4)
+  **accionable** (polite pool/`--email`; ADR 0012, #210); los 5xx agotados conservan
+  `httpx.HTTPStatusError`. Asimetría deliberada: solo el 429 tiene remedio del lado del usuario.
 - **`fetch_citing_batch(ids, *, max_per_paper, since=None) -> dict[seed_id, list[citer_id]]`**: trae los
   citantes **batcheando por OR** (`cites:W1|W2|...`, lotes ≤50), pagina por cursor y **atribuye página a
   página** con **presupuesto por semilla** (corta cuando todas alcanzan `max_per_paper`; sin starvation).

--- a/docs/decisiones/0012-openalex-credenciales.md
+++ b/docs/decisiones/0012-openalex-credenciales.md
@@ -1,6 +1,7 @@
 # 0012 — Credenciales de OpenAlex: email del pool cortés + API key opcional, inyectados
 
-- **Estado:** Aceptada
+- **Estado:** Aceptada · **enmendada 2026-06-29** (#210: un 429 se traduce a `NetworkError`
+  accionable que apunta al polite pool, en `seed` y en el chaining — ver "Seguimiento" al final)
 - **Fecha:** 2026-06-15
 - **Decidido por:** IA (Claude Opus 4.8), validado por el Product Owner humano
   (ver [`registro-ia.md`](registro-ia.md))
@@ -44,3 +45,24 @@ secreto en código**, ningún `os.environ.get("...", "literal")` para la key.
   en el README cuando llegue el Hito 4, y testear ambos caminos (con y sin key) contra API
   mockeada — sin red en CI.
 - No cambia el núcleo puro: las credenciales viven en la costura `Source`, inyectadas.
+
+## Seguimiento — 2026-06-29 (#210: el 429 aflora como error accionable hacia el polite pool)
+
+> Realización de la consecuencia "se avisa" (lección 7): un **429 (Too Many Requests)** del pool
+> anónimo ya **no** aflora como `httpx.HTTPStatusError` pelado, sino como **`NetworkError`** (exit 4,
+> `service/errors.py`) con un mensaje que nombra el **remedio primario — declarar el email mueve la
+> petición al polite pool** (límite más generoso), la **api_key como opcional** y referencia este ADR
+> (`_MSG_RATE_LIMIT_429`). Aplica en **ambos caminos**: `seed()` (al recibir 429) y
+> `fetch_citing`/chaining (`_fetch_all_with_retry`, al **agotar** los reintentos con 429).
+>
+> No cambia la **política** de credenciales (la decisión de este ADR): la implementa. Statuses no-429
+> y los retryables 5xx (500/502/503/504) conservan su conducta anterior — asimetría deliberada: solo
+> el 429 tiene remedio del lado del usuario (el polite pool).
+>
+> Extender el fix más allá del `seed` del DoD original —que el chaining levante `NetworkError` en vez
+> de `HTTPStatusError` al agotar reintentos— fue **decisión consciente del PO**: dejar el footgun del
+> 429 cubierto en todos los caminos de cara a la promoción de la librería.
+>
+> **Decidido por:** Product Owner humano (2026-06-29, #210); implementado y verificado (gate verde).
+> Ver `src/bib2graph/sources/openalex.py` (`_MSG_RATE_LIMIT_429`, `seed`, `_fetch_all_with_retry`) y
+> `docs/API.md` §2.

--- a/src/bib2graph/sources/openalex.py
+++ b/src/bib2graph/sources/openalex.py
@@ -35,6 +35,7 @@ import pyarrow as pa
 from bib2graph.constants import Col, CurationStatus
 from bib2graph.corpus import Corpus, EquationRef, _rows_with_ids
 from bib2graph.schemas import CORPUS_SCHEMA, ProvenanceEvent
+from bib2graph.service.errors import NetworkError
 
 from .base import SeedResult
 
@@ -71,6 +72,18 @@ _RE_WOS_TAG = re.compile(r"\b(TS|AB|TI|AU|SO|LA|DT|WC|SU)=", re.IGNORECASE)
 _RETRY_STATUS_CODES: frozenset[int] = frozenset({429, 500, 502, 503, 504})
 _RETRY_MAX_ATTEMPTS: int = 3
 _RETRY_BACKOFF_BASE: float = 1.0  # segundos; duplica por cada intento
+
+# Mensaje accionable para 429 (pool anónimo → polite pool).
+# ADR 0012: el email mueve al polite pool (límite más generoso);
+# la api_key mejora aún más (opcional).
+_MSG_RATE_LIMIT_429 = (
+    "OpenAlex respondió 429 (Too Many Requests): límite de tasa del pool anónimo"
+    " alcanzado. Remedio primario — declarar tu email mueve la petición al polite"
+    " pool, que tiene un límite más generoso. En el CLI: b2g seed --email"
+    " tu@email.com … En código: OpenAlexSource(email='tu@email.com')."
+    " Opcional: una api_key mejora el límite aún más"
+    " (variable de entorno OPENALEX_API_KEY). Ver ADR 0012."
+)
 
 
 # ---------------------------------------------------------------------------
@@ -552,7 +565,12 @@ class OpenAlexSource:
         equation_id = f"eq-{datetime.now(UTC).strftime('%Y%m%dT%H%M%S')}"
         fetched_at = datetime.now(UTC).isoformat()
 
-        works, openalex_version = self._fetch_all(executed_query)
+        try:
+            works, openalex_version = self._fetch_all(executed_query)
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code == 429:
+                raise NetworkError(_MSG_RATE_LIMIT_429) from exc
+            raise
 
         # R5: bulk-load — construir tabla Arrow de una vez en vez de N add_paper/clone.
         rows = [
@@ -612,9 +630,10 @@ class OpenAlexSource:
             Tupla ``(works, openalex_version)`` con retry/backoff.
 
         Raises:
-            httpx.HTTPStatusError: Si se agotan los reintentos.
+            NetworkError: Si se agotan los reintentos con 429 (con mensaje accionable).
+            httpx.HTTPStatusError: Si se agotan los reintentos con otro código retryable.
         """
-        last_exc: Exception | None = None
+        last_exc: httpx.HTTPStatusError | None = None
         for attempt in range(_RETRY_MAX_ATTEMPTS):
             try:
                 return self._fetch_all(filter_str)
@@ -627,6 +646,8 @@ class OpenAlexSource:
                     raise  # error no retryable: propagar inmediatamente
         # Se agotaron los reintentos
         assert last_exc is not None
+        if last_exc.response.status_code == 429:
+            raise NetworkError(_MSG_RATE_LIMIT_429) from last_exc
         raise last_exc
 
     def fetch_citing(self, openalex_id: str) -> list[dict[str, Any]]:

--- a/tests/unit/test_r5_robustness.py
+++ b/tests/unit/test_r5_robustness.py
@@ -375,10 +375,13 @@ def test_fetch_citing_retry_ante_429_luego_200() -> None:
 
 @pytest.mark.unit
 def test_fetch_citing_retry_agotado_lanza_error() -> None:
-    """fetch_citing lanza HTTPStatusError si se agotan los reintentos.
+    """fetch_citing lanza NetworkError si se agotan los reintentos con 429.
 
-    R5: con 3 intentos de 429 consecutivos, la excepción se propaga.
+    R5 / #210: con 3 intentos de 429 consecutivos, la excepción se convierte
+    a NetworkError accionable (no HTTPStatusError pelado).
     """
+    from bib2graph.service.errors import NetworkError
+
     calls: list[int] = [0]
 
     def handler_siempre_429(request: httpx.Request) -> httpx.Response:
@@ -390,11 +393,13 @@ def test_fetch_citing_retry_agotado_lanza_error() -> None:
 
     with (
         patch("bib2graph.sources.openalex.time.sleep"),
-        pytest.raises(httpx.HTTPStatusError) as exc_info,
+        pytest.raises(NetworkError) as exc_info,
     ):
         source.fetch_citing("W12345")
 
-    assert exc_info.value.response.status_code == 429
+    msg = str(exc_info.value)
+    assert "429" in msg
+    assert "polite" in msg.lower()
     # Se intentó _RETRY_MAX_ATTEMPTS veces (cada intento = al menos 1 HTTP)
     assert calls[0] >= 1
 
@@ -423,6 +428,35 @@ def test_fetch_citing_no_retry_ante_404() -> None:
     # No reintentó — solo 1 llamada
     assert calls[0] == 1
     assert not mock_sleep.called
+
+
+@pytest.mark.unit
+def test_fetch_citing_429_levanta_network_error_accionable() -> None:
+    """fetch_citing con 429 agotado lanza NetworkError con mensaje completo.
+
+    #210: el path de chaining (_fetch_all_with_retry) convierte 429
+    agotado en NetworkError con mensaje que menciona email, polite-pool,
+    ADR 0012 y api_key como opcional. Sin red real (MockTransport).
+    """
+    from bib2graph.service.errors import NetworkError
+
+    def handler_siempre_429(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(429, text="Rate limit exceeded")
+
+    transport = httpx.MockTransport(handler_siempre_429)
+    source = OpenAlexSource(transport=transport)
+
+    with (
+        patch("bib2graph.sources.openalex.time.sleep"),
+        pytest.raises(NetworkError) as exc_info,
+    ):
+        source.fetch_citing("W99999")
+
+    msg = str(exc_info.value)
+    assert "email" in msg.lower()
+    assert "polite" in msg.lower()
+    assert "ADR 0012" in msg
+    assert "api_key" in msg  # la api_key se nombra como opcional en el mensaje
 
 
 # ===========================================================================

--- a/tests/unit/test_sources.py
+++ b/tests/unit/test_sources.py
@@ -782,6 +782,39 @@ def test_translate_exclude_strip_comillas_internas() -> None:
     assert after_not.count('"') == 1  # solo la comilla de cierre
 
 
+# ---------------------------------------------------------------------------
+# #210 — 429 → NetworkError accionable (polite pool / email)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_seed_429_levanta_network_error_accionable() -> None:
+    """Un 429 de OpenAlex en seed() lanza NetworkError con mensaje accionable.
+
+    Sin email declarado → pool anónimo → 429. El error debe mencionar email
+    y polite pool como remedio primario (no un HTTPStatusError pelado).
+    Referencia: ADR 0012.
+    """
+    from bib2graph.service.errors import NetworkError
+
+    def handler_429(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(429, text="Too Many Requests")
+
+    transport = httpx.MockTransport(handler_429)
+    source = OpenAlexSource(transport=transport)
+
+    with pytest.raises(NetworkError) as exc_info:
+        source.seed("ecological exchange")
+
+    msg = str(exc_info.value)
+    assert "429" in msg
+    assert "email" in msg.lower()
+    assert "polite" in msg.lower()
+    assert "OPENALEX_API_KEY" in msg
+    assert "ADR 0012" in msg
+    assert "api_key" in msg  # la api_key se nombra como opcional en el mensaje
+
+
 @pytest.mark.unit
 def test_translate_exclude_con_anio_forma_completa() -> None:
     """Con exclude + year, los NOT van dentro de search y el año va fuera con coma.

--- a/uv.lock
+++ b/uv.lock
@@ -101,7 +101,7 @@ wheels = [
 
 [[package]]
 name = "bib2graph"
-version = "0.10.0"
+version = "0.10.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Qué

Un `429` de OpenAlex subía como `httpx.HTTPStatusError` pelado, sin pista de causa ni remedio (el usuario/agente perdía tiempo diagnosticando). Ahora `seed()` y el chaining (`fetch_citing`, al **agotar** los reintentos) levantan `NetworkError` (exit 4) con un mensaje accionable: nombra el **email/polite-pool** como remedio primario (ADR 0012) y la **api_key** como opcional.

Los demás status y los retryables (5xx) conservan su conducta anterior.

## Por qué

De retroalimentación de uso real (corpus Kant). Footgun invisible de cara a la promoción de la librería: un usuario nuevo sin email choca el 429 mudo. Milestone `0.10.2` (versión limpia).

## Alcance

Por decisión del PO, el fix se extendió más allá del DoD original (solo `seed`) para cubrir también el **chaining** — así el footgun queda cubierto en todos los caminos.

## Tests

- `seed` 429 → `NetworkError` accionable (MockTransport, sin red).
- `fetch_citing` 429 agotado → `NetworkError` accionable (nuevo).
- Contrato de chaining actualizado de `HTTPStatusError` a `NetworkError`.
- Retry 429→200 y no-retry 404 siguen verdes.

## Docs

- `docs/API.md` §2 — fila `OpenAlexSource` + bullet `fetch_citing`.
- `docs/decisiones/0012-*` — enmienda datada (#210).

Closes #210

🤖 Generated with [Claude Code](https://claude.com/claude-code)