### PR TITLE
chore(docs): pin defensivo mkdocs-material<10 y silencia aviso MkDocs 2.0

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,6 +30,11 @@ jobs:
   build:
     name: build
     runs-on: ubuntu-latest
+    env:
+      # mkdocs-material 9.7.2+ avisa sobre la migración a MkDocs 2.0 (ruptura
+      # total: sin plugins, config TOML). Ya estamos pineados <10 (defensa en
+      # profundidad, ver pyproject.toml), así que el aviso es ruido en CI.
+      NO_MKDOCS_2_WARNING: "1"
     steps:
       - uses: actions/checkout@v5
       - name: Install uv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,7 +133,7 @@ dev = [
 # desde docstrings) y mkdocs-click (CLI b2g, desde el grupo Click). termynal
 # anima las sesiones de terminal del quickstart.
 docs = [
-    "mkdocs-material>=9.5",
+    "mkdocs-material>=9.5,<10",
     "mkdocs-include-markdown-plugin>=6",
     "mkdocstrings[python]>=0.24",
     "mkdocs-click>=0.8",

--- a/uv.lock
+++ b/uv.lock
@@ -101,7 +101,7 @@ wheels = [
 
 [[package]]
 name = "bib2graph"
-version = "0.10.1"
+version = "0.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -172,7 +172,7 @@ dev = [
 docs = [
     { name = "mkdocs-click", specifier = ">=0.8" },
     { name = "mkdocs-include-markdown-plugin", specifier = ">=6" },
-    { name = "mkdocs-material", specifier = ">=9.5" },
+    { name = "mkdocs-material", specifier = ">=9.5,<10" },
     { name = "mkdocstrings", extras = ["python"], specifier = ">=0.24" },
     { name = "termynal", specifier = ">=0.12" },
 ]


### PR DESCRIPTION
## Resumen
- MkDocs 2.0 (aún sin fecha) rompe Material for MkDocs de raíz: elimina el sistema de plugins y pasa la config de YAML a TOML. `mkdocs-material` 9.7.6 ya se auto-pinea a `mkdocs<2`, pero agregamos el techo `mkdocs-material>=9.5,<10` en `pyproject.toml` como defensa en profundidad ante un futuro `uv lock --upgrade`.
- Silencia el warning de migración de mkdocs-material en el workflow de docs (`NO_MKDOCS_2_WARNING=1`), ya innecesario porque estamos cubiertos.

Contexto: https://squidfunk.github.io/mkdocs-material/blog/2026/02/18/mkdocs-2.0/

## Test plan
- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run python -m mypy src` (el binario `uv run mypy` falla por un bug de canonicalización de ruta con tilde en Windows, no relacionado)
- [x] `uv run pytest -q` — 1213 passed