### PR TITLE
docs: exponer tutoriales y guías en el nav + arreglar enlace roto

### DIFF
--- a/docs/tutoriales/sota-completo.md
+++ b/docs/tutoriales/sota-completo.md
@@ -555,8 +555,8 @@ git commit -m "SOTA: [Tu Tema] — corpus, redes, reporte"
 
 ## Referencias
 
-- [Cómo elaborar un reporte de estado del arte (guía)](../guias/reporte-estado-del-arte.md) —
-  complemento con más detalles en curación y redacción.
+- [Guías (how-to)](../guias/index.md) — recetas acotadas que complementan cada
+  paso: ecuación, forrajeo, curación PRISMA, lectura de redes y redacción del reporte.
 - [Arquitectura de bib2graph](../ARCHITECTURE.md)
 - [Referencia del CLI `b2g`](../reference/cli.md)
 - [API Python](../reference/python-api.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -135,11 +135,19 @@ nav:
       - Quickstart: getting-started/quickstart.md
   - Tutoriales:
       - tutoriales/index.md
+      - Tu primer mapa (5 min): tutoriales/claude-code.md
+      - De la pregunta al reporte de SOTA: tutoriales/sota-completo.md
   - Guías (how-to):
       - guias/index.md
+      - Ecuación de búsqueda: guias/ecuacion-busqueda.md
+      - Forrajeo (expandir el corpus): guias/forrajeo.md
+      - Curación PRISMA: guias/curacion-prisma.md
+      - Leer las 5 redes: guias/leer-redes.md
+      - Del corpus al reporte: guias/reporte.md
   - Referencia:
       - API de Python: reference/python-api.md
       - CLI b2g: reference/cli.md
+      - Glosario: reference/glosario.md
       - Contratos detallados: API.md
   - Explicación:
       - Arquitectura: ARCHITECTURE.md


### PR DESCRIPTION
## Qué hace

Las páginas de tutoriales y guías del #208 existían y se enlazaban en el texto, pero **no aparecían en la barra de navegación** del sitio: en `mkdocs.yml` las secciones `Tutoriales` y `Guías` solo listaban su `index.md`, sin las páginas hijas.

## Cambios

- **`mkdocs.yml`**: listar las páginas individuales bajo cada sección del nav:
  - **Tutoriales**: "Tu primer mapa (5 min)" + "De la pregunta al reporte de SOTA"
  - **Guías**: Ecuación de búsqueda · Forrajeo · Curación PRISMA · Leer las 5 redes · Del corpus al reporte
  - **Referencia**: agregar **Glosario**
- **`docs/tutoriales/sota-completo.md`**: corregir un enlace roto que apuntaba a la guía eliminada `reporte-estado-del-arte.md` → ahora apunta al índice de Guías.

## Verificación

`uv run mkdocs build --strict` construye sin warnings/errores; el nav generado incluye las 8 páginas nuevas (2 tutoriales + 5 guías + glosario). El enlace roto detectado en el build quedó resuelto.

Solo toca `docs/` + `mkdocs.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VfqH92jLCoRQ9G8AMA1Vgi)_