### PR TITLE
fix(chain): cerrar el lazo — backward count real + forward puebla cited_by_id (ADR 0048)

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -99,6 +99,19 @@ desde `references_id`; forward exacto solo si hay `cited_by_id`). Transiciona a 
 {candidates_found, new_candidates, total_papers, direction, depth, ranking_preview, observed_refs_count,
 loop_state, round, enrichment}`.
 
+- **`chain forward`/`both` puebla `cited_by_id` de las semillas alcanzadas** (ADR 0048, #270): el
+  forrajeo hacia adelante ya trae los citantes; con esta decisión completa además la columna
+  `cited_by_id` de esas semillas (unión idempotente vía `Corpus.merge`), dejando listo el insumo del
+  `CoCitationProjector`. Así el lazo natural `seed → chain forward → curate accept → build` produce la
+  red de co-citación **sin `enrich`** ni flag que descubrir. `chain backward` puro no toca
+  `cited_by_id`.
+- **`candidates_found`** es el **total de candidatos rankeados** que ve `--preview` (backward observados
+  + forward materializados, recortado por `--max-candidates`), **NO** el número de filas materializadas
+  en el corpus (#269). En chaining puramente backward los IDs observados no se materializan como filas
+  (opción B, #54): viven en `observed_refs`/el ranking, así que `candidates_found` puede **exceder**
+  `total_papers` (el corpus no crece con backward). No confundir con `new_candidates` (filas nuevas
+  respecto del corpus previo).
+
 - **`--since` (forrajeo incremental, absorbe `monitor`):** trae **solo citantes desde** una fecha
   (**ISO `YYYY-MM-DD`** o atajo `90d`/`6m`/`1y`, parseado en `cli/_options.py::parse_since`). **Fuerza
   forward** y transiciona a **`MONITORED`**. `backward + --since` → exit 1; `both + --since` → la ventana
@@ -110,6 +123,14 @@ pasada **refs→DOI** corre automática en `chain`; la pasada **co-citación** (
 en `build` cuando hay semillas aceptadas (no-op de red sin ellas). Por eso **`build` ya NO es
 estrictamente "sin red"** (ADR 0025 enmendado). Ambos suman `data["enrichment"]`. El alias `b2g enrich`
 corre ambas pasadas y **NO transiciona**.
+
+> **`build` ya no es el único ni el primer poblador de `cited_by_id`** (ADR 0048, #270): desde que
+> `chain forward`/`both` puebla `cited_by_id` de las semillas alcanzadas, el insumo de la co-citación
+> suele llegar **ya poblado** al `build`. La pasada 8b de `build` sigue existiendo (la frase de arriba
+> sigue siendo cierta) y **se solapa transitoriamente** con lo que dejó `chain`; el solapamiento es
+> inocuo porque la unión sobre `cited_by_id` es **idempotente** (no duplica ni corrompe). Diferencia de
+> alcance: `chain forward` puebla `cited_by_id` de las semillas al traer los citantes (independiente de
+> la curación); la pasada 8b de `build` está atada a `accepted`.
 
 **`curate {dump,apply,accept,reject,filter}`** (grupo noun-verb, #155). **La transición la define el
 VERBO:** solo **`curate filter`→`FILTERED`**; el resto transversal. **BREAKING:** la forma-flag
@@ -1316,9 +1337,11 @@ completo** (crítica #2). La **co-citación** es la más cara (segundo nivel de 
   (`id`) es el nodo.
 - **Co-citación:** el `CoCitationProjector` cuenta **`cited_by_id` compartido** = los **citantes
   compartidos** de la metodología (la frase "citantes con sus citas" ≡ `cited_by_id` compartido).
-  Proyecta con scope `seeds_only`. La co-citación es **end-to-end**: la pasada `cited_by` que corre
-  automática en `build` (cuando hay aceptadas) puebla `cited_by_id` con el 2º nivel de fetch del
-  `OpenAlexEnricher` (ADR 0007/0025), y `Networks.quick` la incluye cuando esa columna está poblada (§10).
+  Proyecta con scope `seeds_only`. La co-citación es **end-to-end**: `cited_by_id` se puebla con el 2º
+  nivel de fetch — desde **`chain forward`/`both`** (ADR 0048/#270, al traer los citantes de las
+  semillas alcanzadas) y/o desde la pasada `cited_by` de **`build`** (cuando hay aceptadas; ADR
+  0007/0025), unión idempotente entre ambas —, y `Networks.quick` la incluye cuando esa columna está
+  poblada (§10).
 - **Los proyectores siguen PUROS — NO setean atributos de nodo** (ADR 0014): producen
   un `nx.Graph` con **ids crudos** como nodos (`doi:…`, `I185261750`, un ORCID), **sin** `label`. La
   legibilidad (label + atributos) la inyecta la **capa `decorate` (§7.1)**, que es la **frontera**

--- a/docs/features/B-forrajear.feature
+++ b/docs/features/B-forrajear.feature
@@ -21,15 +21,34 @@ Característica: Forrajear con chaining backward/forward rankeado por scent
     Y "data.candidates_found" es un entero >= 0
     Y "data.direction" es "both"
     Y "data.depth" es 1
-    Y "data.total_papers" es un entero >= "data.candidates_found"
     Y tras el chain el estado del lazo transiciona a "FORAGED"
+    # #269: "data.candidates_found" es el TOTAL de candidatos rankeados (backward observados +
+    # forward materializados, recortado por --max-candidates), NO el nº de filas del corpus.
+    # Por eso NO se sostiene "total_papers >= candidates_found": en backward puro los candidatos
+    # observados pueden exceder el corpus (que no crece — opción B, #54). candidates_found es
+    # independiente de total_papers.
+
+  Escenario: B1 — chain forward puebla cited_by_id de las semillas alcanzadas (ADR 0048)
+    # #270/ADR 0048: el forrajeo hacia adelante ya trae los citantes; con esto completa además
+    # "cited_by_id" de las semillas (unión idempotente vía Corpus.merge), dejando listo el insumo
+    # del CoCitationProjector. Así el lazo seed → chain forward → curate accept → build arma la red
+    # de co-citación SIN enrich. Anclado a src/bib2graph/foraging/forager.py::_build_seed_cited_by_updates.
+    Dado un corpus sembrado sin "cited_by_id" poblado
+    Cuando ejecuto "b2g chain --direction forward --json"
+    Entonces el exit code es 0
+    Y "data.direction" es "forward"
+    Y las semillas alcanzadas por citantes tienen "cited_by_id" poblado en el corpus persistido
+    Y un "b2g build" posterior proyecta una red de co-citación no vacía sin correr "b2g enrich"
 
   Escenario: B1 — Solo backward chaining (referencias de las semillas)
     Cuando ejecuto "b2g chain --direction backward --json"
     Entonces el exit code es 0
     Y "data.direction" es "backward"
     Y "data.observed_refs_count" es un entero >= 0
-    # #54: los IDs backward observados sin materializar se cuentan acá y en status.referenced_not_fetched.
+    Y "data.candidates_found" puede exceder "data.total_papers"
+    # #54/#269: los IDs backward observados sin materializar se cuentan en observed_refs_count y en
+    # status.referenced_not_fetched; también entran en candidates_found (total rankeado), que por eso
+    # puede superar total_papers — el corpus no crece con backward puro.
 
   Escenario: B1 — Forward chaining requiere un source con fetch_citing
     Dado un source sin "fetch_citing_batch" ni "fetch_citing"

--- a/docs/features/D-redes.feature
+++ b/docs/features/D-redes.feature
@@ -25,7 +25,7 @@ Característica: Proyectar el corpus a redes bibliométricas y exportarlas
     Y tras el build el estado del lazo transiciona a "BUILT"
     Y "networks/.corpus_hash" queda sellado con el hash del corpus filtrado
 
-  Escenario: D1 — La co-citación aparece solo tras enriquecer (cited_by_id)
+  Escenario: D1 — La co-citación aparece cuando cited_by_id está poblado
     Dado un corpus sin "cited_by_id" poblado
     Cuando ejecuto "b2g enrich --max-citing 25 --json"
     Y luego ejecuto "b2g build --json"
@@ -33,6 +33,9 @@ Característica: Proyectar el corpus a redes bibliométricas y exportarlas
     Y "data.networks" incluye el kind "cocitation"
     # Networks.quick agrega cocitación solo si algún paper tiene cited_by_id (Hito 8b).
     # enrich NO transiciona el lazo (ortogonal al FSM).
+    # ADR 0048/#270: enrich NO es el único camino a cited_by_id — "b2g chain --direction forward"
+    # también lo puebla (de las semillas alcanzadas) al traer los citantes. Por eso el lazo natural
+    # seed → chain forward → curate accept → build arma la co-citación SIN enrich (ver B-forrajear).
 
   Escenario: D1 — Filtrar el corpus por curación antes de proyectar
     Cuando ejecuto "b2g build --corpus-scope accepted --json"

--- a/src/bib2graph/cli/commands/chain.py
+++ b/src/bib2graph/cli/commands/chain.py
@@ -63,7 +63,10 @@ def run_chain(
         Dict con ``candidates_found``, ``total_papers``, ``ranking_preview``
         (modo normal); o con ``preview``, ``estimated_candidates``,
         ``by_direction``, ``capped_by_max``, ``forward_requires_fetch``,
-        ``forward_from_cited_by`` (modo preview).
+        ``forward_from_cited_by`` (modo preview).  ``candidates_found`` es el
+        total de candidatos rankeados (backward observados + forward
+        materializados, #269); NO cuenta solo lo materializado en el corpus,
+        que en chaining puramente backward siempre da 0 (opción B, #54).
 
     Raises:
         DependencyError: Si el source no soporta forward chaining.
@@ -163,7 +166,15 @@ def run_chain(
         # decorador @handle_errors las captura por tipo y emite exit 4.
         # AttributeError genuino se propaga limpio (no se disfraza de exit 3).
 
-        candidates_found = len(ranked.corpus)
+        # #269: candidates_found debe reflejar el TOTAL de candidatos encontrados
+        # por el ranking (backward + forward), no solo las filas materializadas
+        # en ranked.corpus. Backward NO materializa filas (opción B, #54): sus IDs
+        # viven en ranked.observed_refs / ranked.ranking, así que len(ranked.corpus)
+        # da 0 en chaining puramente backward aunque haya miles de candidatos
+        # observados — contradiciendo lo que --preview lista. ranked.ranking es la
+        # lista completa (recortada solo por --max-candidates, igual que el preview),
+        # separada del render truncado a 10 de ranking_preview.
+        candidates_found = len(ranked.ranking)
         ranking_preview = [
             {"id": id_, "scent": scent} for id_, scent in ranked.ranking[:10]
         ]

--- a/src/bib2graph/cli/commands/chain.py
+++ b/src/bib2graph/cli/commands/chain.py
@@ -44,8 +44,9 @@ def run_chain(
     Cuando ``preview=True``, estima el crecimiento potencial **sin fetchear**
     ni transicionar el estado del corpus.  La estimación backward es exacta
     (desde ``references_id``); la forward es exacta si el corpus tiene
-    ``cited_by_id`` poblado (pasó por ``b2g enrich``), o indica que se
-    requiere fetch si ``cited_by_id`` está vacío.
+    ``cited_by_id`` poblado (pasó por ``b2g enrich`` o un ``chain forward``
+    previo, ADR 0048), o indica que se requiere fetch si ``cited_by_id``
+    está vacío.
 
     Args:
         store_path: Ruta al archivo ``.duckdb``.

--- a/src/bib2graph/foraging/base.py
+++ b/src/bib2graph/foraging/base.py
@@ -72,18 +72,25 @@ class GrowthPreview(BaseModel):
 class RankedCandidates(BaseModel):
     """Resultado del ``Forager.chain()``: candidatos rankeados por scent.
 
-    El corpus contiene SOLO los candidatos nuevos materializados (forward:
-    filas reales; backward: vacío — los IDs backward van a ``observed_refs``).
-    El corpus NO se mergeó con el corpus semilla.
+    El corpus contiene los candidatos nuevos materializados (forward: filas
+    reales; backward: vacío — los IDs backward van a ``observed_refs``) MÁS,
+    en direction forward/both, filas de semillas ya existentes con
+    ``cited_by_id`` actualizado (ADR 0048, #270).  El corpus NO se mergeó con
+    el corpus semilla — eso lo hace el llamador (``Corpus.merge``, unión de
+    sets en columnas lista — D3, idempotente).
     El ranking es una lista estable ordenada por scent descendente, con
     desempate por id ascendente.
 
     Attributes:
         corpus: Corpus de candidatos materializados con
-            ``curation_status='candidate'`` (solo forward; backward = vacío).
+            ``curation_status='candidate'`` (solo forward; backward = vacío)
+            más las actualizaciones de ``cited_by_id`` de semillas (ADR 0048;
+            estas últimas NO son candidatos: ya existen en el corpus semilla,
+            el merge las fusiona por ``id``).
         ranking: Lista ``(id, information_scent)`` ordenada por scent desc.
             Incluye tanto candidatos forward (materializados) como backward
-            (solo IDs observados, sin fila en corpus).
+            (solo IDs observados, sin fila en corpus).  NO incluye las
+            actualizaciones de ``cited_by_id`` de semillas (no son candidatos).
         observed_refs: IDs de OpenAlex observados en backward chaining pero
             NO materializados como filas del corpus (opción B — #54).  Son
             los candidatos backward que se persisten en la tabla auxiliar

--- a/src/bib2graph/foraging/forager.py
+++ b/src/bib2graph/foraging/forager.py
@@ -14,6 +14,11 @@ funciones puras de ``scent.py`` (R4, ADR 0020/0022):
   Robusto ante corpus con ``references_id`` ralas (estado común tras un seed
   sin enriquecimiento); el acoplamiento bibliográfico puro degeneraba a 0.
   Los candidatos forward SÍ se materializan como filas del corpus.
+- **Co-citación (ADR 0048, #270)**: la pasada forward, de paso, puebla
+  ``cited_by_id`` de las semillas alcanzadas (la atribución citante→semilla
+  ya se trae para el scent; cero red extra).  Deja listo el insumo del
+  ``CoCitationProjector`` (ADR 0014, no se toca) sin requerir ``enrich`` ni
+  curación previa.  Ver ``Forager._build_seed_cited_by_updates``.
 
 Solo él toca la red (a través del ``Source`` inyectado).  El núcleo de
 scent es puro.  ``explain_candidate`` fue **eliminado** (R4, ADR 0022).
@@ -284,8 +289,15 @@ class Forager:
         Los candidatos forward SÍ se materializan como filas en
         ``RankedCandidates.corpus`` (con metadata traída por ``fetch_citing_batch``).
 
+        **ADR 0048 (#270):** en direction forward/both, ``corpus`` también
+        incluye filas de **semillas ya existentes** con ``cited_by_id``
+        actualizado (unión con los citantes traídos en esta pasada). No son
+        candidatos nuevos: el merge posterior (``Corpus.merge``) las fusiona
+        por ``id`` con la semilla ya persistida, sin duplicar filas.
+
         Devuelve un ``RankedCandidates`` con:
-        - ``corpus``: SOLO candidatos forward (no mergeado con el corpus semilla).
+        - ``corpus``: candidatos forward + actualizaciones de cited_by_id de
+          semillas (no mergeado con el corpus semilla).
         - ``ranking``: candidatos backward + forward rankeados por scent.
         - ``observed_refs``: IDs backward observados (no en corpus, tabla auxiliar).
 
@@ -306,6 +318,10 @@ class Forager:
         fwd_candidate_rows: dict[str, dict[str, Any]] = {}
         # IDs backward: se observan pero NO se materializan como corpus rows
         bwd_observed: set[str] = set()
+        # ADR 0048 (#270): filas de semillas con cited_by_id actualizado.
+        # NO son candidatos (no entran al ranking/scent): son actualizaciones
+        # de filas ya existentes que el merge posterior fusiona por id.
+        seed_cited_by_updates: dict[str, dict[str, Any]] = {}
 
         if direction in ("backward", "both"):
             bwd_scent = compute_backward_scent(rows)
@@ -314,7 +330,7 @@ class Forager:
                 bwd_observed.add(ref_id)
 
         if direction in ("forward", "both"):
-            fwd_scent, fwd_rows = self._fetch_forward(
+            fwd_scent, fwd_rows, seed_cited_by_updates = self._fetch_forward(
                 rows, fetched_at=fetched_at, since=since
             )
             for cand_id, scent_val in fwd_scent.items():
@@ -335,14 +351,19 @@ class Forager:
             and cand_id not in fwd_candidate_rows
         ]
 
-        # R5: bulk-load — solo filas FORWARD materializadas.
-        # El orden del ranking se preserva construyendo la lista en ese orden.
+        # R5: bulk-load — filas FORWARD materializadas + actualizaciones de
+        # semillas (ADR 0048, #270). El orden del ranking se preserva
+        # construyendo la lista de candidatos forward en ese orden; las
+        # actualizaciones de semilla van al final (ya tienen id propio, no
+        # participan del ranking). Ambas se fusionan con el corpus original
+        # vía Corpus.merge (unión de sets en cited_by_id — D3, idempotente).
         fwd_rows_ordered = [
             fwd_candidate_rows[cand_id]
             for cand_id, _ in ranking
             if cand_id in fwd_candidate_rows
         ]
-        rows_with_ids = _rows_with_ids(fwd_rows_ordered)
+        all_rows = fwd_rows_ordered + list(seed_cited_by_updates.values())
+        rows_with_ids = _rows_with_ids(all_rows)
         if rows_with_ids:
             table = pa.Table.from_pylist(rows_with_ids, schema=CORPUS_SCHEMA)
             candidates_corpus = Corpus.from_arrow(table)
@@ -376,8 +397,8 @@ class Forager:
         *,
         fetched_at: str,
         since: date | None = None,
-    ) -> tuple[dict[str, float], dict[str, dict[str, Any]]]:
-        """Trae citantes via batcheo y calcula scent forward.
+    ) -> tuple[dict[str, float], dict[str, dict[str, Any]], dict[str, dict[str, Any]]]:
+        """Trae citantes via batcheo, calcula scent forward y puebla ``cited_by_id``.
 
         Usa ``fetch_citing_batch_with_works`` del source (batcheo OR ≤50 IDs
         por request, presupuesto por semilla, retry/backoff incluidos) para
@@ -398,14 +419,27 @@ class Forager:
         canónico), con ``is_seed=False``, ``chaining_hop=1`` y
         ``source_tag='chaining:forward'``.
 
+        **ADR 0048 (#270):** además, puebla ``cited_by_id`` de las semillas del
+        corpus alcanzadas por esta pasada (la atribución citante→semillas ya
+        se trajo para calcular el scent; no requiere red extra).  Devuelve
+        filas de actualización *completas* (copia de la fila semilla original
+        con ``cited_by_id`` unido a los nuevos citantes) para que ``chain()``
+        las incluya en ``RankedCandidates.corpus`` y el merge posterior
+        (``Corpus.merge``, unión de sets — D3) las fusione de forma
+        idempotente con la semilla ya persistida.  El ``CoCitationProjector``
+        (ADR 0014, no se toca) consume ``cited_by_id`` como insumo.
+
         Args:
             corpus_rows: Filas del corpus actual.
             fetched_at: Timestamp ISO del fetch.
 
         Returns:
-            Tupla ``(scent_map, candidate_rows)`` donde ``candidate_rows``
-            tiene la fila completa (con metadata real) de cada candidato
-            forward con score > 0.
+            Tupla ``(scent_map, candidate_rows, seed_updates)`` donde
+            ``candidate_rows`` tiene la fila completa (con metadata real) de
+            cada candidato forward con score > 0, y ``seed_updates`` tiene,
+            por ``id`` canónico de semilla, la fila de la semilla con
+            ``cited_by_id`` actualizado (unión con los citantes de esta
+            pasada).
 
         Raises:
             AttributeError: Si el ``source`` no tiene ``fetch_citing_batch``.
@@ -420,7 +454,7 @@ class Forager:
         # Alcance: todas las semillas (is_seed=True); el chaining precede a la curación
         seed_ids = _extract_seed_ids(corpus_rows)
         if not seed_ids:
-            return {}, {}
+            return {}, {}, {}
 
         # Se incluye source_id porque los IDs de motor (W… de OpenAlex) aparecen
         # en references_id y deben cruzar contra source_id W… del corpus.
@@ -478,8 +512,16 @@ class Forager:
                 if citer_id not in corpus_ids:
                     citer_to_seeds.setdefault(citer_id, []).append(seed_id)
 
+        # ADR 0048 (#270): construir seed_updates = filas de semilla con
+        # cited_by_id poblado, ANTES del early-return, porque citing_dict ya
+        # trae la atribución completa (incluye citantes que ya estaban en el
+        # corpus_ids, filtrados arriba solo de citer_to_seeds). Se reconstruye
+        # la atribución completa (sin excluir citer_id ∈ corpus_ids) porque un
+        # citante ya presente en el corpus también cuenta para cited_by_id.
+        seed_updates = self._build_seed_cited_by_updates(corpus_rows, citing_dict)
+
         if not citer_to_seeds:
-            return {}, {}
+            return {}, {}, seed_updates
 
         # Construir filas con metadata real (vía _work_to_row) cuando el source
         # proveyó los works; el score es len(seeds_citados ∩ corpus_ids).
@@ -543,4 +585,54 @@ class Forager:
                     }
                 candidate_rows[citer_id] = row
 
-        return scent_map, candidate_rows
+        return scent_map, candidate_rows, seed_updates
+
+    def _build_seed_cited_by_updates(
+        self,
+        corpus_rows: list[dict[str, Any]],
+        citing_dict: dict[str, list[str]],
+    ) -> dict[str, dict[str, Any]]:
+        """Construye filas de semilla con ``cited_by_id`` actualizado (ADR 0048).
+
+        Para cada semilla con citantes nuevos en ``citing_dict``, copia su fila
+        original del corpus y le une (D3: unión de sets) los ``citer_id``
+        encontrados a ``cited_by_id``.  Devuelve filas *completas* (no parches)
+        para que ``Corpus.merge`` las fusione sin fabricar valores placeholder
+        en columnas no-nullable (``title``, ``is_seed``, ``curation_status``).
+
+        Si una semilla no tiene citantes nuevos, o ``cited_by_id`` ya contiene
+        exactamente el mismo set, no se incluye en el resultado (idempotencia:
+        no aporta nada nuevo al merge).
+
+        Args:
+            corpus_rows: Filas del corpus actual (incluye las semillas).
+            citing_dict: ``{seed_source_id: [citer_id, ...]}`` devuelto por
+                ``fetch_citing_batch``/``fetch_citing_batch_with_works``.
+
+        Returns:
+            Dict ``{id_canonico_semilla: fila_actualizada}``.
+        """
+        if not citing_dict:
+            return {}
+
+        # source_id (W...) → fila completa de la semilla en el corpus.
+        seed_rows_by_source_id: dict[str, dict[str, Any]] = {}
+        for row in corpus_rows:
+            if row.get(Col.IS_SEED) and row.get(Col.SOURCE_ID):
+                seed_rows_by_source_id[str(row[Col.SOURCE_ID])] = row
+
+        updates: dict[str, dict[str, Any]] = {}
+        for seed_source_id, citer_ids in citing_dict.items():
+            seed_row = seed_rows_by_source_id.get(seed_source_id)
+            if seed_row is None or not citer_ids:
+                continue
+            existing: list[str] = list(seed_row.get(Col.CITED_BY_ID) or [])
+            merged = sorted(set(existing) | set(citer_ids))
+            if set(merged) == set(existing):
+                # Nada nuevo: no aporta al merge (idempotencia limpia).
+                continue
+            updated_row = dict(seed_row)
+            updated_row[Col.CITED_BY_ID] = merged
+            updates[str(seed_row[Col.ID])] = updated_row
+
+        return updates

--- a/tests/integration/test_chain_forward_cocitation.py
+++ b/tests/integration/test_chain_forward_cocitation.py
@@ -1,0 +1,310 @@
+"""Tests — #270 / ADR 0048: ``chain forward`` puebla ``cited_by_id``.
+
+Verifica el "camino único de co-citación" decidido en el ADR 0048: el
+forrajeo hacia adelante (``chain --direction forward``), que ya trae los
+citantes de las semillas para el chaining, completa además el campo
+``cited_by_id`` de esas semillas — el insumo que consume el
+``CoCitationProjector`` (ADR 0014, no se toca).
+
+Cubre:
+- Forager puro: ``chain(direction='forward')`` incluye en ``RankedCandidates
+  .corpus`` una fila de actualización de la semilla con ``cited_by_id``
+  poblado (unión, no reemplazo).
+- Idempotencia: correr forward dos veces no duplica ``cited_by_id``.
+- End-to-end del camino feliz: ``seed → chain forward → curate accept →
+  build`` produce una red de co-citación NO vacía, sin necesidad de
+  ``enrich`` (deprecado) ni de que build dependa de seeds aceptadas para
+  poblar el insumo (el insumo ya llega poblado desde chain).
+
+Marcador: ``integration`` (DuckDB local + httpx.MockTransport; sin red real).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pyarrow as pa
+import pytest
+
+from bib2graph.corpus import Corpus
+from bib2graph.foraging.forager import Forager
+from bib2graph.schemas import CORPUS_SCHEMA
+
+pytestmark = pytest.mark.integration
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _base_row(
+    id: str,
+    *,
+    source_id: str | None = None,
+    is_seed: bool = True,
+    cited_by_id: list[str] | None = None,
+    curation_status: str = "candidate",
+) -> dict[str, Any]:
+    return {
+        "id": id,
+        "source_id": source_id,
+        "doi": None,
+        "title": f"Paper {id}",
+        "year": 2020,
+        "abstract": None,
+        "source": None,
+        "language": None,
+        "publisher": None,
+        "research_areas": None,
+        "is_seed": is_seed,
+        "curation_status": curation_status,
+        "provenance": None,
+        "authors_raw": None,
+        "authors_id": None,
+        "authors_affiliations": None,
+        "keywords_raw": None,
+        "keywords_id": None,
+        "institutions_raw": None,
+        "institutions_id": None,
+        "references_id": None,
+        "references_doi": None,
+        "cited_by_id": cited_by_id,
+    }
+
+
+def _make_corpus(*rows: dict[str, Any]) -> Corpus:
+    table = pa.Table.from_pylist(list(rows), schema=CORPUS_SCHEMA)
+    return Corpus.from_arrow(table)
+
+
+def _citing_work(
+    citer_id: str,
+    *,
+    cites_ids: list[str],
+    title: str = "Citing Paper",
+    year: int = 2022,
+) -> dict[str, Any]:
+    """Work JSON de OpenAlex que cita ``cites_ids`` (IDs cortos, sin prefijo)."""
+    return {
+        "id": f"https://openalex.org/{citer_id}",
+        "doi": None,
+        "title": title,
+        "display_name": title,
+        "publication_year": year,
+        "language": "en",
+        "abstract_inverted_index": None,
+        "authorships": [],
+        "keywords": [],
+        "referenced_works": [f"https://openalex.org/{cid}" for cid in cites_ids],
+        "primary_location": None,
+        "type": "article",
+    }
+
+
+def _make_forward_transport(
+    citing_works: list[dict[str, Any]],
+) -> httpx.MockTransport:
+    """Transport que responde a ``cites:`` con los works dados y vacío al resto.
+
+    Cubre también ``openalex_id:`` (refs→DOI, pasada automática de ``chain``)
+    devolviendo vacío: no hay DOIs que resolver en estos tests.
+    """
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        params = dict(request.url.params)
+        filter_val: str = params.get("filter", "")
+        results: list[dict[str, Any]] = citing_works if "cites:" in filter_val else []
+        return httpx.Response(
+            200,
+            json={
+                "results": results,
+                "meta": {"count": len(results), "next_cursor": None},
+            },
+            headers={"x-openalex-api-version": "2026-05-01"},
+        )
+
+    return httpx.MockTransport(handler)
+
+
+# ---------------------------------------------------------------------------
+# Forager puro: chain(forward) puebla cited_by_id
+# ---------------------------------------------------------------------------
+
+
+class TestForagerForwardPopulatesCitedById:
+    """El Forager, en direction forward, incluye actualizaciones de semilla."""
+
+    def test_chain_forward_incluye_cited_by_de_semilla(self) -> None:
+        """RankedCandidates.corpus incluye la semilla con cited_by_id poblado."""
+        from bib2graph.sources.openalex import OpenAlexSource
+
+        rows = [_base_row("P1", source_id="W1", curation_status="accepted")]
+        corpus = _make_corpus(*rows)
+
+        transport = _make_forward_transport([_citing_work("W9999", cites_ids=["W1"])])
+        source = OpenAlexSource(transport=transport)
+        forager = Forager(source, depth=1)
+        ranked = forager.chain(corpus, direction="forward")
+
+        rows_out = ranked.corpus.to_arrow().to_pylist()
+        seed_row = next((r for r in rows_out if r["id"] == "P1"), None)
+        assert seed_row is not None, (
+            "chain(forward) debe incluir una fila de actualización para la "
+            "semilla P1 con cited_by_id poblado (ADR 0048, #270)"
+        )
+        assert seed_row["cited_by_id"] == ["W9999"], (
+            f"cited_by_id de la semilla debe contener el citante; "
+            f"got {seed_row['cited_by_id']!r}"
+        )
+
+    def test_cited_by_id_es_union_no_reemplazo(self) -> None:
+        """Si la semilla ya tenía cited_by_id, el nuevo citante se une (D3)."""
+        from bib2graph.sources.openalex import OpenAlexSource
+
+        rows = [
+            _base_row(
+                "P1",
+                source_id="W1",
+                curation_status="accepted",
+                cited_by_id=["W_OLD"],
+            )
+        ]
+        corpus = _make_corpus(*rows)
+
+        transport = _make_forward_transport([_citing_work("W9999", cites_ids=["W1"])])
+        source = OpenAlexSource(transport=transport)
+        forager = Forager(source, depth=1)
+        ranked = forager.chain(corpus, direction="forward")
+
+        rows_out = ranked.corpus.to_arrow().to_pylist()
+        seed_row = next(r for r in rows_out if r["id"] == "P1")
+        assert set(seed_row["cited_by_id"]) == {"W_OLD", "W9999"}, (
+            "cited_by_id debe ser la unión del valor existente y el nuevo "
+            f"citante; got {seed_row['cited_by_id']!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# run_chain: idempotencia end-to-end sobre el store
+# ---------------------------------------------------------------------------
+
+
+class TestRunChainForwardCitedByIdempotente:
+    """run_chain(forward) persiste cited_by_id; correr dos veces no duplica."""
+
+    def _seed_store(self, store_path: Path) -> None:
+        from bib2graph.cycle import CycleState
+        from bib2graph.stores.duckdb import DuckDBStore
+
+        row = _base_row("P1", source_id="W1", curation_status="accepted")
+        table = pa.Table.from_pylist([row], schema=CORPUS_SCHEMA)
+        corpus = Corpus.from_arrow(table)
+        store = DuckDBStore(store_path)
+        store.persist(corpus)
+        store.backend.set_loop_state(CycleState.SEEDED, cycle_round=1)
+        store.close()
+
+    def test_run_chain_forward_puebla_cited_by_id(self, tmp_path: Path) -> None:
+        from bib2graph.cli.commands.chain import run_chain
+        from bib2graph.stores.duckdb import DuckDBStore
+
+        store_path = tmp_path / "lib.duckdb"
+        self._seed_store(store_path)
+
+        transport = _make_forward_transport([_citing_work("W9999", cites_ids=["W1"])])
+        run_chain(store_path, direction="forward", transport=transport)
+
+        store = DuckDBStore(store_path)
+        rows = store.load().to_arrow().to_pylist()
+        store.close()
+
+        seed_row = next(r for r in rows if r["id"] == "P1")
+        assert seed_row["cited_by_id"] == ["W9999"], (
+            "Tras run_chain(forward), la semilla debe tener cited_by_id "
+            f"poblado; got {seed_row['cited_by_id']!r}"
+        )
+
+    def test_run_chain_forward_idempotente(self, tmp_path: Path) -> None:
+        """Correr chain forward dos veces no duplica cited_by_id."""
+        from bib2graph.cli.commands.chain import run_chain
+        from bib2graph.stores.duckdb import DuckDBStore
+
+        store_path = tmp_path / "lib.duckdb"
+        self._seed_store(store_path)
+
+        transport = _make_forward_transport([_citing_work("W9999", cites_ids=["W1"])])
+        run_chain(store_path, direction="forward", transport=transport)
+        run_chain(store_path, direction="forward", transport=transport)
+
+        store = DuckDBStore(store_path)
+        rows = store.load().to_arrow().to_pylist()
+        store.close()
+
+        seed_row = next(r for r in rows if r["id"] == "P1")
+        assert seed_row["cited_by_id"] == ["W9999"], (
+            "Repetir chain(forward) no debe duplicar cited_by_id; "
+            f"got {seed_row['cited_by_id']!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: seed -> chain forward -> curate accept -> build (co-citación)
+# ---------------------------------------------------------------------------
+
+
+class TestEndToEndCocitationCierraElLazo:
+    """El camino natural del lazo produce una red de co-citación no vacía."""
+
+    def test_build_produce_cocitacion_tras_chain_forward(self, tmp_path: Path) -> None:
+        """seed -> chain forward -> curate accept -> build: co-citación > 0.
+
+        Dos semillas (P1=W1, P2=W2) comparten un citante (W9999) que las cita
+        a ambas.  Tras ``chain --direction forward``, ambas quedan con
+        ``cited_by_id=["W9999"]``: comparten un citante, luego están
+        co-citadas.  ``build`` debe reflejarlo con ``edges > 0`` en la red
+        ``cocitation``, SIN pasar por ``enrich`` (deprecado, ADR 0048).
+        """
+        from bib2graph.cli.commands.build import run_build
+        from bib2graph.cli.commands.chain import run_chain
+        from bib2graph.cycle import CycleState
+        from bib2graph.stores.duckdb import DuckDBStore
+
+        store_path = tmp_path / "lib.duckdb"
+
+        rows = [
+            _base_row("P1", source_id="W1", curation_status="accepted"),
+            _base_row("P2", source_id="W2", curation_status="accepted"),
+        ]
+        table = pa.Table.from_pylist(rows, schema=CORPUS_SCHEMA)
+        corpus = Corpus.from_arrow(table)
+        store = DuckDBStore(store_path)
+        store.persist(corpus)
+        store.backend.set_loop_state(CycleState.SEEDED, cycle_round=1)
+        store.close()
+
+        # Un citante que cita ambas semillas: co-citación entre P1 y P2.
+        transport = _make_forward_transport(
+            [_citing_work("W9999", cites_ids=["W1", "W2"])]
+        )
+        chain_result = run_chain(store_path, direction="forward", transport=transport)
+        assert chain_result["candidates_found"] > 0
+
+        # curate accept: ambas semillas ya vienen 'accepted' en este fixture
+        # (no hace falta un paso CLI adicional; refleja que build no necesita
+        # depender de la pasada 8b para tener el insumo — ya llegó de chain).
+        # build sigue corriendo su propia pasada 8b heredada (ADR 0025/0038,
+        # solapamiento transitorio documentado en ADR 0048); se le inyecta el
+        # mismo transport mockeado (idempotente: no debería aportar citantes
+        # nuevos, el insumo ya está poblado desde chain forward).
+        build_result = run_build(store_path, corpus_scope="all", transport=transport)
+
+        cocitation_entries = [
+            n for n in build_result["networks"] if n["kind"] == "cocitation"
+        ]
+        assert cocitation_entries, "build debe producir una red 'cocitation'"
+        assert cocitation_entries[0]["edges"] > 0, (
+            "La red de co-citación debe tener aristas: P1 y P2 comparten el "
+            f"citante W9999 tras chain forward; got {cocitation_entries[0]}"
+        )

--- a/tests/unit/test_backward_no_placeholders.py
+++ b/tests/unit/test_backward_no_placeholders.py
@@ -474,6 +474,40 @@ class TestRunChainBackwardNoPersistePlaceholders:
         assert "observed_refs_count" in result
         assert result["observed_refs_count"] == 2
 
+    def test_candidates_found_no_es_cero_con_refs_observadas(
+        self, tmp_path: Path
+    ) -> None:
+        """#269: candidates_found refleja el total real de candidatos backward.
+
+        Antes del fix, ``candidates_found = len(ranked.corpus)`` daba SIEMPRE
+        0 en chaining puramente backward (opción B, #54: los candidatos
+        backward no se materializan como filas del corpus) — contradiciendo
+        lo que ``--preview`` lista (miles de referencias observadas).  El
+        envelope debe reportar el total de candidatos backward encontrados,
+        coincidiendo con lo que ve el preview (``estimated_candidates`` /
+        ``by_direction["backward"]``).
+        """
+        from bib2graph.cli.commands.chain import run_chain
+
+        store_path = tmp_path / "lib.duckdb"
+        self._seed_store(store_path, ["REF_A", "REF_B", "REF_C"])
+
+        # El preview ve 3 candidatos backward (references_id de la semilla).
+        preview_result = run_chain(store_path, direction="backward", preview=True)
+        assert preview_result["by_direction"]["backward"] == 3
+
+        # El chain real (sin preview) debe reportar el mismo total, no 0.
+        result = run_chain(store_path, direction="backward", transport=_NOOP_TRANSPORT)
+
+        assert result["candidates_found"] > 0, (
+            "candidates_found es 0 pese a haber refs observadas: el envelope "
+            "se contradice con --preview (#269)"
+        )
+        assert result["candidates_found"] == 3
+        assert result["candidates_found"] == preview_result["by_direction"]["backward"]
+        # Coincide también con lo que observed_refs_count reporta (mismo total).
+        assert result["candidates_found"] == result["observed_refs_count"]
+
     def test_chain_idempotente_referenced(self, tmp_path: Path) -> None:
         """Correr chain backward dos veces no duplica los IDs en la tabla auxiliar."""
         from bib2graph.backends.duckdb import DuckDBBackend
@@ -568,11 +602,21 @@ class TestForwardNoRegression:
         forager = Forager(TrackingSource(), depth=1)  # type: ignore[arg-type]
         ranked = forager.chain(corpus, direction="forward")
 
-        # Forward: el corpus tiene el candidato
+        # Forward: el corpus tiene el candidato Y la actualización de cited_by_id
+        # de la semilla P1 (ADR 0048, #270) — 2 filas en total.
         cand_rows = ranked.corpus.to_arrow().to_pylist()
-        assert len(cand_rows) == 1, (
-            f"Forward chaining debe materializar 1 candidato, hay {len(cand_rows)}"
+        assert len(cand_rows) == 2, (
+            f"Forward chaining debe materializar 1 candidato + 1 actualización "
+            f"de semilla (cited_by_id, ADR 0048), hay {len(cand_rows)}"
         )
+        # El ranking (candidatos reales) sigue teniendo exactamente 1 entrada
+        # (el candidato W9999, identificado por su source_id de OpenAlex).
+        assert len(ranked.ranking) == 1
+        assert ranked.ranking[0][0] == "W9999"
+        # La fila de actualización de semilla es la de P1 (id existente,
+        # no recalculado por _rows_with_ids).
+        seed_row = next(row for row in cand_rows if row["id"] == "P1")
+        assert seed_row["cited_by_id"] == ["W9999"]
         # observed_refs está vacío (solo backward genera observed_refs)
         assert ranked.observed_refs == []
 

--- a/tests/unit/test_foraging.py
+++ b/tests/unit/test_foraging.py
@@ -504,8 +504,12 @@ class TestForagerForward:
         assert len(ranked.ranking) >= 1
         # El score del candidato refleja citación directa (1 corpus-paper citado)
         assert ranked.ranking[0][1] == 1.0
-        # El candidato forward tiene is_seed=False
-        cand_rows = ranked.corpus.to_arrow().to_pylist()
+        # El candidato forward tiene is_seed=False (la fila de actualización de
+        # cited_by_id de la semilla P1, ADR 0048/#270, sí es is_seed=True y no
+        # es un candidato — se excluye por su id, que ya se conoce del corpus
+        # sembrado).
+        cand_rows = [r for r in ranked.corpus.to_arrow().to_pylist() if r["id"] != "P1"]
+        assert cand_rows
         assert all(not r["is_seed"] for r in cand_rows)
 
     def test_chain_forward_usa_fetch_citing_batch(self) -> None:
@@ -889,7 +893,9 @@ class TestForwardChainingMetadataReal:
         forager = Forager(source, depth=1)
         ranked = forager.chain(corpus, direction="forward")
 
-        cand_rows = ranked.corpus.to_arrow().to_pylist()
+        # La semilla P1 recibe además una fila de actualización de cited_by_id
+        # (ADR 0048/#270); se excluye para aislar el candidato forward real.
+        cand_rows = [r for r in ranked.corpus.to_arrow().to_pylist() if r["id"] != "P1"]
         assert len(cand_rows) == 1, "Debe haber exactamente 1 candidato forward"
         titulo = cand_rows[0].get("title", "")
         assert not titulo.startswith("[candidate:"), (
@@ -917,7 +923,9 @@ class TestForwardChainingMetadataReal:
         forager = Forager(source, depth=1)
         ranked = forager.chain(corpus, direction="forward")
 
-        cand_rows = ranked.corpus.to_arrow().to_pylist()
+        # La semilla P1 recibe además una fila de actualización de cited_by_id
+        # (ADR 0048/#270); se excluye para aislar el candidato forward real.
+        cand_rows = [r for r in ranked.corpus.to_arrow().to_pylist() if r["id"] != "P1"]
         assert len(cand_rows) == 1
         assert cand_rows[0]["year"] == 2022, (
             f"El año debe ser 2022; es {cand_rows[0]['year']}"
@@ -976,7 +984,9 @@ class TestForwardChainingMetadataReal:
         forager = Forager(source, depth=1)
         ranked = forager.chain(corpus, direction="forward")
 
-        cand_rows = ranked.corpus.to_arrow().to_pylist()
+        # La semilla P1 recibe además una fila de actualización de cited_by_id
+        # (ADR 0048/#270); se excluye para aislar el candidato forward real.
+        cand_rows = [r for r in ranked.corpus.to_arrow().to_pylist() if r["id"] != "P1"]
         assert len(cand_rows) == 1
         row = cand_rows[0]
         assert row["is_seed"] is False, "Los candidatos forward deben ser is_seed=False"


### PR DESCRIPTION
**Bloque A del 0.12.0 — cerrar el lazo end-to-end.** Dos arreglos del forrajeo.

- **#269 (bug P1):** `chain --direction backward` reportaba "0 candidatos" pese a `--preview` listar miles. Causa: `candidates_found = len(ranked.corpus)`, siempre 0 en backward puro (los candidatos backward no se materializan como filas, #54). Fix: `len(ranked.ranking)` — el total rankeado que ve el preview.
- **#270 (ADR 0048):** `chain forward`/`both` ahora puebla `cited_by_id` de las semillas alcanzadas (unión idempotente), de modo que `build` arma la red de co-citación **sin `enrich`**. Filas de semilla completas (no parches) por el schema no-nullable.

**Tests:** regresión backward + integración e2e `seed → chain forward → curate accept → build` (cocitation edges>0). **Gate verde (1261 passed).** Docs sincronizadas (API.md §chain, features B/D).

Closes #269, #270. Parte del Plan 0.12.0, Bloque A.
