### PR TITLE
feat(networks): adjuntar doi y url a nodos de paper-kinds y exports (#209)

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1273,9 +1273,18 @@ def decorate(artifact: NetworkArtifact, table: pa.Table) -> None:
 | `label` | todos | string legible (mapeo por kind, abajo) |
 | `degree_centrality` | todos | `float`, vía `nx.degree_centrality` |
 | `year` | paper (coupling/cocitation) | `int` (ausente si `None` en el corpus) |
+| `doi` | paper (coupling/cocitation) | `string` desde `Col.DOI` (DOI desnudo/normalizado, p. ej. `10.1234/abc`); **ausente si el paper no tiene DOI** (mismo criterio que `year`) |
+| `url` | paper (coupling/cocitation) | `string` derivada `https://doi.org/<doi>`; **solo presente si hay DOI** (no es columna del corpus, ver nota abajo) |
 | `is_seed` | paper | `bool` |
 | `curation_status` | paper | `string` |
 | `community` | todos | `int`, **solo** si se provee `artifact.communities` |
+
+`doi`/`url` aplican **solo a paper-kinds** (`bibliographic_coupling` y `cocitation`); los nodos de
+autor/institución/keyword **no los reciben**. `url` es **derivada** (`https://doi.org/<doi>`), no una
+columna del corpus: el DOI es la única identidad de primera clase (ADR 0036) y la URL es una expansión
+trivial determinista a la hora de decorar. Ausencia condicional como `year`: sin DOI truthy, el nodo no
+recibe ni `doi` ni `url`. Los exporters CSV/GraphML (§9) los propagan **automáticamente** cuando están
+presentes (son genéricos y omiten `None`) — sin cambios en exporters.
 
 **Mapeo de `label` por `NetworkKind`:**
 
@@ -1402,8 +1411,9 @@ class CsvExporter: ...       # v1 — nodos.csv + aristas.csv para pandas
 
 - **`CsvExporter`** escribe `aristas.csv` (`source,target,weight`) y `nodos.csv` (`id,label` +
   atributos de nodo + métricas de `results` —degree/betweenness/community— unidas por id). Orden
-  de filas determinista. El `label` (y `year`/`is_seed`/`curation_status`/`community`) lo inyecta la
-  capa `decorate` (§7.1) antes del export, no el exporter.
+  de filas determinista. El `label` (y `year`/`doi`/`url`/`is_seed`/`curation_status`/`community`) lo
+  inyecta la capa `decorate` (§7.1) antes del export, no el exporter; `doi`/`url` salen solo en
+  paper-kinds y solo cuando el paper tiene DOI.
 - **`GraphMLExporter`** escribe esos atributos como node attributes, **omite** los atributos con
   valor `None` (Gephi / `nx.write_graphml` no los admiten) y **no muta** el grafo original (opera
   sobre una copia).

--- a/src/bib2graph/networks/decorate.py
+++ b/src/bib2graph/networks/decorate.py
@@ -30,6 +30,8 @@ Atributos adicionales de paper (coupling/cocitation):
   - ``year``: int o ausente si None.
   - ``is_seed``: bool.
   - ``curation_status``: string.
+  - ``doi``: string o ausente si no hay DOI en el corpus.
+  - ``url``: ``"https://doi.org/<doi>"`` o ausente si no hay DOI.
 
 Atributo de comunidad (si se provee ``communities``):
   - ``community``: int.
@@ -67,9 +69,10 @@ _PAPER_KINDS: frozenset[str] = frozenset(
 
 
 def _build_paper_index(table: pa.Table) -> dict[str, dict[str, object]]:
-    """Construye un índice ``{paper_id → {label, year, is_seed, curation_status}}``.
+    """Construye un índice ``{paper_id → {label, year, is_seed, curation_status, doi}}``.
 
     El label de paper es ``"título (año)"`` truncado a ``LABEL_MAX_CHARS`` chars.
+    ``doi`` es el DOI del paper (string) o ``None`` si no está disponible.
 
     Args:
         table: Tabla Arrow canónica del Corpus.
@@ -82,10 +85,11 @@ def _build_paper_index(table: pa.Table) -> dict[str, dict[str, object]]:
     years = table.column(Col.YEAR).to_pylist()
     is_seeds = table.column(Col.IS_SEED).to_pylist()
     statuses = table.column(Col.CURATION_STATUS).to_pylist()
+    dois = table.column(Col.DOI).to_pylist()
 
     index: dict[str, dict[str, object]] = {}
-    for pid, title, year, is_seed, status in zip(
-        ids, titles, years, is_seeds, statuses, strict=False
+    for pid, title, year, is_seed, status, doi in zip(
+        ids, titles, years, is_seeds, statuses, dois, strict=False
     ):
         if pid is None:
             continue
@@ -105,6 +109,7 @@ def _build_paper_index(table: pa.Table) -> dict[str, dict[str, object]]:
             "year": int(year) if year is not None else None,
             "is_seed": bool(is_seed) if is_seed is not None else False,
             "curation_status": str(status) if status is not None else None,
+            "doi": str(doi) if doi is not None else None,
         }
     return index
 
@@ -194,6 +199,8 @@ def decorate_graph(
       - ``year``: int o ausente si None en el corpus.
       - ``is_seed``: bool.
       - ``curation_status``: string.
+      - ``doi``: string o ausente si el paper no tiene DOI en el corpus.
+      - ``url``: ``"https://doi.org/<doi>"`` o ausente si no hay DOI.
 
     Atributo de comunidad (si se provee ``communities``):
       - ``community``: int.
@@ -229,6 +236,11 @@ def decorate_graph(
             curation = info.get("curation_status")
             if curation is not None:
                 graph.nodes[node]["curation_status"] = str(curation)
+            # doi y url: solo si hay DOI (no None, no cadena vacía)
+            doi = info.get("doi")
+            if isinstance(doi, str) and doi:
+                graph.nodes[node]["doi"] = doi
+                graph.nodes[node]["url"] = f"https://doi.org/{doi}"
 
     elif kind == NetworkKind.AUTHOR_COLLAB:
         author_index = _build_author_index(table)

--- a/tests/unit/test_decorate.py
+++ b/tests/unit/test_decorate.py
@@ -1,12 +1,14 @@
-"""Tests de la capa decorate — issue #25.
+"""Tests de la capa decorate — issue #25 y #209.
 
 Verifica:
 - ``decorate_graph`` inyecta ``label`` correcto por ``NetworkKind``.
 - Atributos ``year``/``is_seed``/``curation_status``/``degree_centrality`` presentes
   en nodos de paper.
+- Atributos ``doi``/``url`` presentes en nodos de paper cuando hay DOI (#209).
 - Atributo ``community`` presente cuando se pasa ``communities``.
 - Round-trip GraphML: exportar grafo decorado → releer → nodos tienen ``label``
   legible (no el id crudo).
+- Round-trip CSV y GraphML incluyen ``doi``/``url`` cuando están presentes (#209).
 - Los proyectores siguen puros (sin ``label``) — la decoración es aparte.
 - Determinismo: mismo corpus → mismos atributos.
 
@@ -23,6 +25,8 @@ import pytest
 
 from bib2graph.constants import NetworkKind
 from bib2graph.corpus import Corpus
+from bib2graph.exporters.csv import CsvExporter
+from bib2graph.exporters.graphml import GraphMLExporter
 from bib2graph.networks.decorate import LABEL_MAX_CHARS, decorate, decorate_graph
 from bib2graph.networks.facade import Networks
 from bib2graph.networks.projectors import (
@@ -471,3 +475,237 @@ def test_label_paper_truncado_si_titulo_largo() -> None:
     assert label.endswith("..."), f"label largo no truncado: {label!r}"
     # El label truncado tiene exactamente LABEL_MAX_CHARS chars + "..."
     assert len(label) == LABEL_MAX_CHARS + 3
+
+
+# ---------------------------------------------------------------------------
+# doi / url en nodos de paper (#209)
+# ---------------------------------------------------------------------------
+
+
+def _make_table_con_doi() -> pa.Table:
+    """Tabla Arrow con un paper con DOI y otro sin DOI.
+
+    Ambos comparten ``R_shared`` para que el acoplamiento bibliográfico cree
+    una arista entre ellos (los dos nodos quedan en el grafo).
+    """
+    rows = [
+        {
+            "id": "PDOI",
+            "source_id": None,
+            "doi": "10.1234/ejemplo.2024",
+            "title": "Paper con DOI",
+            "year": 2024,
+            "abstract": None,
+            "source": None,
+            "language": None,
+            "publisher": None,
+            "research_areas": None,
+            "is_seed": True,
+            "curation_status": "accepted",
+            "provenance": None,
+            "authors_raw": None,
+            "authors_id": None,
+            "authors_affiliations": None,
+            "keywords_raw": None,
+            "keywords_id": None,
+            "institutions_raw": None,
+            "institutions_id": None,
+            "references_id": ["R_shared", "R_a"],
+            "references_doi": None,
+            "cited_by_id": None,
+        },
+        {
+            "id": "PNODOI",
+            "source_id": None,
+            "doi": None,
+            "title": "Paper sin DOI",
+            "year": 2023,
+            "abstract": None,
+            "source": None,
+            "language": None,
+            "publisher": None,
+            "research_areas": None,
+            "is_seed": True,
+            "curation_status": "candidate",
+            "provenance": None,
+            "authors_raw": None,
+            "authors_id": None,
+            "authors_affiliations": None,
+            "keywords_raw": None,
+            "keywords_id": None,
+            "institutions_raw": None,
+            "institutions_id": None,
+            "references_id": ["R_shared", "R_b"],
+            "references_doi": None,
+            "cited_by_id": None,
+        },
+    ]
+    return pa.Table.from_pylist(rows, schema=CORPUS_SCHEMA)
+
+
+@pytest.mark.unit
+def test_doi_y_url_en_nodo_paper_con_doi() -> None:
+    """Nodo de paper con DOI → atributos ``doi`` y ``url`` correctos (#209)."""
+    table = _make_table_con_doi()
+    projector = BibliographicCouplingProjector()
+    g = projector.project(table)
+    assert "PDOI" in g.nodes, "PDOI debe estar en el grafo"
+
+    decorate_graph(g, table, NetworkKind.BIBLIOGRAPHIC_COUPLING)
+
+    attrs = g.nodes["PDOI"]
+    assert "doi" in attrs, "atributo doi ausente en nodo con DOI"
+    assert attrs["doi"] == "10.1234/ejemplo.2024"
+    assert "url" in attrs, "atributo url ausente en nodo con DOI"
+    assert attrs["url"] == "https://doi.org/10.1234/ejemplo.2024"
+
+
+@pytest.mark.unit
+def test_sin_doi_no_tiene_url_basura() -> None:
+    """Nodo de paper sin DOI NO debe tener atributos ``doi`` ni ``url`` (#209).
+
+    Garantiza que no aparezca ``url = 'https://doi.org/None'`` ni un doi vacío.
+    """
+    table = _make_table_con_doi()
+    projector = BibliographicCouplingProjector()
+    g = projector.project(table)
+    assert "PNODOI" in g.nodes, "PNODOI debe estar en el grafo"
+
+    decorate_graph(g, table, NetworkKind.BIBLIOGRAPHIC_COUPLING)
+
+    attrs = g.nodes["PNODOI"]
+    assert "doi" not in attrs, f"doi no debería estar en nodo sin DOI: {attrs!r}"
+    assert "url" not in attrs, f"url no debería estar en nodo sin DOI: {attrs!r}"
+
+
+@pytest.mark.unit
+def test_doi_no_se_inyecta_en_nodo_autor() -> None:
+    """Los atributos doi/url NO se inyectan en nodos de red de autores.
+
+    Solo aplican a paper-kinds (bibliographic_coupling, cocitation).
+    """
+    rows = [
+        {
+            "id": "PA1",
+            "source_id": None,
+            "doi": "10.9999/autor.2024",
+            "title": "Autor compartido A",
+            "year": 2024,
+            "abstract": None,
+            "source": None,
+            "language": None,
+            "publisher": None,
+            "research_areas": None,
+            "is_seed": True,
+            "curation_status": "accepted",
+            "provenance": None,
+            "authors_raw": ["Juan Pérez"],
+            "authors_id": ["auth_shared"],
+            "authors_affiliations": None,
+            "keywords_raw": None,
+            "keywords_id": None,
+            "institutions_raw": None,
+            "institutions_id": None,
+            "references_id": None,
+            "references_doi": None,
+            "cited_by_id": None,
+        },
+        {
+            "id": "PA2",
+            "source_id": None,
+            "doi": "10.9999/autor.2025",
+            "title": "Autor compartido B",
+            "year": 2025,
+            "abstract": None,
+            "source": None,
+            "language": None,
+            "publisher": None,
+            "research_areas": None,
+            "is_seed": True,
+            "curation_status": "accepted",
+            "provenance": None,
+            "authors_raw": ["Juan Pérez", "Ana García"],
+            "authors_id": ["auth_shared", "auth_other"],
+            "authors_affiliations": None,
+            "keywords_raw": None,
+            "keywords_id": None,
+            "institutions_raw": None,
+            "institutions_id": None,
+            "references_id": None,
+            "references_doi": None,
+            "cited_by_id": None,
+        },
+    ]
+    t = pa.Table.from_pylist(rows, schema=CORPUS_SCHEMA)
+    projector = AuthorCollaborationProjector()
+    g = projector.project(t)
+    assert g.number_of_nodes() > 0, "grafo de autores debe tener nodos"
+
+    decorate_graph(g, t, NetworkKind.AUTHOR_COLLAB)
+
+    for node in g.nodes():
+        attrs = g.nodes[node]
+        assert "doi" not in attrs, (
+            f"doi no debe estar en nodo de autor {node!r}: {attrs!r}"
+        )
+        assert "url" not in attrs, (
+            f"url no debe estar en nodo de autor {node!r}: {attrs!r}"
+        )
+
+
+@pytest.mark.unit
+def test_export_csv_incluye_doi_url(tmp_path: Path) -> None:
+    """El CSV de un grafo decorado con DOIs incluye columnas doi y url (#209).
+
+    CsvExporter es genérico: vuelca todos los atributos de nodo presentes.
+    Si decorate_graph inyecta doi/url, aparecen en nodos.csv.
+    """
+    table = _make_table_con_doi()
+    projector = BibliographicCouplingProjector()
+    g = projector.project(table)
+    decorate_graph(g, table, NetworkKind.BIBLIOGRAPHIC_COUPLING)
+
+    CsvExporter().export(g, {}, tmp_path)
+
+    content = (tmp_path / "nodos.csv").read_text(encoding="utf-8-sig")
+    header = content.splitlines()[0]
+    assert "doi" in header, f"columna doi ausente en nodos.csv; header: {header!r}"
+    assert "url" in header, f"columna url ausente en nodos.csv; header: {header!r}"
+
+    # El nodo con DOI tiene el valor correcto
+    assert "10.1234/ejemplo.2024" in content
+    assert "https://doi.org/10.1234/ejemplo.2024" in content
+
+
+@pytest.mark.unit
+def test_export_graphml_incluye_doi_url(tmp_path: Path) -> None:
+    """El GraphML de un grafo decorado con DOIs incluye atributos doi y url (#209).
+
+    GraphMLExporter es genérico: escribe todos los atributos de nodo presentes.
+    """
+    table = _make_table_con_doi()
+    projector = BibliographicCouplingProjector()
+    g = projector.project(table)
+    decorate_graph(g, table, NetworkKind.BIBLIOGRAPHIC_COUPLING)
+
+    GraphMLExporter().export(g, {}, tmp_path)
+
+    reloaded = nx.read_graphml(str(tmp_path / "network.graphml"))
+
+    # El nodo con DOI tiene ambos atributos
+    assert "doi" in reloaded.nodes["PDOI"], (
+        f"doi ausente en PDOI tras round-trip GraphML: {dict(reloaded.nodes['PDOI'])!r}"
+    )
+    assert reloaded.nodes["PDOI"]["doi"] == "10.1234/ejemplo.2024"
+    assert "url" in reloaded.nodes["PDOI"], (
+        f"url ausente en PDOI tras round-trip GraphML: {dict(reloaded.nodes['PDOI'])!r}"
+    )
+    assert reloaded.nodes["PDOI"]["url"] == "https://doi.org/10.1234/ejemplo.2024"
+
+    # El nodo sin DOI NO tiene url basura
+    assert "doi" not in reloaded.nodes["PNODOI"], (
+        "doi no debería aparecer en PNODOI tras round-trip GraphML"
+    )
+    assert "url" not in reloaded.nodes["PNODOI"], (
+        "url no debería aparecer en PNODOI tras round-trip GraphML"
+    )


### PR DESCRIPTION
## Qué

`decorate_graph` inyecta `doi` (desde `Col.DOI`, ya normalizado) y una `url` derivada (`https://doi.org/<doi>`) en los nodos de **paper-kinds** (`bibliographic_coupling` y `cocitation`), solo cuando hay DOI. Los exporters CSV y GraphML los propagan solos (genéricos / omiten `None`) — sin cambios en exporters.

**Cierra el "último kilómetro"**: el archivo de relaciones ahora es navegable hasta el paper sin re-unir a mano contra el corpus.

## Manejo de ausencia
Mismo criterio que `year`: si no hay DOI, el nodo NO recibe `doi` ni `url` — sin `https://doi.org/None`. Nodos de autor/institución/keyword no los reciben.

## Tests
doi/url correctos en nodo con DOI; sin url basura cuando falta; no se filtra a nodos de autor; CSV y GraphML (round-trip real) los incluyen.

## Docs
`docs/API.md` §7.1 y §9. Sin ADR (URL derivada = presentación; DOI ya es columna de 1ª clase, ADR 0036).

Closes #209

🤖 Generated with [Claude Code](https://claude.com/claude-code)