### PR TITLE
docs: quickstart 5 pasos + posicionamiento antídoto-sesgo + limpieza internals (#187, #264)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 > De una búsqueda bibliográfica a **redes de citación reproducibles** — una biblioteca de literatura que curás vos, sin servidores ni planillas.
 
+**Un antídoto al sesgo del *related work* escrito de memoria.** Cuando armás la revisión
+de literatura recordando papers, repetís lo que ya conocés y dejás afuera lo que no.
+bib2graph convierte una búsqueda en un **corpus + redes de citación + un orden de lectura
+priorizado** —deterministas, reproducibles y con procedencia—. **Te lleva hasta la lectura
+y se detiene ahí:** no interpreta, no gestiona tu investigación ni usa IA; el juicio queda tuyo.
+
 [![PyPI](https://img.shields.io/pypi/v/bib2graph)](https://pypi.org/project/bib2graph/)
 [![Python](https://img.shields.io/pypi/pyversions/bib2graph)](https://pypi.org/project/bib2graph/)
 [![License: GPL-3.0](https://img.shields.io/badge/license-GPL--3.0--or--later-blue)](LICENSE)
@@ -36,19 +42,23 @@ Sembrar desde archivos BibTeX necesita un extra: `bib2graph[bibtex]`.
 
 ## Quickstart
 
-De una ecuación a un GraphML, sin escribir código:
+De una ecuación de búsqueda hasta un orden de lectura, sin escribir código:
 
 ```bash
 b2g init mi-investigacion
 cd mi-investigacion
 
-b2g seed --equation '"unequal ecological exchange"' --max-results 50   # corpus desde OpenAlex
-b2g build                                                              # construye las redes
-b2g export --format graphml                                           # → redes en GraphML
+b2g seed --equation '"unequal ecological exchange"' --max-results 50   # 1. corpus desde OpenAlex
+b2g chain --direction both --max-candidates 300                        # 2. barrido: siguiendo citaciones
+b2g curate dump && b2g curate apply curacion.csv                       # 3. curás vos (revisás el CSV)
+b2g build                                                              # 4. construye las redes
+b2g read top --kind bibliographic_coupling                            #    → orden de lectura (centrales primero)
+b2g export --format graphml                                           # → redes en GraphML para Gephi
 ```
 
-Cada comando acepta `--json` para orquestarlo desde scripts o agentes. Lista completa de
-comandos: `b2g --help`.
+Ese es el hilo completo: **lista ingenua → barrido → curación → redes → lectura dirigida.**
+La escritura de tu revisión narrativa —el paso 5— queda de tu lado. Cada comando acepta
+`--json` para orquestarlo desde scripts o agentes. Lista completa: `b2g --help`.
 
 ### Con Claude Code: pedile a Claude que lo use
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -6,6 +6,33 @@ title: Quickstart
 
 De una ecuación de búsqueda a un GraphML, sin escribir código.
 
+## El hilo: 5 pasos para no repetir tu related work de memoria
+
+Cuando escribís el *related work* de memoria, repetís los papers que ya conocés y
+dejás afuera —sin querer— los que no. bib2graph existe para romper ese sesgo:
+convierte tu búsqueda en un corpus, redes de citación y un **orden de lectura**
+con procedencia. Te lleva **hasta la lectura** y se detiene ahí; la interpretación
+y la escritura quedan tuyas.
+
+El ciclo de comandos que ves abajo es este hilo, paso a paso:
+
+1. **Lista ingenua → barrido.** Partís de tu ecuación de búsqueda y sembrás un
+   primer corpus (`seed`). Después lo expandís siguiendo las citaciones, para que
+   entren los papers que tu búsqueda inicial no vio (`chain`).
+2. **Puntos ciegos.** El barrido trae candidatos que *no* estaban en tu lista
+   mental. Esos son, justamente, los que tendías a olvidar.
+3. **Curás vos.** Aceptás o rechazás cada candidato con criterios explícitos
+   (`curate`). Vos decidís qué entra; bib2graph solo te da la estructura.
+4. **Lectura dirigida.** Construís las redes (`build`) y pedís el orden de lectura:
+   los papers más centrales primero (`read top`). No leés al azar ni de memoria:
+   leés por estructura.
+5. **Escritura narrativa.** Con el corpus, las redes y el orden de lectura en la
+   mano, escribís tu revisión. Ese paso es **tuyo** — bib2graph no interpreta ni
+   redacta por vos.
+
+Las [Guías](../guias/index.md) desarrollan cada paso en detalle. Lo que sigue es la
+versión mínima para verlo funcionar de punta a punta.
+
 ## Antes de empezar: conseguí tu API key de OpenAlex
 
 bib2graph siembra el corpus desde [OpenAlex](https://openalex.org). Funciona **sin
@@ -45,30 +72,44 @@ pool* de OpenAlex, con un límite más sano. No es un secreto (es un identificad
 
 ```
 $ b2g init mi-investigacion
-Workspace creado en ./mi-investigacion
+Carpeta de investigación creada en ./mi-investigacion
 $ cd mi-investigacion
 $ b2g seed --equation '"unequal ecological exchange"' --email tu@correo.org --max-results 50
-Sembrando desde OpenAlex...
+Sembrando desde OpenAlex...        # paso 1: lista ingenua
 ---> 100%
 52 papers en el corpus
-$ b2g build
+$ b2g chain --direction both --max-candidates 300 --email tu@correo.org
+Siguiendo citaciones...            # paso 1-2: barrido + puntos ciegos
+---> 100%
++180 candidatos para revisar
+$ b2g curate dump                  # paso 3: curás vos (revisás el CSV offline)
+Candidatos volcados a ./exports/curacion.csv
+$ b2g curate apply curacion.csv
+Aplicadas tus decisiones: 210 aceptados · 22 rechazados
+$ b2g build                        # paso 4: redes + orden de lectura
 Construyendo las redes...
 ---> 100%
 Listas: acoplamiento · co-citación · co-autoría · instituciones · co-keywords
+$ b2g read top --kind bibliographic_coupling
+Orden de lectura (papers más centrales primero):
+ 1. ...
 $ b2g export --format graphml
-Exportadas a ./redes/*.graphml
+Exportadas a ./exports/*.graphml
 ```
 
-En tres pasos pasaste de una ecuación a redes en GraphML, sin escribir código.
+Pasaste de una ecuación a un corpus curado, redes en GraphML y un orden de lectura,
+sin escribir código. Lo que hagas con esa lectura —el **paso 5**, la escritura— es
+tuyo.
 
 Cada comando acepta `--json` para orquestarlo desde scripts o agentes. Para la
 lista completa de comandos y opciones, corré `b2g --help` o mirá la
 [referencia del CLI `b2g`](../reference/cli.md).
 
-!!! tip "Workspace por investigación"
-    `b2g init` crea una carpeta autocontenida (`workspace.json` + base de datos +
-    redes/snapshots/exports). Todos los comandos resuelven el workspace desde el
-    directorio actual — por eso el `cd` después de `init`.
+!!! tip "Una carpeta por investigación"
+    `b2g init` crea una carpeta autocontenida con tu corpus, tus redes y tus
+    exports adentro. Corré el resto de los comandos **dentro de esa carpeta**
+    (por eso el `cd` después de `init`): así cada investigación queda separada y
+    todo lo que generás se guarda junto.
 
 ## Desde Python
 
@@ -76,7 +117,7 @@ lista completa de comandos y opciones, corré `b2g --help` o mirá la
 from pathlib import Path
 from bib2graph import OpenAlexSource, DuckDBStore, Networks, GraphMLExporter
 
-# email = polite pool; api_key se toma de OPENALEX_API_KEY si no se pasa (ADR 0012)
+# email = polite pool; api_key se toma de OPENALEX_API_KEY si no se pasa
 corpus = OpenAlexSource(email="tu@correo.org").seed('"unequal ecological exchange"').corpus
 store = DuckDBStore(Path("biblioteca.duckdb"))
 store.persist(corpus)

--- a/docs/guias/reporte.md
+++ b/docs/guias/reporte.md
@@ -110,7 +110,7 @@ Total: 12–20 páginas
 > **Años:** 2015–2024 (con 3 foundational 2008–2010).
 >
 > **Redes:** Acoplamiento bibliográfico (comunidades), co-citación (influentes), co-autoría (colaboraciones).
-> **Herramienta:** bib2graph v0.3 + Louvain clustering (resolution=1.0).
+> **Herramienta:** bib2graph (indicá la versión con `b2g --version`) + Louvain clustering (resolution=1.0).
 
 ---
 


### PR DESCRIPTION
Bloque C del 0.12.0 — documentación de usuario.

- **#187 (entra como docs, no feature):** el quickstart gana el hilo conductor **"5 pasos para no repetir tu related work de memoria"** (lista ingenua → barrido → puntos ciegos → curación tuya → lectura dirigida → escritura, tuya) y muestra el ciclo real completo `seed→chain→curate→build→read→export`. El README suma la línea de posicionamiento **"antídoto al sesgo del related work"** con la frase-ancla del ADR 0047 (no interpreta / no gestiona / no usa IA; el juicio queda tuyo).
- **#264:** saca los internals filtrados a la doc de usuario (ADR 0012 en un snippet, jerga de workspace/precedencia → "una carpeta por investigación"; versión hardcodeada 0.3 → `b2g --version`). El contrato técnico sigue en `API.md`/`decisiones`.

`mkdocs build --strict`: 0 enlaces rotos. Closes #187, #264.
