### PR TITLE
docs(openalex): paso de la API key de OpenAlex (#124)

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -90,6 +90,23 @@ muestras chicas); **`--exclude TEXT`** (repetible) = negaciones quirúrgicas iny
 OpenAlex con `--from-bib` → exit 1** (salvo `--email` junto a `--resolve`). **No existe
 `seed --from-corpus`** (rehidratar un parquet curado es `snapshot restore`).
 
+**Credenciales de OpenAlex (`seed`/`chain`/`build`; ADR [0012](decisiones/0012-openalex-credenciales.md)).**
+Dos credenciales, ambas **inyectadas**, ninguna obligatoria:
+
+- **API key** — env **`OPENALEX_API_KEY`** (no hay flag `--api-key` en los verbos vivos: es un
+  secreto, entra solo por entorno para no aparecer en el envelope `--json`). Precedencia:
+  **argumento `api_key=` (solo Python) > env `OPENALEX_API_KEY` > ausencia ⇒ polite pool**. Con key se
+  manda como header **`Authorization: Bearer <key>`**. Sube el rate limit (relevante con el modelo de
+  créditos de OpenAlex 2026, #124). **Sin key el `Source` no rompe:** corre en polite pool con menor
+  límite (sin degradación de resultados, solo de velocidad).
+- **`--email` (polite pool)** — no es secreto (identificador de cortesía); viaja como **`mailto`** en la
+  query y mueve las peticiones al *polite pool* (límite más generoso que el anónimo).
+
+Un **429** (rate limit agotado tras retry/backoff) aflora como **`NetworkError`** (exit 4) con mensaje
+accionable (declarar `--email` / configurar la key) y **`error.subcode = "RATE_LIMITED"`** en el envelope
+`--json` (grieta 3a, ADR [0045](decisiones/0045-cerrar-tres-grietas-agent-native.md) #258); análogamente
+un 504 agotado da `error.subcode = "UPSTREAM_TIMEOUT"`. Ver `error.subcode` en §Envelope.
+
 **`chain`** (paso CHAIN): expande el corpus con candidatos rankeados por *information scent*
 (forward/backward batcheado, §5). **`--direction [backward|forward|both]`** (default `both`),
 **`--depth`** (solo 1), **`--max-candidates`**, **`--max-citing`** (presupuesto de citantes por semilla
@@ -927,7 +944,7 @@ def load_equation_spec(path: str | Path) -> EquationSpec:
 
 | Implementación | Estado | Notas |
 |----------------|--------|-------|
-| `OpenAlexSource` | **v1** | **Referencia/backbone**, sobre `httpx`. Entrega mínimo + enriquecimiento (refs inline + afiliaciones per-autor + instituciones; `cited_by_id` lo puebla el chaining/Enricher, no el seed). Traducción **passthrough**: envuelve la ecuación en `title_and_abstract.search:(...)` y **reporta** los límites WoS (NEAR/comodín/tags) sin traducirlos. Flag `native=True` (query cruda). **Negaciones (`exclude`):** cada `AND NOT "<término>"` se inyecta **dentro** de la única expresión `search:((query) AND NOT "<término>")` (campo no repetido; el filtro de año queda como predicado separado por coma, fuera del `search`) y se reporta en el `translation_report`; ignorado con `native`. Credenciales inyectadas (arg → `OPENALEX_API_KEY` → `~/.openalex/credentials` → polite pool; ADR 0012). Cursor paging con tope `max_results` (default 200). Puebla `Manifest.openalex_version` (ADR 0017). `transport` inyectable (tests sin red). Un **429** (rate limit del pool anónimo) en `seed()` → `NetworkError` (exit 4) con mensaje **accionable**: declarar `--email` mueve la petición al polite pool (remedio primario); api_key opcional (ADR 0012, #210). |
+| `OpenAlexSource` | **v1** | **Referencia/backbone**, sobre `httpx`. Entrega mínimo + enriquecimiento (refs inline + afiliaciones per-autor + instituciones; `cited_by_id` lo puebla el chaining/Enricher, no el seed). Traducción **passthrough**: envuelve la ecuación en `title_and_abstract.search:(...)` y **reporta** los límites WoS (NEAR/comodín/tags) sin traducirlos. Flag `native=True` (query cruda). **Negaciones (`exclude`):** cada `AND NOT "<término>"` se inyecta **dentro** de la única expresión `search:((query) AND NOT "<término>")` (campo no repetido; el filtro de año queda como predicado separado por coma, fuera del `search`) y se reporta en el `translation_report`; ignorado con `native`. Credenciales inyectadas: la **api_key** se resuelve `arg` → env `OPENALEX_API_KEY` → ausencia ⇒ polite pool (ADR 0012); con key viaja en el header `Authorization: Bearer <key>`. El **email** (arg `email=`/`--email`) viaja como `mailto` en la query (polite pool). Sin key el source **no rompe**: corre en polite pool, solo con menor límite. Cursor paging con tope `max_results` (default 200). Puebla `Manifest.openalex_version` (ADR 0017). `transport` inyectable (tests sin red). Un **429** (rate limit del pool anónimo) en `seed()` → `NetworkError` (exit 4) con mensaje **accionable**: declarar `--email` mueve la petición al polite pool (remedio primario); api_key opcional (ADR 0012, #210). |
 | `BibtexSource` | **v1, secundaria** | Sembrar desde *pearls* vía `load()`. Extra **`[bibtex]`** (import perezoso de `bibtexparser`); acceso defensivo (campos faltantes sin `KeyError`). Mínimo universal. `seed()` lanza `NotImplementedError`. `.bib` con error grave → `ValueError`; sin entradas válidas → `UserWarning` (no no-op silencioso). Carga bulk con `from_arrow`. |
 | `ScieloSource` / `RedalycSource` / `LaReferenciaSource` | futuro | Fuentes regionales, mínimo universal. Declaradas, no implementadas (ADR 0018). |
 | `RisSource` / `CsvSource` | futuro | No implementados. |

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -6,6 +6,39 @@ title: Quickstart
 
 De una ecuación de búsqueda a un GraphML, sin escribir código.
 
+## Antes de empezar: conseguí tu API key de OpenAlex
+
+bib2graph siembra el corpus desde [OpenAlex](https://openalex.org). Funciona **sin
+credenciales** (el *polite pool*), pero para cualquier trabajo real conviene una **API key
+gratuita**: desde 2026 OpenAlex usa un modelo de créditos, y sin key el tier gratis
+(~100 créditos/día) se agota rápido y empezás a ver errores `429` (rate limit) en pleno
+forrajeo. La key sube el límite y evita esos cortes.
+
+**1. Conseguí la key (gratis).** Pedila en [openalex.org/pricing](https://openalex.org/pricing)
+(o desde tu cuenta de OpenAlex). Es opcional pero recomendada.
+
+**2. Configurala como variable de entorno.** bib2graph la lee de `OPENALEX_API_KEY`:
+
+=== "Linux / macOS"
+
+    ```bash
+    export OPENALEX_API_KEY="tu-key-aquí"
+    ```
+
+=== "Windows (PowerShell)"
+
+    ```powershell
+    $env:OPENALEX_API_KEY="tu-key-aquí"
+    ```
+
+**3. Declará tu email para el polite pool.** Independiente de la key, pasá `--email tu@correo.org`
+a los comandos que pegan a OpenAlex (`seed`, `chain`, `build`): mueve tus peticiones al *polite
+pool* de OpenAlex, con un límite más sano. No es un secreto (es un identificador de cortesía).
+
+!!! tip "¿Sin key?"
+    Podés hacer el Quickstart sin key para probar. Si ves un error `429 (Too Many Requests)`,
+    es la señal de que necesitás configurar `OPENALEX_API_KEY` (y/o `--email`).
+
 ## Desde el CLI
 
 <!-- termynal -->
@@ -14,7 +47,7 @@ De una ecuación de búsqueda a un GraphML, sin escribir código.
 $ b2g init mi-investigacion
 Workspace creado en ./mi-investigacion
 $ cd mi-investigacion
-$ b2g seed --equation '"unequal ecological exchange"' --max-results 50
+$ b2g seed --equation '"unequal ecological exchange"' --email tu@correo.org --max-results 50
 Sembrando desde OpenAlex...
 ---> 100%
 52 papers en el corpus
@@ -43,7 +76,8 @@ lista completa de comandos y opciones, corré `b2g --help` o mirá la
 from pathlib import Path
 from bib2graph import OpenAlexSource, DuckDBStore, Networks, GraphMLExporter
 
-corpus = OpenAlexSource().seed('"unequal ecological exchange"').corpus
+# email = polite pool; api_key se toma de OPENALEX_API_KEY si no se pasa (ADR 0012)
+corpus = OpenAlexSource(email="tu@correo.org").seed('"unequal ecological exchange"').corpus
 store = DuckDBStore(Path("biblioteca.duckdb"))
 store.persist(corpus)
 

--- a/docs/guias/ecuacion-busqueda.md
+++ b/docs/guias/ecuacion-busqueda.md
@@ -14,6 +14,12 @@ Esta guía es una receta para llegar a una ecuación acotada, testeada, sin ruid
     - Toma: 30 minutos de escritura + testing
     - Herramienta: lápiz/papel, OpenAlex (o bib2graph), un agente opcional
 
+!!! tip "Antes de sembrar: API key de OpenAlex"
+    Cuando pases de testear la ecuación a sembrar con `b2g seed`, conviene tener configurada tu
+    **API key de OpenAlex** (`OPENALEX_API_KEY`) y pasar `--email` para el polite pool — sin eso, el
+    tier gratis se agota y aparecen errores `429`. Cómo hacerlo:
+    [Quickstart → conseguí tu API key](../getting-started/quickstart.md#antes-de-empezar-consegui-tu-api-key-de-openalex).
+
 ---
 
 ## Antes de empezar: afina tu pregunta

--- a/docs/guias/forrajeo.md
+++ b/docs/guias/forrajeo.md
@@ -70,8 +70,14 @@ Responde:
 
 ```bash
 cd tu-sota
-b2g chain --depth 1 --limit 100
+b2g chain --depth 1 --limit 100 --email tu@correo.org
 ```
+
+!!! tip "API key de OpenAlex"
+    El forrajeo hace **muchas** peticiones a OpenAlex (una tanda por semilla), así que es donde más
+    rápido chocás con el rate limit. Configurá tu **API key** (`OPENALEX_API_KEY`) y pasá `--email`
+    para el polite pool antes de forrajear un corpus grande. Cómo conseguirla y configurarla:
+    [Quickstart → conseguí tu API key](../getting-started/quickstart.md#antes-de-empezar-consegui-tu-api-key-de-openalex).
 
 **Opciones:**
 


### PR DESCRIPTION
Documenta el uso de la **API key de OpenAlex** (#124, Bloque E del 0.12.0) — prioridad del PO, urgente por el modelo de créditos 2026.

El **wiring ya existía** (`OpenAlexSource` lee `OPENALEX_API_KEY` del env, header Bearer, retry/backoff; ADR 0012 + grieta 3a `subcode=RATE_LIMITED`), así que esto es **documentación**:
- **quickstart**: paso temprano "conseguí tu API key" (por qué importa, dónde, `export OPENALEX_API_KEY` / `$env:` en Windows, `--email` polite pool).
- **API.md §seed**: bloque "Credenciales de OpenAlex" (precedencia arg > env > polite pool). Corrige un **drift** real: la doc afirmaba leer `~/.openalex/credentials`, el código no lo hace.
- **guías** forrajeo/ecuación: nota + enlace al paso.

**Decisión:** se cierra #124 **documentalmente** — la key va solo por env; NO se expone `--api-key` (secreto, no debe aparecer en el envelope `--json`; ADR 0043/0012).

Follow-ups menores señalados (no en este PR): mención de `OPENALEX_API_KEY` en `b2g seed --help` (Nota 31); enmienda al ADR 0012 + ROADMAP por el mismo drift de `~/.openalex/credentials`.

Closes #124.
