### PR TITLE
fix(curate): apply tolera CSV con BOM UTF-8 (Excel-Windows) (#238)

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -125,7 +125,8 @@ VERBO:** solo **`curate filter`→`FILTERED`**; el resto transversal. **BREAKING
   `undecided`→no-op; case-insensitive). **Idempotente** (`decided_at` inyectado en la frontera CLI, R2).
   CSV sin `id`/`decision` o `decision` inválida → `DataError` exit 2. IDs huérfanos → `not_found_count` +
   aviso (no no-op silencioso). `data = {accepted_count, rejected_count, skipped_count, not_found_count,
-  total_rows}`. **`note` se ignora en apply** (advisory).
+  total_rows}`. **`note` se ignora en apply** (advisory). Lee el CSV con `utf-8-sig`: **tolera el
+  BOM UTF-8** que Excel-Windows agrega al guardar como UTF-8 (#238, política Excel-friendly de #214).
 - **`curate accept --ids ... [--by NOMBRE]`** / **`curate reject --ids ... [--by NOMBRE]`** — por ID
   (uno-a-uno o lote). Comparten `accept_papers`/`reject_papers` con los verbos sueltos `accept`/`reject`
   (alias deprecados).

--- a/src/bib2graph/service/curate.py
+++ b/src/bib2graph/service/curate.py
@@ -319,7 +319,7 @@ def run_curate_from_csv(
         )
 
     rows: list[dict[str, str]] = []
-    with open(csv_path, newline="", encoding="utf-8") as f:
+    with open(csv_path, newline="", encoding="utf-8-sig") as f:
         reader = csv.DictReader(f)
         fieldnames = set(reader.fieldnames or [])
 

--- a/tests/unit/test_curate.py
+++ b/tests/unit/test_curate.py
@@ -1038,3 +1038,56 @@ def test_round_trip_con_columnas_nuevas(tmp_path: Path) -> None:
     by_id = {r["id"]: r for r in corpus.to_arrow().to_pylist()}
     assert by_id["PA"]["curation_status"] == "accepted"
     assert by_id["PB"]["curation_status"] == "rejected"
+
+
+# ---------------------------------------------------------------------------
+# 26. BOM UTF-8 — curate apply tolera el BOM que agrega Excel-Windows (#238)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "with_bom",
+    [False, True],
+    ids=["sin_bom", "con_bom"],
+)
+def test_from_csv_tolerates_utf8_bom(tmp_path: Path, with_bom: bool) -> None:
+    """run_curate_from_csv procesa correctamente CSV con y sin BOM UTF-8 (#238).
+
+    Excel-Windows antepone EF BB BF al guardar CSV como UTF-8.  Sin utf-8-sig
+    el header de la primera columna se lee como '\\ufeffid' en vez de 'id',
+    causando el falso error 'falta columna id'.
+    """
+    from bib2graph.cli.commands.curate import CSV_COLUMNS, run_curate_from_csv
+    from bib2graph.stores.duckdb import DuckDBStore
+
+    store_path = tmp_path / "test.duckdb"
+    rows = [_make_corpus_row(id="P1"), _make_corpus_row(id="P2")]
+    _seed_store(store_path, rows)
+
+    encoding = "utf-8-sig" if with_bom else "utf-8"
+    csv_path = tmp_path / "decisions.csv"
+    with open(csv_path, "w", newline="", encoding=encoding) as f:
+        writer = csv.DictWriter(f, fieldnames=CSV_COLUMNS)
+        writer.writeheader()
+        writer.writerow(
+            {**{c: "" for c in CSV_COLUMNS}, "id": "P1", "decision": "accepted"}
+        )
+        writer.writerow(
+            {**{c: "" for c in CSV_COLUMNS}, "id": "P2", "decision": "rejected"}
+        )
+
+    now = datetime.now(UTC)
+    result = run_curate_from_csv(store_path, csv_path, decided_at=now)
+
+    assert result["accepted_count"] == 1
+    assert result["rejected_count"] == 1
+    assert result["skipped_count"] == 0
+    assert result["not_found_count"] == 0
+
+    store = DuckDBStore(store_path)
+    corpus = store.load()
+    by_id = {r["id"]: r for r in corpus.to_arrow().to_pylist()}
+    store.close()
+    assert by_id["P1"]["curation_status"] == "accepted"
+    assert by_id["P2"]["curation_status"] == "rejected"


### PR DESCRIPTION
## Qué

`curate apply` leía el CSV en utf-8 plano → un **BOM** (`EF BB BF`, el que **Excel-Windows agrega al guardar como UTF-8**) pegaba el BOM al primer header (`﻿id`) y el comando fallaba con un error **engañoso** ("falta columna id") aunque la columna estuviera. Rompía el workflow previsto `dump → editar en Excel → apply`.

**Fix:** leer con `encoding="utf-8-sig"` (strippea el BOM si está; idéntico sin él). Mismo criterio Excel-friendly que #214 para la escritura.

## Por qué importa

`curate dump --help` dice "editá en Excel/Calc". Excel-Windows agrega BOM al guardar. Footgun directo del público hispano-Excel. Encontrado en la verificación e2e del CLI (capstone 0.11.0).

## Tests
`curate apply` de un CSV con BOM funciona igual que sin BOM (parametrizado con/sin BOM). Verificado además funcionalmente end-to-end (la repro exacta que fallaba ahora importa 10 aceptados).

## Docs
`docs/API.md` (curate apply tolera BOM). Sin ADR (robustez de lectura, alineada con #214).

## Fuera de alcance (nota del issue)
`curate dump` sigue escribiendo sin BOM; alinearlo a utf-8-sig queda como decisión del PO (#238 lo menciona).

Closes #238

🤖 Generated with [Claude Code](https://claude.com/claude-code)