### PR TITLE
chore: ignorar notas personales del PO (NO-HACER-COMMIT-*, *.local.md)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,13 @@ site/
 # Borradores y exploración local (no va al repo)
 scratch/
 
+# Notas personales / cognición tercerizada de Luis — NUNCA se trackean.
+# Norma: cualquier nota privada va acá y el agente no la puede subir por error.
+docs/Notas/NO-HACER-COMMIT-*
+docs/Notas/local/
+**/*.local.md
+.notas-locales/
+
 # Logs
 logs
 *.log


### PR DESCRIPTION
Implementa la norma de notas personales: las notas privadas del PO viven en rutas ignoradas y el agente nunca las sube. Solo toca `.gitignore`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)