### PR TITLE
feat(service): resolver público id→DOI/URL (resolve_doi/resolve_url) (#212)

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -424,7 +424,9 @@ transición de ciclo**; determinismo R2 (mismo corpus → misma lectura).
 
 El módulo conserva además funciones de lectura más ricas (`get_workspace`, `list_rounds`, `get_scent`,
 `get_network`, `compare_rounds`) que hoy ningún comando consume (su poda opcional es trabajo de
-limpieza, [#191](https://github.com/complexluise/bib2graph/issues/191)). Decisiones de modelado:
+limpieza, [#191](https://github.com/complexluise/bib2graph/issues/191)), más la **resolución inversa
+id→DOI/URL** (`resolve_doi`, `resolve_url`; [#212](https://github.com/complexluise/bib2graph/issues/212),
+aditiva, devuelven `None` sin lanzar). Decisiones de modelado:
 **ronda = snapshot sellado** (no el contador `loop_round`), `get_scent` = **score de acoplamiento real
 + vecinos**, `get_network` = **red de la ronda viva recomputada**.
 
@@ -509,6 +511,23 @@ def get_top(ws: Workspace, *, n=10, kind="bibliographic_coupling") -> dict[str, 
     SIEMPRE presente, scope="all", empty_networks=["cocitation"] si la co-citación quedó vacía.
     Raises DataError si kind inválido, n <= 0, o la red
     falla genuinamente; StoreError si el store falla. (Detrás de `read top`.)"""
+
+
+# --- Resolución inversa id→DOI/URL (#212, opción 1; sin red, sobre el corpus cargado) ---
+
+def resolve_doi(ws: Workspace, paper_id: str) -> str | None:
+    """DOI desnudo del paper con `Col.ID == paper_id`, o `None`. Devuelve `None`
+    (NO lanza DataError) cuando el id no existe, el paper no tiene DOI, o el DOI es
+    cadena vacía `""` (mismo criterio de "vacío = ausente" que networks/decorate.py).
+    Sin red: opera sobre el corpus ya cargado. Raises StoreError si el store falla."""
+
+def resolve_url(ws: Workspace, paper_id: str) -> str | None:
+    """URL canónica `https://doi.org/<doi>` del paper, o `None` en los mismos casos
+    que resolve_doi (id inexistente / sin DOI / DOI vacío). Deriva vía
+    `doi_to_url(resolve_doi(...))`. Sin red. Raises StoreError si el store falla.
+    `doi_to_url(doi: str|None) -> str|None` (bib2graph.constants) es la FUENTE ÚNICA
+    de la derivación DOI→URL, compartida con la decoración del atributo `url` de redes
+    (#209, ver §8 nota) — sin drift."""
 ```
 
 **Nota de fidelidad al núcleo.** Las lecturas no inventan campos que el núcleo no sostiene:
@@ -1282,7 +1301,9 @@ def decorate(artifact: NetworkArtifact, table: pa.Table) -> None:
 `doi`/`url` aplican **solo a paper-kinds** (`bibliographic_coupling` y `cocitation`); los nodos de
 autor/institución/keyword **no los reciben**. `url` es **derivada** (`https://doi.org/<doi>`), no una
 columna del corpus: el DOI es la única identidad de primera clase (ADR 0036) y la URL es una expansión
-trivial determinista a la hora de decorar. Ausencia condicional como `year`: sin DOI truthy, el nodo no
+trivial determinista a la hora de decorar. La derivación vive en `doi_to_url(doi: str|None) -> str|None`
+(`bib2graph.constants`), **fuente única** compartida con `resolve_url` (§0.1, #212) — sin drift.
+Ausencia condicional como `year`: sin DOI truthy, el nodo no
 recibe ni `doi` ni `url`. Los exporters CSV/GraphML (§9) los propagan **automáticamente** cuando están
 presentes (son genéricos y omiten `None`) — sin cambios en exporters.
 

--- a/src/bib2graph/constants.py
+++ b/src/bib2graph/constants.py
@@ -106,6 +106,29 @@ class NetworkKind(StrEnum):
 
 
 # ---------------------------------------------------------------------------
+# doi_to_url — derivación canónica DOI → URL (fuente única, sin drift)
+# ---------------------------------------------------------------------------
+
+
+def doi_to_url(doi: str | None) -> str | None:
+    """Deriva la URL canónica ``https://doi.org/<doi>`` a partir de un DOI.
+
+    Criterio compartido por ``networks/decorate.py`` y ``service/reads.py``
+    para evitar drift en la regla de derivación.
+
+    Args:
+        doi: String del DOI (sin prefijo URL), o ``None``.
+
+    Returns:
+        ``"https://doi.org/<doi>"`` si ``doi`` es un string no vacío;
+        ``None`` en cualquier otro caso (None, vacío).
+    """
+    if isinstance(doi, str) and doi:
+        return f"https://doi.org/{doi}"
+    return None
+
+
+# ---------------------------------------------------------------------------
 # LIST_COLUMNS — columnas de tipo list[string] (centraliza _LIST_COLS y _LIST_COL_NAMES)
 # ---------------------------------------------------------------------------
 

--- a/src/bib2graph/networks/decorate.py
+++ b/src/bib2graph/networks/decorate.py
@@ -44,7 +44,7 @@ from typing import TYPE_CHECKING, Any
 import networkx as nx
 import pyarrow as pa
 
-from bib2graph.constants import Col, NetworkKind
+from bib2graph.constants import Col, NetworkKind, doi_to_url
 
 if TYPE_CHECKING:
     from bib2graph.networks.spec import NetworkArtifact
@@ -236,11 +236,14 @@ def decorate_graph(
             curation = info.get("curation_status")
             if curation is not None:
                 graph.nodes[node]["curation_status"] = str(curation)
-            # doi y url: solo si hay DOI (no None, no cadena vacía)
-            doi = info.get("doi")
-            if isinstance(doi, str) and doi:
-                graph.nodes[node]["doi"] = doi
-                graph.nodes[node]["url"] = f"https://doi.org/{doi}"
+            # doi y url: solo si hay DOI (no None, no cadena vacía).
+            # Criterio de derivación en doi_to_url (constants.py) — fuente única.
+            doi_val = info.get("doi")
+            doi_str = doi_val if isinstance(doi_val, str) else None
+            url = doi_to_url(doi_str)
+            if url is not None:
+                graph.nodes[node]["doi"] = doi_str
+                graph.nodes[node]["url"] = url
 
     elif kind == NetworkKind.AUTHOR_COLLAB:
         author_index = _build_author_index(table)

--- a/src/bib2graph/service/__init__.py
+++ b/src/bib2graph/service/__init__.py
@@ -14,6 +14,9 @@ Contrato público re-exportado:
     (#156, sub-issue de la superficie CLI 0.10.0).
   - ``get_top`` — nodos centrales + pares de co-citación con título resuelto
     (#157, sub-issue de la superficie CLI 0.10.0).
+  - ``resolve_doi``, ``resolve_url`` — resolución inversa id→DOI/URL sin red
+    (#212, opción 1); criterio de derivación compartido con
+    ``networks/decorate.py`` vía ``doi_to_url`` de ``constants.py``.
   - ``accept_papers``, ``reject_papers``, ``curate_paper`` — escrituras del
     Hito G3 (ADR 0028).
   - ``resolve_dois`` — resolución DOI→source_id (ADR 0035).
@@ -45,6 +48,8 @@ from bib2graph.service.reads import (
     get_workspace,
     list_papers,
     list_rounds,
+    resolve_doi,
+    resolve_url,
 )
 from bib2graph.service.resolve import resolve_dois
 
@@ -71,5 +76,7 @@ __all__ = [
     "list_papers",
     "list_rounds",
     "reject_papers",
+    "resolve_doi",
     "resolve_dois",
+    "resolve_url",
 ]

--- a/src/bib2graph/service/reads.py
+++ b/src/bib2graph/service/reads.py
@@ -43,7 +43,7 @@ import json
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from bib2graph.constants import Col, NetworkKind
+from bib2graph.constants import Col, NetworkKind, doi_to_url
 from bib2graph.service.errors import DataError, StoreError
 
 if TYPE_CHECKING:
@@ -951,3 +951,69 @@ def get_top(
     )
 
     return result
+
+
+# ---------------------------------------------------------------------------
+# 10. resolve_doi / resolve_url  (issue #212 — opción 1)
+# ---------------------------------------------------------------------------
+
+
+def resolve_doi(ws: Workspace, paper_id: str) -> str | None:
+    """Devuelve el DOI del paper identificado por ``paper_id``, o ``None``.
+
+    Busca ``paper_id`` en ``Col.ID`` del corpus y devuelve el valor de
+    ``Col.DOI`` para esa fila.  Devuelve ``None`` tanto si el id no existe
+    como si el paper no tiene DOI; no lanza ``DataError``.
+
+    No toca la red: opera sobre el corpus ya cargado del workspace.
+    Criterio de derivación compartido con ``networks/decorate.py`` vía
+    ``doi_to_url`` en ``constants.py`` (fuente única, sin drift).
+
+    Args:
+        ws: Workspace resuelto (ADR 0029).
+        paper_id: Valor de ``Col.ID`` del paper a resolver.
+
+    Returns:
+        String DOI (sin prefijo URL) si el paper existe y tiene DOI;
+        ``None`` en cualquier otro caso.
+
+    Raises:
+        StoreError: Si el store no existe o está bloqueado.
+    """
+    store = _open_readonly(ws.library_path)
+    corpus = store.load()
+    table = corpus.to_arrow()
+
+    ids = table.column(Col.ID).to_pylist()
+    dois = table.column(Col.DOI).to_pylist()
+
+    for pid, doi in zip(ids, dois, strict=False):
+        if pid is not None and str(pid) == paper_id:
+            # DOI vacío ("") se trata como ausente → None, coherente con
+            # networks/decorate.py y con resolve_url (issue #212).
+            return str(doi) if doi else None
+    return None
+
+
+def resolve_url(ws: Workspace, paper_id: str) -> str | None:
+    """Devuelve la URL canónica del paper identificado por ``paper_id``, o ``None``.
+
+    Deriva ``https://doi.org/<doi>`` usando el mismo criterio que
+    ``networks/decorate.py``: solo cuando hay un DOI string no vacío.
+    Ambas funciones comparten ``doi_to_url`` de ``constants.py`` como
+    fuente única, sin drift.
+
+    No toca la red: opera sobre el corpus ya cargado del workspace.
+
+    Args:
+        ws: Workspace resuelto (ADR 0029).
+        paper_id: Valor de ``Col.ID`` del paper a resolver.
+
+    Returns:
+        ``"https://doi.org/<doi>"`` si el paper existe y tiene DOI;
+        ``None`` en cualquier otro caso.
+
+    Raises:
+        StoreError: Si el store no existe o está bloqueado.
+    """
+    return doi_to_url(resolve_doi(ws, paper_id))

--- a/tests/unit/test_service_reads.py
+++ b/tests/unit/test_service_reads.py
@@ -39,6 +39,7 @@ def _row(
     year: int = 2020,
     is_seed: bool = True,
     curation_status: str = "candidate",
+    doi: str | None = None,
     references_id: list[str] | None = None,
     cited_by_id: list[str] | None = None,
 ) -> dict[str, Any]:
@@ -46,7 +47,7 @@ def _row(
     return {
         "id": id,
         "openalex_id": None,
-        "doi": None,
+        "doi": doi,
         "title": title,
         "year": year,
         "abstract": None,
@@ -545,3 +546,132 @@ def test_get_scent_paper_inexistente_lanza_dataerror(tmp_path: Path) -> None:
 
 # Neutralidad de transporte de service.reads: consolidada en
 # test_service.py::test_service_modulo_neutral_de_transporte (epic #184).
+
+
+# ---------------------------------------------------------------------------
+# 5. resolve_doi / resolve_url  (issue #212 — opción 1)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_resolve_doi_con_doi(tmp_path: Path) -> None:
+    """resolve_doi devuelve el DOI desnudo cuando el paper existe y tiene DOI."""
+    from bib2graph.service.reads import resolve_doi
+
+    ws = _init_workspace(tmp_path)
+    _seed_store(ws, [_row(id="P1", doi="10.1234/test.001")])
+
+    result = resolve_doi(ws, "P1")
+
+    assert result == "10.1234/test.001"
+
+
+@pytest.mark.unit
+def test_resolve_doi_sin_doi(tmp_path: Path) -> None:
+    """resolve_doi devuelve None cuando el paper existe pero no tiene DOI."""
+    from bib2graph.service.reads import resolve_doi
+
+    ws = _init_workspace(tmp_path)
+    _seed_store(ws, [_row(id="P1", doi=None)])
+
+    result = resolve_doi(ws, "P1")
+
+    assert result is None
+
+
+@pytest.mark.unit
+def test_resolve_doi_doi_vacio_es_none(tmp_path: Path) -> None:
+    """resolve_doi trata un DOI cadena vacía ('') como ausente → None.
+
+    Coherente con networks/decorate.py (que solo emite doi/url cuando el
+    DOI es truthy) y con resolve_url. Sella el contrato 'None en los 3
+    casos' del issue #212.
+    """
+    from bib2graph.service.reads import resolve_doi, resolve_url
+
+    ws = _init_workspace(tmp_path)
+    _seed_store(ws, [_row(id="P1", doi="")])
+
+    assert resolve_doi(ws, "P1") is None
+    assert resolve_url(ws, "P1") is None
+
+
+@pytest.mark.unit
+def test_resolve_doi_id_inexistente(tmp_path: Path) -> None:
+    """resolve_doi devuelve None cuando el id no existe en el corpus (no lanza)."""
+    from bib2graph.service.reads import resolve_doi
+
+    ws = _init_workspace(tmp_path)
+    _seed_store(ws, [_row(id="P1")])
+
+    result = resolve_doi(ws, "id-que-no-existe")
+
+    assert result is None
+
+
+@pytest.mark.unit
+def test_resolve_url_con_doi(tmp_path: Path) -> None:
+    """resolve_url devuelve la URL bien formada cuando hay DOI."""
+    from bib2graph.service.reads import resolve_url
+
+    ws = _init_workspace(tmp_path)
+    _seed_store(ws, [_row(id="P1", doi="10.1234/test.001")])
+
+    result = resolve_url(ws, "P1")
+
+    assert result == "https://doi.org/10.1234/test.001"
+
+
+@pytest.mark.unit
+def test_resolve_url_sin_doi(tmp_path: Path) -> None:
+    """resolve_url devuelve None cuando el paper existe pero no tiene DOI."""
+    from bib2graph.service.reads import resolve_url
+
+    ws = _init_workspace(tmp_path)
+    _seed_store(ws, [_row(id="P1", doi=None)])
+
+    result = resolve_url(ws, "P1")
+
+    assert result is None
+
+
+@pytest.mark.unit
+def test_resolve_url_id_inexistente(tmp_path: Path) -> None:
+    """resolve_url devuelve None cuando el id no existe en el corpus (no lanza)."""
+    from bib2graph.service.reads import resolve_url
+
+    ws = _init_workspace(tmp_path)
+    _seed_store(ws, [_row(id="P1")])
+
+    result = resolve_url(ws, "id-que-no-existe")
+
+    assert result is None
+
+
+@pytest.mark.unit
+def test_resolve_url_criterio_consistente_con_decorate(tmp_path: Path) -> None:
+    """resolve_url usa el mismo criterio doi→url que networks/decorate.py.
+
+    Ambos consumen doi_to_url de constants.py como fuente única.
+    Este test fija el contrato: mismo DOI → misma URL.
+    """
+    from bib2graph.constants import doi_to_url
+    from bib2graph.service.reads import resolve_url
+
+    doi = "10.9999/consistencia"
+    ws = _init_workspace(tmp_path)
+    _seed_store(ws, [_row(id="P1", doi=doi)])
+
+    # resolve_url debe coincidir con la derivación de doi_to_url directa
+    assert resolve_url(ws, "P1") == doi_to_url(doi)
+
+
+@pytest.mark.unit
+def test_resolve_doi_y_url_expuestos_en_service(tmp_path: Path) -> None:
+    """resolve_doi y resolve_url son importables desde bib2graph.service."""
+    import bib2graph.service as svc
+
+    assert hasattr(svc, "resolve_doi")
+    assert hasattr(svc, "resolve_url")
+    assert callable(svc.resolve_doi)
+    assert callable(svc.resolve_url)


### PR DESCRIPTION
## Qué

Helpers públicos de resolución inversa id→DOI/URL (opción 1 del issue):
- `resolve_doi(ws, paper_id) -> str | None` y `resolve_url(ws, paper_id) -> str | None` en `service/reads.py`, expuestos en `bib2graph.service`.
- Sin red, sobre el corpus cargado. Devuelven `None` (no lanzan) si el id no existe, no tiene DOI, o el DOI es cadena vacía.

## Por qué

El `id` canónico es lossy (oculta el DOI tras un hash). Da una vía pública y documentada para llegar al DOI/URL sin re-implementar el mapa a mano. Compañero de #209 (cierra el último kilómetro también desde código).

## Anti-drift (lección de #175)

La derivación `doi→url` se extrajo a `doi_to_url()` en `constants.py` como **fuente única**, compartida con `networks/decorate.py` (#209). `decorate.py` ahora la reusa **sin cambiar conducta** (verificado caso por caso contra el historial). Test anti-drift incluido.

## Alcance

Solo opción 1. La opción 2 (mapa id→doi en snapshot) y la opción 3 (id reversible — toca identidad → Discussion) quedan fuera.

## Tests

con DOI / sin DOI / **DOI vacío → None** / id inexistente / exposición en `service` / consistencia con #209.

## Docs
`docs/API.md` §0.1 (reads) y §8 (nota de url de redes). Sin ADR (lectura aditiva, no cambia identidad ni contrato).

Closes #212

🤖 Generated with [Claude Code](https://claude.com/claude-code)