### PR TITLE
refactor: extraer normalize_and_dedup + umbrales + open_store a módulos neutrales (#175)

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1531,12 +1531,14 @@ networks:
 
 **Dedup fuzzy determinista** con `rapidfuzz` (núcleo desde #88): el complemento aproximado de la
 normalización conservadora del `Preprocessor` (§6). Las funciones siguen exportadas desde
-`bib2graph.preprocessors`, pero **se invocan automáticamente** desde el helper de frontera
-`cli/_ingest.py::normalize_and_dedup`, no a mano. Operan sobre la columna `_id`
+`bib2graph.preprocessors`, pero **se invocan automáticamente** desde el helper canónico
+`preprocessors.pipeline::normalize_and_dedup`, no a mano. Operan sobre la columna `_id`
 (`authors_id`/`keywords_id`), **nunca** sobre `_raw`.
 
 ```python
-# Helper de frontera — punto único de la ingesta (cli/_ingest.py)
+# Helper canónico — punto único de la ingesta (preprocessors/pipeline.py;
+# re-exportado por compat desde cli/_ingest.py → el import viejo
+# `from bib2graph.cli._ingest import normalize_and_dedup` sigue vivo, no es breaking)
 def normalize_and_dedup(corpus: Corpus, *, applied_at: datetime | None = None) -> Corpus:
     """normalize → deduplicate_authors(0.92) → deduplicate_keywords(0.90), en ese orden, sobre el
     corpus COMPLETO YA MERGEADO (existing + incoming) ⇒ dedup CROSS-BIBLIOTECA. NO aplica thesaurus
@@ -1561,7 +1563,9 @@ def deduplicate_keywords(corpus: Corpus, *, threshold: float = 0.90) -> Corpus:
   **`persist_replace`** (§4.1) porque el upsert-concat D3 reintroduciría las variantes colapsadas.
   `build` sigue **puro** (el corpus ya entra deduplicado).
 - **`threshold` por-campo** (autores `0.92` / keywords `0.90`): `rapidfuzz.fuzz.token_sort_ratio` (0–100)
-  contra `threshold * 100`. Umbrales fijos en `cli/_ingest.py`.
+  contra `threshold * 100`. Umbrales fijos como **constantes públicas** `THRESHOLD_AUTHORS` /
+  `THRESHOLD_KEYWORDS` de `bib2graph.preprocessors` (fuente única en `preprocessors.pipeline`, issue
+  #175): el umbral compartido por la ingesta y el `restore` es **uno solo**, sin copias que diverjan.
 - **Determinista e idempotente:** los pares ≥ umbral forman **componentes conexas** vía Union-Find; el
   **canónico** del cluster es la variante más frecuente (desempate por `id` ascendente); se preserva el
   **orden de primera aparición** y **nunca se toca `_raw`**. Mismo corpus + threshold + versión de

--- a/src/bib2graph/cli/_ingest.py
+++ b/src/bib2graph/cli/_ingest.py
@@ -1,14 +1,14 @@
-"""cli._ingest — Helper de ingesta automática: normalize + dedup.
+"""cli._ingest — Re-exportación de la pipeline de ingesta automática.
 
-Aplica la pipeline de preprocesamiento automático al corpus completo en el
-momento de la ingesta (seed / seed_from_bib / restore / chain), sobre el
-corpus YA MERGEADO con el existente.  El thesaurus queda como paso explícito
-(``b2g build --thesaurus``).
+La implementación canónica vive en ``preprocessors.pipeline`` (issue #175).
+Este módulo la re-exporta para que los imports existentes del CLI y de los
+tests — ``from bib2graph.cli._ingest import normalize_and_dedup`` — sigan
+funcionando sin cambios.
 
-Orden determinista:
+Orden determinista de la pipeline:
   1. ``Preprocessor().normalize``  — canonicaliza ``authors_id`` y ``language``.
-  2. ``deduplicate_authors(threshold=0.92)``  — colapsa variantes de autores.
-  3. ``deduplicate_keywords(threshold=0.90)`` — colapsa variantes de keywords.
+  2. ``deduplicate_authors(threshold=THRESHOLD_AUTHORS)``  — colapsa variantes.
+  3. ``deduplicate_keywords(threshold=THRESHOLD_KEYWORDS)`` — colapsa variantes.
 
 El dedup opera sobre el corpus COMPLETO (existing + incoming ya mergeados),
 garantizando deduplicación cross-biblioteca (no solo intra-lote).
@@ -21,51 +21,7 @@ en curación.  Ver ``preprocessor.py``.
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
+# Re-exportar desde el módulo neutral para backward compat con imports existentes.
+from bib2graph.preprocessors.pipeline import normalize_and_dedup
 
-from bib2graph.corpus import Corpus
-from bib2graph.preprocessors.dedup import deduplicate_authors, deduplicate_keywords
-from bib2graph.preprocessors.preprocessor import Preprocessor
-
-# Umbrales fijos del auto-preproc (ADR 0031).
-_THRESHOLD_AUTHORS: float = 0.92
-_THRESHOLD_KEYWORDS: float = 0.90
-
-
-def normalize_and_dedup(
-    corpus: Corpus,
-    *,
-    applied_at: datetime | None = None,
-) -> Corpus:
-    """Aplica normalize + dedup_authors + dedup_keywords al corpus.
-
-    Punto de entrada único para la ingesta automática.  Se llama DESPUÉS de
-    ``Corpus.merge`` (corpus ya completo = existing + incoming), garantizando
-    deduplicación cross-biblioteca: el dedup ve toda la biblioteca acumulada,
-    no solo el lote entrante.
-
-    Idempotente en contenido: re-correr sobre el mismo corpus produce el
-    mismo resultado (las tres operaciones son idempotentes).
-
-    El thesaurus NO se aplica aquí; es un paso explícito del usuario
-    (``b2g build --thesaurus``).
-
-    Args:
-        corpus: Corpus de entrada (no muta; semántica de valor).
-            Debe ser el corpus COMPLETO ya mergeado (existing + incoming).
-        applied_at: Timestamp de la operación para el ``PreprocRef``.  La
-            frontera CLI inyecta un único ``datetime.now(UTC)`` por
-            invocación (R2).  Si ``None``, se usa ``datetime.now(UTC)``
-            (para uso como librería independiente).
-
-    Returns:
-        Nuevo Corpus normalizado y deduplicado.
-    """
-    ts = applied_at if applied_at is not None else datetime.now(UTC)
-    preprocessor = Preprocessor()
-
-    result = preprocessor.normalize(corpus, applied_at=ts)
-    result = deduplicate_authors(result, threshold=_THRESHOLD_AUTHORS)
-    result = deduplicate_keywords(result, threshold=_THRESHOLD_KEYWORDS)
-
-    return result
+__all__ = ["normalize_and_dedup"]

--- a/src/bib2graph/cli/_store.py
+++ b/src/bib2graph/cli/_store.py
@@ -14,6 +14,11 @@ R5 — footgun de auto-creación:
   para no crear silenciosamente un store vacío ante un typo en la ruta
   (Nota 06, catálogo de secundarios).  ``open_store`` (escritura) mantiene
   el comportamiento de crear el archivo si no existe.
+
+Fuente única (issue #175):
+  ``open_store`` se re-exporta desde ``service.store`` para que la capa de
+  servicios y el CLI usen la misma implementación sin violar el layering
+  (ADR 0028).
 """
 
 from __future__ import annotations
@@ -22,6 +27,11 @@ from pathlib import Path
 from typing import Any
 
 from bib2graph.cli._errors import StoreError, UsageError
+
+# Re-exportar open_store desde la capa neutral (service.store) para:
+# 1. Mantener backward compat con todos los imports de ``cli._store.open_store``.
+# 2. Garantizar fuente única con ``service.snapshot`` (issue #175).
+from bib2graph.service.store import open_store as open_store
 
 
 def resolve_library_path(ctx_obj: dict[str, Any]) -> Path:
@@ -79,39 +89,6 @@ def resolve_workspace(ctx_obj: dict[str, Any]) -> Any:
         return Workspace.resolve(workspace=workspace)
     except WorkspaceNotFoundError as exc:
         raise UsageError(str(exc)) from exc
-
-
-def open_store(path: str | Path) -> Any:
-    """Abre (o crea) el DuckDBStore en ``path``.
-
-    Captura ``StoreLockedError`` (subclase de ``OSError``) y lo re-lanza
-    como ``StoreError`` (exit 5) para el decorador ``@handle_errors``.
-
-    Uso: comandos de ESCRITURA (seed, chain, filter, build, accept, reject,
-    snapshot, export).  Los comandos de SOLO LECTURA deben usar
-    ``open_store_readonly`` para no auto-crear el store ante un typo.
-
-    Args:
-        path: Ruta al archivo ``.duckdb``.
-
-    Returns:
-        ``DuckDBStore`` abierto y listo para usar.
-
-    Raises:
-        StoreError: Si el archivo está bloqueado o no se puede abrir.
-    """
-    from bib2graph.backends.duckdb import StoreLockedError
-    from bib2graph.stores.duckdb import DuckDBStore
-
-    try:
-        return DuckDBStore(path)
-    except StoreLockedError as exc:
-        raise StoreError(str(exc)) from exc
-    except OSError as exc:
-        raise StoreError(
-            f"No se puede abrir el store '{path}': {exc}. "
-            "Verificá que el archivo no esté bloqueado por otro proceso."
-        ) from exc
 
 
 def open_store_readonly(path: str | Path) -> Any:

--- a/src/bib2graph/preprocessors/__init__.py
+++ b/src/bib2graph/preprocessors/__init__.py
@@ -1,7 +1,7 @@
 """preprocessors — normalización, thesaurus multilingüe y dedup fuzzy.
 
 Exporta ``Preprocessor`` y las funciones puras de normalización, thesaurus
-y deduplicación fuzzy.
+y deduplicación fuzzy, más la pipeline de ingesta automática.
 
 Las funciones de dedup (``deduplicate_authors``, ``deduplicate_keywords``)
 requieren el extra ``[dedup]`` (``uv sync --extra dedup``).  El import del
@@ -13,6 +13,18 @@ Ver docs/API.md §6, ADR 0011, ADR 0017.
 from __future__ import annotations
 
 from bib2graph.preprocessors.dedup import deduplicate_authors, deduplicate_keywords
+from bib2graph.preprocessors.pipeline import (
+    THRESHOLD_AUTHORS,
+    THRESHOLD_KEYWORDS,
+    normalize_and_dedup,
+)
 from bib2graph.preprocessors.preprocessor import Preprocessor
 
-__all__ = ["Preprocessor", "deduplicate_authors", "deduplicate_keywords"]
+__all__ = [
+    "THRESHOLD_AUTHORS",
+    "THRESHOLD_KEYWORDS",
+    "Preprocessor",
+    "deduplicate_authors",
+    "deduplicate_keywords",
+    "normalize_and_dedup",
+]

--- a/src/bib2graph/preprocessors/pipeline.py
+++ b/src/bib2graph/preprocessors/pipeline.py
@@ -1,0 +1,83 @@
+"""preprocessors.pipeline — Punto de entrada único de la pipeline de preprocesamiento automático.
+
+Orquesta normalize + dedup_authors + dedup_keywords sobre el corpus completo
+ya mergeado.  Módulo neutral: sin I/O, sin Click, sin red.
+
+Callers:
+  - ``cli._ingest`` (ingesta: seed / chain / seed_from_bib)
+  - ``service.snapshot`` (restore)
+
+Ambas rutas importan ``normalize_and_dedup`` y los umbrales **desde aquí**,
+garantizando que no pueden diverger (issue #175, ADR 0031).
+
+Fuente única:
+  ``THRESHOLD_AUTHORS`` y ``THRESHOLD_KEYWORDS`` son la fuente canónica.  No
+  dupliques estos valores en ningún otro módulo; importalos desde acá.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from bib2graph.corpus import Corpus
+
+# ---------------------------------------------------------------------------
+# Umbrales fijos del auto-preproc (ADR 0031, fuente única — issue #175)
+# ---------------------------------------------------------------------------
+
+#: Umbral de similitud para deduplicar variantes de autores.
+#: ``rapidfuzz.fuzz.token_sort_ratio`` >= ``THRESHOLD_AUTHORS * 100`` → colapso.
+THRESHOLD_AUTHORS: float = 0.92
+
+#: Umbral de similitud para deduplicar variantes de keywords.
+#: ``rapidfuzz.fuzz.token_sort_ratio`` >= ``THRESHOLD_KEYWORDS * 100`` → colapso.
+THRESHOLD_KEYWORDS: float = 0.90
+
+
+# ---------------------------------------------------------------------------
+# Pipeline pública
+# ---------------------------------------------------------------------------
+
+
+def normalize_and_dedup(
+    corpus: Corpus,
+    *,
+    applied_at: datetime | None = None,
+) -> Corpus:
+    """Aplica normalize + dedup_authors + dedup_keywords al corpus.
+
+    Punto de entrada único para la ingesta automática.  Se llama DESPUÉS de
+    ``Corpus.merge`` (corpus ya completo = existing + incoming), garantizando
+    deduplicación cross-biblioteca: el dedup ve toda la biblioteca acumulada,
+    no solo el lote entrante.
+
+    Idempotente en contenido: re-correr sobre el mismo corpus produce el
+    mismo resultado (las tres operaciones son idempotentes).
+
+    El thesaurus NO se aplica aquí; es un paso explícito del usuario
+    (``b2g build --thesaurus``).
+
+    Args:
+        corpus: Corpus de entrada (no muta; semántica de valor).
+            Debe ser el corpus COMPLETO ya mergeado (existing + incoming).
+        applied_at: Timestamp de la operación para el ``PreprocRef``.  La
+            frontera CLI inyecta un único ``datetime.now(UTC)`` por
+            invocación (R2).  Si ``None``, se usa ``datetime.now(UTC)``
+            (para uso como librería independiente).
+
+    Returns:
+        Nuevo Corpus normalizado y deduplicado.
+    """
+    from bib2graph.preprocessors.dedup import deduplicate_authors, deduplicate_keywords
+    from bib2graph.preprocessors.preprocessor import Preprocessor
+
+    ts = applied_at if applied_at is not None else datetime.now(UTC)
+    preprocessor = Preprocessor()
+
+    result = preprocessor.normalize(corpus, applied_at=ts)
+    result = deduplicate_authors(result, threshold=THRESHOLD_AUTHORS)
+    result = deduplicate_keywords(result, threshold=THRESHOLD_KEYWORDS)
+
+    return result

--- a/src/bib2graph/service/snapshot.py
+++ b/src/bib2graph/service/snapshot.py
@@ -19,79 +19,13 @@ el shim ``b2g restore`` también delega acá (fuente única — ADR 0038 §163).
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 
-from bib2graph.service.errors import DataError, StoreError
-
-# Umbrales fijos del auto-preproc (ADR 0031, espejo de cli/_ingest.py).
-# Fuente canónica: cli/_ingest.py. Si se cambian allí, actualizar acá también.
-_THRESHOLD_AUTHORS: float = 0.92
-_THRESHOLD_KEYWORDS: float = 0.90
-
-
-# ---------------------------------------------------------------------------
-# Helper interno — abrir store para escritura
-# ---------------------------------------------------------------------------
-
-
-def _open_store(path: Path) -> Any:
-    """Abre (o crea) el DuckDBStore en ``path`` para escritura.
-
-    Args:
-        path: Ruta al archivo ``.duckdb``.
-
-    Returns:
-        ``DuckDBStore`` abierto y listo para leer/escribir.
-
-    Raises:
-        StoreError: Si el store está bloqueado o no se puede abrir.
-    """
-    from bib2graph.backends.duckdb import StoreLockedError
-    from bib2graph.stores.duckdb import DuckDBStore
-
-    try:
-        return DuckDBStore(path)
-    except StoreLockedError as exc:
-        raise StoreError(str(exc)) from exc
-    except OSError as exc:
-        raise StoreError(
-            f"No se puede abrir el store '{path}': {exc}. "
-            "Verificá que el archivo no esté bloqueado por otro proceso."
-        ) from exc
-
-
-# ---------------------------------------------------------------------------
-# Helper interno — normalize + dedup (espejo neutral de cli._ingest)
-# ---------------------------------------------------------------------------
-
-
-def _normalize_and_dedup(corpus: Any, *, applied_at: datetime | None) -> Any:
-    """Aplica normalize + dedup_authors + dedup_keywords al corpus.
-
-    Espejo neutral de ``cli._ingest.normalize_and_dedup``.  No importa de
-    ``cli/`` para mantener la capa de servicios independiente del adaptador
-    Click.  Los umbrales son los mismos que en ``cli/_ingest.py`` (ADR 0031).
-
-    Args:
-        corpus: Corpus completo ya mergeado (existing + incoming).
-        applied_at: Timestamp de la operación (R2).  ``None`` usa
-            ``datetime.now(UTC)`` internamente (para uso como librería).
-
-    Returns:
-        Nuevo Corpus normalizado y deduplicado.
-    """
-    from bib2graph.preprocessors.dedup import deduplicate_authors, deduplicate_keywords
-    from bib2graph.preprocessors.preprocessor import Preprocessor
-
-    ts = applied_at if applied_at is not None else datetime.now(UTC)
-    preprocessor = Preprocessor()
-    result = preprocessor.normalize(corpus, applied_at=ts)
-    result = deduplicate_authors(result, threshold=_THRESHOLD_AUTHORS)
-    result = deduplicate_keywords(result, threshold=_THRESHOLD_KEYWORDS)
-    return result
-
+from bib2graph.preprocessors.pipeline import normalize_and_dedup
+from bib2graph.service.errors import DataError
+from bib2graph.service.store import open_store as _open_store
 
 # ---------------------------------------------------------------------------
 # run_snapshot
@@ -230,7 +164,7 @@ def run_restore(
         # Merge primero, dedup después sobre el corpus COMPLETO (fix bug cross-biblioteca).
         # El reloj se fija UNA vez por invocación (R2): pasado via decided_at.
         merged = existing.merge(incoming)
-        merged_deduped = _normalize_and_dedup(merged, applied_at=decided_at)
+        merged_deduped = normalize_and_dedup(merged, applied_at=decided_at)
         papers_loaded = len(incoming)
         total_papers = len(merged_deduped)
         merged_backend_close = getattr(merged_deduped._backend, "close", None)

--- a/src/bib2graph/service/store.py
+++ b/src/bib2graph/service/store.py
@@ -1,0 +1,53 @@
+"""service.store — Helper neutral para abrir DuckDBStore.
+
+Sin Click, sin print, sin sys.exit.  Capa de servicios neutral (ADR 0028).
+
+Callers:
+  - ``service.snapshot`` (run_snapshot / run_restore)
+  - ``cli._store`` (re-exporta ``open_store`` para que los comandos CLI
+    y los tests que importan desde allí sigan funcionando)
+
+Este módulo es la fuente canónica de ``open_store`` (issue #175): evita la
+duplicación que existía entre ``cli/_store.py`` y ``service/snapshot.py``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from bib2graph.service.errors import StoreError
+
+
+def open_store(path: str | Path) -> Any:
+    """Abre (o crea) el DuckDBStore en ``path`` para escritura/lectura.
+
+    Captura ``StoreLockedError`` (subclase de ``OSError``) y lo re-lanza
+    como ``StoreError`` (exit 5).
+
+    Uso: operaciones de ESCRITURA (seed, chain, filter, build, accept, reject,
+    snapshot, restore) o lectura desde ``service/``.  Los comandos CLI de
+    SOLO LECTURA deben usar ``cli._store.open_store_readonly`` para no
+    auto-crear el store ante un typo.
+
+    Args:
+        path: Ruta al archivo ``.duckdb``.
+
+    Returns:
+        ``DuckDBStore`` abierto y listo para usar.
+
+    Raises:
+        StoreError: Si el archivo está bloqueado o no se puede abrir.
+    """
+    from bib2graph.backends.duckdb import StoreLockedError
+    from bib2graph.stores.duckdb import DuckDBStore
+
+    try:
+        return DuckDBStore(path)
+    except StoreLockedError as exc:
+        raise StoreError(str(exc)) from exc
+    except OSError as exc:
+        raise StoreError(
+            f"No se puede abrir el store '{path}': {exc}. "
+            "Verificá que el archivo no esté bloqueado por otro proceso."
+        ) from exc

--- a/tests/unit/test_ingest.py
+++ b/tests/unit/test_ingest.py
@@ -777,3 +777,42 @@ def test_thesaurus_remapeo_no_acumula_canonicos(tmp_path: Path) -> None:
         f"El canónico v2 ('artificial intelligence') no está en la biblioteca. "
         f"Keywords: {kws_v2}."
     )
+
+
+# ---------------------------------------------------------------------------
+# 10. Anti-drift: fuente única de umbrales y normalize_and_dedup (issue #175)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_umbrales_vienen_del_modulo_neutral() -> None:
+    """THRESHOLD_AUTHORS y THRESHOLD_KEYWORDS viven en preprocessors.pipeline.
+
+    Sella el invariante del issue #175: los umbrales tienen UN SOLO lugar
+    canónico (``preprocessors.pipeline``) para que ingest y snapshot restore
+    no puedan diverger silenciosamente.
+    """
+    from bib2graph.preprocessors.pipeline import THRESHOLD_AUTHORS, THRESHOLD_KEYWORDS
+
+    assert THRESHOLD_AUTHORS == 0.92, (
+        f"THRESHOLD_AUTHORS cambió su valor canónico: {THRESHOLD_AUTHORS}"
+    )
+    assert THRESHOLD_KEYWORDS == 0.90, (
+        f"THRESHOLD_KEYWORDS cambió su valor canónico: {THRESHOLD_KEYWORDS}"
+    )
+
+
+@pytest.mark.unit
+def test_cli_ingest_reexporta_misma_funcion_que_modulo_neutral() -> None:
+    """cli._ingest.normalize_and_dedup ES el mismo objeto que preprocessors.pipeline.
+
+    Si alguien re-introduce una copia local en cli/_ingest.py (en vez de
+    re-exportar), este test falla — protección contra regresión de drift.
+    """
+    from bib2graph.cli._ingest import normalize_and_dedup as nd_ingest
+    from bib2graph.preprocessors.pipeline import normalize_and_dedup as nd_pipeline
+
+    assert nd_ingest is nd_pipeline, (
+        "cli._ingest.normalize_and_dedup debe ser el mismo objeto que "
+        "preprocessors.pipeline.normalize_and_dedup — no una copia local."
+    )


### PR DESCRIPTION
## Qué

Refactor DRY: elimina la duplicación byte-a-byte entre `cli/_ingest.py` y `service/snapshot.py`.

- `preprocessors/pipeline.py` — fuente canónica de `normalize_and_dedup` + `THRESHOLD_AUTHORS` (0.92) / `THRESHOLD_KEYWORDS` (0.90).
- `service/store.py` — fuente canónica de `open_store`.
- `cli/_ingest.py` y `cli/_store.py` quedan como thin re-exports (imports públicos viejos siguen vivos → **no breaking**).
- `service/snapshot.py` importa de los módulos neutrales.

## Por qué

Footgun de drift: cambiar un umbral en un lado hacía diverger el camino de `snapshot restore`. Mantenibilidad (follow-up de #163/#88).

## Garantías

- **Sin cambio de conducta**: umbrales y secuencia idénticos (verificado contra el historial git); `StoreError` es la misma clase.
- **Layering ADR 0028**: cli→service→preprocessors, nunca al revés (los módulos neutrales no importan Click).
- Tests existentes sin tocar (todos verdes) + 2 tests anti-drift nuevos que sellan el umbral único y la identidad del re-export.

## Docs
`docs/API.md` §11 (ruta canónica + nota de compat). Sin ADR (refactor interno, contrato público inalterado).

Closes #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)