### PR TITLE
feat(export,skill): CSV URL/i18n (#203) + skill --provider (#193)

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -49,7 +49,8 @@ comandos de nivel superior, ni uno más):
   `snapshot {create,restore}`. Un grupo **sin subcomando** imprime ayuda y sale **exit 0**; el `command`
   del envelope usa la **ruta completa** (`"read list"`).
 - **2 comandos meta** fuera del set de 10 (no son pasos del ciclo; ni FSM ni workspace):
-  **`skill add`** (ADR 0039) y **`schema`** (ADR 0045 #260, ver §`schema`).
+  **`skill`** (grupo `{add,providers}`; ADR 0039, ADR 0046 #193) y **`schema`** (ADR 0045 #260, ver
+  §`schema`). Un grupo `skill` **sin subcomando** imprime ayuda y sale **exit 0** (como los demás grupos).
 
 **Retirado en `0.12.0` (BREAKING, #207, ADR 0038 P1 ejecutado):** los **9 verbos planos deprecados**
 —`accept`, `reject`, `filter`, `inspect`, `monitor`, `networks`, `enrich`, `restore`, `resolve`— ya
@@ -254,17 +255,34 @@ Lógica en `service/reads.py` (§0.1).
   `cited_by_id`) → bloque `[]` + `reason`/`fix_command` (de `predict_build_preview`). `--kind` inválido →
   exit 1; `n <= 0` o red que falla genuinamente → `DataError` exit 2.
 
-**`skill add [--user|--project] [--force]`** (comando meta, ADR
-[0039](decisiones/0039-skill-comando-meta-distribucion.md)): **instala la skill de Claude Code end-user**
+**`skill add [--provider claude-code|opencode] [--user|--project] [--force]`** (comando meta, ADR
+[0039](decisiones/0039-skill-comando-meta-distribucion.md), enmendado por ADR
+[0046](decisiones/0046-skill-distribucion-agnostica-proveedor.md) #193): **instala la skill end-user**
 que enseña al agente a usar bib2graph (los 10 verbos + el one-shot `init→seed→chain→build→read`). La
 skill viaja **vendoreada en el wheel** bajo `src/bib2graph/skill/` (`SKILL.md` + `reference/`, fuente
 commiteada vía `packages = ["src/bib2graph"]`): el version-lock skill==cli garantiza que la skill enseñe
-los verbos que el CLI expone. `skill add` **copia** la skill al directorio del cliente: **`--user`**
-(default) → `~/.claude/skills/bib2graph/`, **`--project`** → `.claude/skills/bib2graph/`. **Idempotente**;
-si el destino existe y difiere falla accionable y **`--force`** pisa. **Funciona SIN workspace** y emite
-`--json` `schema="1"` **sin transición de FSM**. La skill es markdown sin dependencias Python (la IA está
-en el Claude Code del usuario, no en el producto; ADR 0022). `data = {install_path, scope, installed,
+los verbos que el CLI expone. `skill add` **copia** la skill al directorio del cliente elegido por
+**`--provider`** (default `claude-code`; el provider es un **dato**, no una rama de control, ADR 0046) y
+scope **`--user`** (default) o **`--project`**:
+
+| `--provider` | `--user` (default) | `--project` |
+|---|---|---|
+| `claude-code` (default) | `~/.claude/skills/bib2graph/` | `.claude/skills/bib2graph/` |
+| `opencode` | `~/.config/opencode/skills/bib2graph/` | `.opencode/skills/bib2graph/` |
+
+La transformación del contenido es **identidad** (mismo `SKILL.md` para todo provider; OpenCode ya lee
+`.claude/skills/` de todos modos — ADR 0046, fase 1). **Idempotente**; si el destino existe y difiere,
+falla accionable y **`--force`** pisa. **Funciona SIN workspace** y emite `--json` `schema="1"` **sin
+transición de FSM**. La skill es markdown sin dependencias Python (la IA está en el Claude Code / OpenCode
+del usuario, no en el producto; ADR 0022). `data = {install_path, scope, provider, installed,
 already_present, skill_md, reference_dir, how_to}`.
+
+**`skill providers [--json]`** (comando meta, ADR 0046 #193): **enumera los providers soportados** por
+`skill add`, para que un agente descubra por introspección qué clientes puede targetear sin leer el
+código ni la doc. Sigue el patrón de `skill`/`schema`: **no transiciona la FSM, no resuelve workspace, no
+lee el store ni hace red**. `data = {providers: [{name, default, description, project_root, user_root}],
+default_provider}` (con `default_provider = "claude-code"`; las rutas van relativas, tal como se resuelven
+contra cwd/home).
 
 **`schema`** (comando meta, ADR [0045](decisiones/0045-cerrar-tres-grietas-agent-native.md) #260):
 **introspección del contrato por el mismo canal de invocación**, para que un agente en frío conozca la
@@ -1394,19 +1412,26 @@ def decorate(artifact: NetworkArtifact, table: pa.Table) -> None:
 | `degree_centrality` | todos | `float`, vía `nx.degree_centrality` |
 | `year` | paper (coupling/cocitation) | `int` (ausente si `None` en el corpus) |
 | `doi` | paper (coupling/cocitation) | `string` desde `Col.DOI` (DOI desnudo/normalizado, p. ej. `10.1234/abc`); **ausente si el paper no tiene DOI** (mismo criterio que `year`) |
-| `url` | paper (coupling/cocitation) | `string` derivada `https://doi.org/<doi>`; **solo presente si hay DOI** (no es columna del corpus, ver nota abajo) |
+| `url` | paper (coupling/cocitation) | `string` derivada **DOI-first**: `https://doi.org/<doi>` si hay DOI; **fallback** `https://openalex.org/<source_id>` si no hay DOI pero sí `source_id` de OpenAlex (#203); **ausente** si no hay ninguno de los dos (no es columna del corpus, ver nota abajo) |
+| `venue` | paper (coupling/cocitation) | `string` desde `Col.SOURCE` (revista / fuente); **ausente** si el paper no tiene fuente (#203) |
+| `authors` | paper (coupling/cocitation) | `string`: nombres de `Col.AUTHORS_RAW` unidos con `"\|"`; **ausente** si no hay autores (#203) |
+| `keywords` | paper (coupling/cocitation) | `string`: keywords de `Col.KEYWORDS_ID` unidas con `"\|"`; **ausente** si no hay keywords (#203) |
+| `cited_by_count` | paper (coupling/cocitation) | `int` **derivado** `len(Col.CITED_BY_ID)` (nº de citantes conocidos en el corpus); **ausente** si la lista es vacía/`None`. **Puede subestimar** el conteo real si el corpus no pasó por la pasada `cited_by` de `build` (#203) |
 | `is_seed` | paper | `bool` |
 | `curation_status` | paper | `string` |
 | `community` | todos | `int`, **solo** si se provee `artifact.communities` |
 
-`doi`/`url` aplican **solo a paper-kinds** (`bibliographic_coupling` y `cocitation`); los nodos de
-autor/institución/keyword **no los reciben**. `url` es **derivada** (`https://doi.org/<doi>`), no una
-columna del corpus: el DOI es la única identidad de primera clase (ADR 0036) y la URL es una expansión
-trivial determinista a la hora de decorar. La derivación vive en `doi_to_url(doi: str|None) -> str|None`
-(`bib2graph.constants`), **fuente única** compartida con `resolve_url` (§0.1, #212) — sin drift.
-Ausencia condicional como `year`: sin DOI truthy, el nodo no
-recibe ni `doi` ni `url`. Los exporters CSV/GraphML (§9) los propagan **automáticamente** cuando están
-presentes (son genéricos y omiten `None`) — sin cambios en exporters.
+`doi`/`url`/`venue`/`authors`/`keywords`/`cited_by_count` aplican **solo a paper-kinds**
+(`bibliographic_coupling` y `cocitation`); los nodos de autor/institución/keyword **no los reciben**.
+`url` es **derivada** (no es columna del corpus) y **DOI-first con fallback a OpenAlex**: el DOI es la
+única identidad de primera clase (ADR 0036), pero cuando el paper no tiene DOI la URL cae al recurso de
+OpenAlex (`https://openalex.org/<source_id>`) para no perder el enlace navegable (#203). La derivación
+vive en `resolve_paper_url(doi: str|None, source_id: str|None) -> str|None` (`bib2graph.constants`),
+que compone `doi_to_url` y `openalex_id_to_url` (**fuente única** de cada regla, compartida con
+`resolve_url` §0.1, #212 — sin drift). Ausencia condicional como `year`: sin DOI **ni** `source_id`, el
+nodo no recibe `url`; `venue`/`authors`/`keywords`/`cited_by_count` se omiten cuando su valor es vacío/
+`None`. Los exporters CSV/GraphML (§9) propagan **todos** estos atributos **automáticamente** cuando
+están presentes (son genéricos y omiten `None`) — sin cambios en exporters.
 
 **Mapeo de `label` por `NetworkKind`:**
 
@@ -1533,9 +1558,12 @@ class CsvExporter: ...       # v1 — nodos.csv + aristas.csv para pandas
 
 - **`CsvExporter`** escribe `aristas.csv` (`source,target,weight`) y `nodos.csv` (`id,label` +
   atributos de nodo + métricas de `results` —degree/betweenness/community— unidas por id). Orden
-  de filas determinista. El `label` (y `year`/`doi`/`url`/`is_seed`/`curation_status`/`community`) lo
-  inyecta la capa `decorate` (§7.1) antes del export, no el exporter; `doi`/`url` salen solo en
-  paper-kinds y solo cuando el paper tiene DOI.
+  de filas determinista. Ambos CSV se escriben con **BOM UTF-8** (`encoding="utf-8-sig"`) para que
+  Excel-Windows autodetecte UTF-8 y no rompa tildes (#214). El `label` (y `year`/`doi`/`url`/`venue`/
+  `authors`/`keywords`/`cited_by_count`/`is_seed`/`curation_status`/`community`) lo inyecta la capa
+  `decorate` (§7.1) antes del export, no el exporter; `doi`/`url`/`venue`/`authors`/`keywords`/
+  `cited_by_count` salen solo en paper-kinds y solo cuando su valor está presente. `url` es DOI-first
+  con fallback a OpenAlex (#203, §7.1); `authors`/`keywords` van con separador `"|"`.
 - **`GraphMLExporter`** escribe esos atributos como node attributes, **omite** los atributos con
   valor `None` (Gephi / `nx.write_graphml` no los admiten) y **no muta** el grafo original (opera
   sobre una copia).

--- a/src/bib2graph/cli/commands/skill.py
+++ b/src/bib2graph/cli/commands/skill.py
@@ -1,21 +1,30 @@
-"""cli.commands.skill — Grupo noun-verb ``b2g skill`` (Epic #188).
+"""cli.commands.skill — Grupo noun-verb ``b2g skill`` (Epic #188, ADR 0046/#193).
 
-Gestión de la skill vendida de bib2graph para Claude.
+Gestión de la skill vendida de bib2graph para agentes de código.
 
-  ``skill add`` — instala la skill en ~/.claude/skills/bib2graph/ (scope
-                 ``--user``, default) o en <cwd>/.claude/skills/bib2graph/
-                 (scope ``--project``).
+  ``skill add``       — instala la skill en el directorio de skills del
+                        ``--provider`` elegido (default ``claude-code``),
+                        scope ``--user`` (default) o ``--project``.
+  ``skill providers`` — lista los providers soportados (introspección agente).
 
 La skill reside en ``src/bib2graph/skill/`` y se localiza vía
 ``importlib.resources.files("bib2graph") / "skill"`` con fallback a la ruta
 relativa a ``__file__`` (árbol de desarrollo).
 
-Flags de ``skill add``:
-  --user / --project   Scope de instalación (mutuamente excluyentes vía
-                       ``flag_value``; default ``--user``).
-  --force              Pisar el destino si ya existe.
+Distribución agnóstica del proveedor (ADR 0046, enmienda al ADR 0039):
+  El provider se modela como un **dato** (``_Provider``), no como ramas
+  ``if provider == ...``. Cada provider fija dónde vive la skill en scope
+  ``--project``/``--user`` y una ``transform`` sobre el contenido (en la 1ª
+  iteración, siempre identidad — ``copytree`` tal cual). Agregar un provider
+  de copia-identidad es agregar una fila a ``_PROVIDERS``, no una rama nueva.
 
-Comportamiento (idempotente — contrato en ADR 0039 / API.md):
+Flags de ``skill add``:
+  --provider            Cliente destino (``claude-code`` default, ``opencode``).
+  --user / --project     Scope de instalación (mutuamente excluyentes vía
+                        ``flag_value``; default ``--user``).
+  --force               Pisar el destino si ya existe.
+
+Comportamiento (idempotente — contrato en ADR 0039/0046 / API.md):
   - Destino no existe → instala.
   - Destino existe e **idéntico** a la versión vendida → **no-op**, exit 0, lo
     reporta (``already_present=True``). Re-correr el comando es seguro.
@@ -25,14 +34,18 @@ Comportamiento (idempotente — contrato en ADR 0039 / API.md):
   - **NO requiere workspace** (es comando meta global; no llama a
     ``resolve_workspace``).
   - Emite envelope ``--json`` ``schema="1"`` con ``install_path``, ``scope``,
-    ``installed`` y ``already_present``.
+    ``provider``, ``installed`` y ``already_present``.
   - Sin transición de FSM (operación transversal al lazo, como ``gui``).
+  - **Version-lock (ADR 0039 M2, preservado por 0046):** el ``--provider``
+    cambia SOLO el destino (y, en fase 2, la forma); la skill siempre viaja
+    en el wheel instalado, nunca se descarga de otra fuente.
 """
 
 from __future__ import annotations
 
 import filecmp
 import shutil
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -41,6 +54,64 @@ import click
 from bib2graph.cli._envelope import build_envelope, emit, emit_human
 from bib2graph.cli._errors import UsageError, handle_errors
 from bib2graph.cli._options import json_mode, json_option
+
+# Provider-como-dato (ADR 0046)
+
+
+@dataclass(frozen=True)
+class _Provider:
+    """Un cliente de agentes soportado por ``skill add``.
+
+    ``project_root``/``user_root`` son rutas RELATIVAS (al cwd y al home,
+    respectivamente); se resuelven en ``run_skill_add``. ``transform`` es
+    ``None`` en la 1ª iteración (ADR 0046): copia-identidad vía
+    ``copytree``. Un provider con transformación real (fase 2, p. ej.
+    ``agents-md``) fijaría acá una función de transformación de contenido.
+    """
+
+    name: str
+    project_root: Path
+    user_root_parts: tuple[str, ...]  # partes relativas a Path.home()
+    description: str
+
+
+_PROVIDERS: dict[str, _Provider] = {
+    "claude-code": _Provider(
+        name="claude-code",
+        project_root=Path(".claude") / "skills" / "bib2graph",
+        user_root_parts=(".claude", "skills", "bib2graph"),
+        description="Claude Code (Anthropic) — .claude/skills/bib2graph/ (default).",
+    ),
+    "opencode": _Provider(
+        name="opencode",
+        project_root=Path(".opencode") / "skills" / "bib2graph",
+        user_root_parts=(".config", "opencode", "skills", "bib2graph"),
+        description=(
+            "OpenCode — .opencode/skills/bib2graph/. Comodidad: OpenCode ya lee "
+            ".claude/skills/ de todos modos (mismo SKILL.md, sin transformación)."
+        ),
+    ),
+}
+
+DEFAULT_PROVIDER: str = "claude-code"
+
+
+def _resolve_dest(provider: _Provider, scope: str, *, cwd: Path, home: Path) -> Path:
+    """Resuelve el directorio destino para ``(provider, scope)`` (ADR 0046).
+
+    Args:
+        provider: Dato del provider elegido.
+        scope: ``"user"`` o ``"project"``.
+        cwd: Directorio de trabajo (para scope ``"project"``).
+        home: Directorio home (para scope ``"user"``).
+
+    Returns:
+        Ruta absoluta al directorio destino de instalación.
+    """
+    if scope == "user":
+        return home.joinpath(*provider.user_root_parts)
+    return cwd / provider.project_root
+
 
 # Helpers internos
 
@@ -114,7 +185,12 @@ _HOW_IT_WORKS = (
 
 
 def _build_result(
-    dest: Path, scope: str, *, installed: bool, already_present: bool
+    dest: Path,
+    scope: str,
+    provider: str,
+    *,
+    installed: bool,
+    already_present: bool,
 ) -> dict[str, Any]:
     """Arma el dict de resultado de ``skill add``.
 
@@ -126,6 +202,7 @@ def _build_result(
     return {
         "install_path": str(dest),
         "scope": scope,
+        "provider": provider,
         "installed": installed,
         "already_present": already_present,
         "skill_md": str(dest / "SKILL.md"),
@@ -138,44 +215,57 @@ def run_skill_add(
     *,
     scope: str,
     force: bool,
+    provider: str = DEFAULT_PROVIDER,
     cwd: Path | None = None,
     home: Path | None = None,
 ) -> dict[str, Any]:
-    """Instala la skill de bib2graph en el directorio de Claude.
+    """Instala la skill de bib2graph en el directorio de skills del provider.
 
     Args:
-        scope: ``"user"`` (instala en ``~/.claude/skills/bib2graph/``) o
-               ``"project"`` (instala en ``<cwd>/.claude/skills/bib2graph/``).
+        scope: ``"user"`` (instala en la raíz global del provider) o
+               ``"project"`` (instala en ``<cwd>/<project_root del provider>``).
         force: Si ``True``, pisa el destino si ya existe.
+        provider: Cliente destino (``"claude-code"`` default, ``"opencode"``).
+            Ver ``_PROVIDERS`` (ADR 0046) — el provider es un dato, no una
+            rama de control; agregar uno nuevo de copia-identidad es agregar
+            una fila a la tabla.
         cwd: Directorio de trabajo para el scope ``"project"`` (inyectable
              en tests; default: ``Path.cwd()``).
         home: Directorio home para el scope ``"user"`` (inyectable en tests;
               default: ``Path.home()``).
 
     Returns:
-        Dict con ``install_path``, ``scope``, ``installed`` (``True`` si
-        copió/pisó, ``False`` si fue no-op), ``already_present`` (``True`` si la
-        versión vendida ya estaba), y —para que un agente sepa dónde leerla—
-        ``skill_md`` (ruta al SKILL.md), ``reference_dir`` y ``how_to`` (resumen).
+        Dict con ``install_path``, ``scope``, ``provider``, ``installed``
+        (``True`` si copió/pisó, ``False`` si fue no-op), ``already_present``
+        (``True`` si la versión vendida ya estaba), y —para que un agente
+        sepa dónde leerla— ``skill_md`` (ruta al SKILL.md), ``reference_dir``
+        y ``how_to`` (resumen).
 
     Raises:
-        UsageError: Si el destino existe, **difiere** de la versión vendida y
-            ``force=False``.
+        UsageError: Si ``provider`` no está soportado, o si el destino
+            existe, **difiere** de la versión vendida y ``force=False``.
         RuntimeError: Si no se puede localizar el directorio de la skill.
     """
+    if provider not in _PROVIDERS:
+        raise UsageError(
+            f"Provider '{provider}' no soportado. "
+            f"Providers disponibles: {sorted(_PROVIDERS)}. "
+            "Corré `b2g skill providers` para ver la lista completa."
+        )
+
     effective_home = home if home is not None else Path.home()
     effective_cwd = cwd if cwd is not None else Path.cwd()
 
-    if scope == "user":
-        dest = effective_home / ".claude" / "skills" / "bib2graph"
-    else:
-        dest = effective_cwd / ".claude" / "skills" / "bib2graph"
+    provider_data = _PROVIDERS[provider]
+    dest = _resolve_dest(provider_data, scope, cwd=effective_cwd, home=effective_home)
 
     source = _locate_skill_source()
 
     # Idempotencia: si ya está exactamente la versión vendida → no-op.
     if dest.exists() and _trees_identical(source, dest):
-        return _build_result(dest, scope, installed=False, already_present=True)
+        return _build_result(
+            dest, scope, provider, installed=False, already_present=True
+        )
 
     # Existe pero difiere (edición del usuario u otra versión): exige --force.
     if dest.exists() and not force:
@@ -187,9 +277,38 @@ def run_skill_add(
     if dest.exists():
         shutil.rmtree(dest)
 
+    dest.parent.mkdir(parents=True, exist_ok=True)
     shutil.copytree(source, dest)
 
-    return _build_result(dest, scope, installed=True, already_present=False)
+    return _build_result(dest, scope, provider, installed=True, already_present=False)
+
+
+def run_skill_providers() -> dict[str, Any]:
+    """Enumera los providers soportados por ``skill add`` (ADR 0046, #193).
+
+    Comando meta introspectable: un agente puede descubrir qué clientes
+    puede targetear sin leer el código ni la documentación.
+
+    Returns:
+        Dict con ``providers``: lista de dicts ``{name, default, description,
+        project_root, user_root}`` (rutas relativas, tal como se resuelven
+        contra cwd/home) y ``default_provider``.
+    """
+    providers = []
+    for name, data in _PROVIDERS.items():
+        providers.append(
+            {
+                "name": name,
+                "default": name == DEFAULT_PROVIDER,
+                "description": data.description,
+                "project_root": str(data.project_root).replace("\\", "/"),
+                "user_root": "~/" + "/".join(data.user_root_parts),
+            }
+        )
+    return {
+        "providers": providers,
+        "default_provider": DEFAULT_PROVIDER,
+    }
 
 
 # Grupo raíz
@@ -198,14 +317,16 @@ def run_skill_add(
 @click.group("skill", invoke_without_command=True)
 @click.pass_context
 def skill_grp(ctx: click.Context) -> None:
-    """Gestión de la skill de bib2graph para Claude.
+    """Gestión de la skill de bib2graph para agentes de código.
 
-    Subcomandos: add.
+    Subcomandos: add, providers.
 
     Ejemplos:
         b2g skill add
         b2g skill add --project
+        b2g skill add --provider opencode
         b2g skill add --force
+        b2g skill providers
     """
     ctx.ensure_object(dict)
     # Click 8.4: no_args_is_help=True en grupos termina con exit 2.
@@ -219,17 +340,25 @@ def skill_grp(ctx: click.Context) -> None:
 
 @skill_grp.command("add")
 @click.option(
+    "--provider",
+    "provider",
+    type=click.Choice(sorted(_PROVIDERS)),
+    default=DEFAULT_PROVIDER,
+    show_default=True,
+    help="Cliente destino de la instalación (ADR 0046).",
+)
+@click.option(
     "--user",
     "scope",
     flag_value="user",
     default=True,
-    help="Instala la skill en ~/.claude/skills/bib2graph/ (default).",
+    help="Instala la skill en la raíz global del provider (default).",
 )
 @click.option(
     "--project",
     "scope",
     flag_value="project",
-    help="Instala la skill en <cwd>/.claude/skills/bib2graph/.",
+    help="Instala la skill en <cwd>/<ruta de proyecto del provider>.",
 )
 @click.option(
     "--force",
@@ -242,19 +371,22 @@ def skill_grp(ctx: click.Context) -> None:
 @handle_errors("skill add")
 def add_cmd(
     ctx: click.Context,
+    provider: str,
     scope: str,
     force: bool,
     json_output: bool,
 ) -> None:
-    """Instala la skill de bib2graph en el directorio de Claude.
+    """Instala la skill de bib2graph en el directorio de skills del provider.
 
-    Por defecto instala en ~/.claude/skills/bib2graph/ (scope --user).
-    Con --project instala en <cwd>/.claude/skills/bib2graph/.
+    Por defecto usa el provider ``claude-code`` e instala en
+    ~/.claude/skills/bib2graph/ (scope --user). Con --project instala en
+    <cwd>/.claude/skills/bib2graph/. Con --provider opencode instala en la
+    ruta nativa de OpenCode (.opencode/skills/bib2graph/).
 
     Es idempotente: si la versión vendida ya está instalada, no hace nada y lo
     reporta. Si el destino existe pero difiere, use --force para pisarlo.
     """
-    data = run_skill_add(scope=scope, force=force)
+    data = run_skill_add(scope=scope, force=force, provider=provider)
 
     if json_mode(json_output):
         envelope = build_envelope(
@@ -274,7 +406,7 @@ def add_cmd(
         # cómo opera bib2graph a grandes rasgos, y la instrucción de leerlo
         # (cualquier agente, no solo Claude Code, puede auto-onboardearse así).
         emit_human(
-            f"{estado} en: {data['install_path']}\n"
+            f"{estado} ({data['provider']}) en: {data['install_path']}\n"
             "\n"
             "Cómo opera bib2graph (a grandes rasgos):\n"
             f"  {data['how_to']}\n"
@@ -283,3 +415,34 @@ def add_cmd(
             f"  {data['skill_md']}\n"
             f"  (marco teórico en {data['reference_dir']}/ciclo.md)"
         )
+
+
+# skill providers
+
+
+@skill_grp.command("providers")
+@json_option
+@handle_errors("skill providers")
+def providers_cmd(json_output: bool) -> None:
+    """Lista los providers soportados por ``skill add`` (ADR 0046, #193).
+
+    Comando meta e introspectable: no requiere workspace ni transiciona FSM.
+    """
+    data = run_skill_providers()
+
+    if json_mode(json_output):
+        envelope = build_envelope(
+            command="skill providers",
+            ok=True,
+            data=data,
+            exit_code=0,
+        )
+        emit(envelope)
+    else:
+        emit_human(f"Providers soportados ({len(data['providers'])}):")
+        for p in data["providers"]:
+            marca = " (default)" if p["default"] else ""
+            emit_human(f"  {p['name']}{marca}")
+            emit_human(f"    project: {p['project_root']}")
+            emit_human(f"    user:    {p['user_root']}")
+            emit_human(f"    {p['description']}")

--- a/src/bib2graph/constants.py
+++ b/src/bib2graph/constants.py
@@ -109,6 +109,46 @@ def doi_to_url(doi: str | None) -> str | None:
     return None
 
 
+def openalex_id_to_url(source_id: str | None) -> str | None:
+    """Deriva la URL de OpenAlex ``https://openalex.org/<source_id>`` desde un id corto.
+
+    ``source_id`` (``Col.SOURCE_ID``) es el id corto de OpenAlex (p. ej. ``W12345``)
+    cuando el paper proviene de ``OpenAlexSource`` — las demás fuentes (p. ej.
+    ``BibtexSource``) siempre lo dejan en ``None``, así que un ``source_id`` truthy
+    es seguro de interpretar como id de OpenAlex.
+
+    Args:
+        source_id: Id corto de OpenAlex, o ``None``.
+
+    Returns:
+        ``"https://openalex.org/<source_id>"`` si ``source_id`` es un string no
+        vacío; ``None`` en cualquier otro caso.
+    """
+    if isinstance(source_id, str) and source_id:
+        return f"https://openalex.org/{source_id}"
+    return None
+
+
+def resolve_paper_url(doi: str | None, source_id: str | None) -> str | None:
+    """URL canónica del paper: DOI primero, OpenAlex como fallback (#203).
+
+    Precedencia: ``https://doi.org/<doi>`` si hay DOI; si no, y solo si hay
+    ``source_id`` (OpenAlex), ``https://openalex.org/<source_id>``. ``None``
+    si no hay ninguno de los dos — nunca inventa una URL.
+
+    Reusa ``doi_to_url``/``openalex_id_to_url`` (fuente única de cada regla de
+    derivación) para no duplicar el criterio de "string no vacío".
+
+    Args:
+        doi: DOI del paper (sin prefijo URL), o ``None``.
+        source_id: Id corto de OpenAlex, o ``None``.
+
+    Returns:
+        La URL canónica, o ``None`` si no hay DOI ni ``source_id``.
+    """
+    return doi_to_url(doi) or openalex_id_to_url(source_id)
+
+
 LIST_COLUMNS: frozenset[str] = frozenset(
     {
         Col.RESEARCH_AREAS,

--- a/src/bib2graph/networks/decorate.py
+++ b/src/bib2graph/networks/decorate.py
@@ -31,7 +31,17 @@ Atributos adicionales de paper (coupling/cocitation):
   - ``is_seed``: bool.
   - ``curation_status``: string.
   - ``doi``: string o ausente si no hay DOI en el corpus.
-  - ``url``: ``"https://doi.org/<doi>"`` o ausente si no hay DOI.
+  - ``url``: ``"https://doi.org/<doi>"`` (DOI-first) o, sin DOI,
+    ``"https://openalex.org/<source_id>"`` si el paper viene de OpenAlex
+    (#203); ausente si no hay ninguno de los dos.
+  - ``venue``: string (``Col.SOURCE``) o ausente si no hay fuente/revista.
+  - ``authors``: nombres de autor unidos con ``"|"`` (``Col.AUTHORS_RAW``),
+    o ausente si no hay autores.
+  - ``keywords``: keywords unidas con ``"|"`` (``Col.KEYWORDS_ID``), o
+    ausente si no hay keywords.
+  - ``cited_by_count``: int, nº de citantes conocidos en el corpus
+    (``len(Col.CITED_BY_ID)``); ausente si la lista es vacía/None (mismo
+    criterio de "vacío = ausente" que el resto de los atributos opcionales).
 
 Atributo de comunidad (si se provee ``communities``):
   - ``community``: int.
@@ -44,7 +54,7 @@ from typing import TYPE_CHECKING, Any
 import networkx as nx
 import pyarrow as pa
 
-from bib2graph.constants import Col, NetworkKind, doi_to_url
+from bib2graph.constants import Col, NetworkKind, resolve_paper_url
 
 if TYPE_CHECKING:
     from bib2graph.networks.spec import NetworkArtifact
@@ -62,10 +72,13 @@ _PAPER_KINDS: frozenset[str] = frozenset(
 
 
 def _build_paper_index(table: pa.Table) -> dict[str, dict[str, object]]:
-    """Construye un índice ``{paper_id → {label, year, is_seed, curation_status, doi}}``.
+    """Construye un índice ``{paper_id → {label, year, is_seed, ...}}``.
 
     El label de paper es ``"título (año)"`` truncado a ``LABEL_MAX_CHARS`` chars.
-    ``doi`` es el DOI del paper (string) o ``None`` si no está disponible.
+    ``doi``/``source_id`` alimentan la derivación de ``url`` (#203, DOI-first
+    con fallback a OpenAlex). ``authors``/``venue``/``keywords`` son campos
+    útiles para un investigador que no estaban expuestos en nodos.csv (#203);
+    ``cited_by_count`` es un conteo derivado (no columna del schema).
 
     Args:
         table: Tabla Arrow canónica del Corpus.
@@ -79,10 +92,38 @@ def _build_paper_index(table: pa.Table) -> dict[str, dict[str, object]]:
     is_seeds = table.column(Col.IS_SEED).to_pylist()
     statuses = table.column(Col.CURATION_STATUS).to_pylist()
     dois = table.column(Col.DOI).to_pylist()
+    source_ids = table.column(Col.SOURCE_ID).to_pylist()
+    venues = table.column(Col.SOURCE).to_pylist()
+    authors_raw = table.column(Col.AUTHORS_RAW).to_pylist()
+    keywords_id = table.column(Col.KEYWORDS_ID).to_pylist()
+    cited_by = table.column(Col.CITED_BY_ID).to_pylist()
 
     index: dict[str, dict[str, object]] = {}
-    for pid, title, year, is_seed, status, doi in zip(
-        ids, titles, years, is_seeds, statuses, dois, strict=False
+    for (
+        pid,
+        title,
+        year,
+        is_seed,
+        status,
+        doi,
+        source_id,
+        venue,
+        authors,
+        keywords,
+        citers,
+    ) in zip(
+        ids,
+        titles,
+        years,
+        is_seeds,
+        statuses,
+        dois,
+        source_ids,
+        venues,
+        authors_raw,
+        keywords_id,
+        cited_by,
+        strict=False,
     ):
         if pid is None:
             continue
@@ -102,6 +143,17 @@ def _build_paper_index(table: pa.Table) -> dict[str, dict[str, object]]:
             "is_seed": bool(is_seed) if is_seed is not None else False,
             "curation_status": str(status) if status is not None else None,
             "doi": str(doi) if doi is not None else None,
+            "source_id": str(source_id) if source_id is not None else None,
+            "venue": str(venue) if venue else None,
+            "authors": "|".join(str(a) for a in authors)
+            if isinstance(authors, list) and authors
+            else None,
+            "keywords": "|".join(str(k) for k in keywords)
+            if isinstance(keywords, list) and keywords
+            else None,
+            "cited_by_count": len(citers)
+            if isinstance(citers, list) and citers
+            else None,
         }
     return index
 
@@ -189,7 +241,13 @@ def decorate_graph(
       - ``is_seed``: bool.
       - ``curation_status``: string.
       - ``doi``: string o ausente si el paper no tiene DOI en el corpus.
-      - ``url``: ``"https://doi.org/<doi>"`` o ausente si no hay DOI.
+      - ``url``: ``"https://doi.org/<doi>"`` (DOI-first) o
+        ``"https://openalex.org/<source_id>"`` como fallback (#203); ausente
+        si no hay ni DOI ni source_id de OpenAlex.
+      - ``venue``: string o ausente si no hay fuente/revista.
+      - ``authors``: nombres unidos con ``"|"``, o ausente si no hay autores.
+      - ``keywords``: keywords unidas con ``"|"``, o ausente si no hay.
+      - ``cited_by_count``: int, o ausente si no hay citantes conocidos.
 
     Atributo de comunidad (si se provee ``communities``):
       - ``community``: int.
@@ -225,10 +283,25 @@ def decorate_graph(
                 graph.nodes[node]["curation_status"] = str(curation)
             doi_val = info.get("doi")
             doi_str = doi_val if isinstance(doi_val, str) else None
-            url = doi_to_url(doi_str)
-            if url is not None:
+            if doi_str is not None:
                 graph.nodes[node]["doi"] = doi_str
+            source_id_val = info.get("source_id")
+            source_id_str = source_id_val if isinstance(source_id_val, str) else None
+            url = resolve_paper_url(doi_str, source_id_str)
+            if url is not None:
                 graph.nodes[node]["url"] = url
+            venue = info.get("venue")
+            if venue is not None:
+                graph.nodes[node]["venue"] = str(venue)
+            authors = info.get("authors")
+            if authors is not None:
+                graph.nodes[node]["authors"] = str(authors)
+            keywords = info.get("keywords")
+            if keywords is not None:
+                graph.nodes[node]["keywords"] = str(keywords)
+            cited_by_count = info.get("cited_by_count")
+            if isinstance(cited_by_count, int):
+                graph.nodes[node]["cited_by_count"] = cited_by_count
 
     elif kind == NetworkKind.AUTHOR_COLLAB:
         author_index = _build_author_index(table)

--- a/tests/unit/test_constants.py
+++ b/tests/unit/test_constants.py
@@ -1,0 +1,57 @@
+"""Tests de bib2graph.constants — derivación de URL canónica (#203).
+
+Verifica:
+- ``doi_to_url``: caso base ya cubierto en otros tests (test_service_reads.py,
+  test_decorate.py); acá solo se agregan casos límite (None, string vacío).
+- ``openalex_id_to_url``: derivación análoga desde ``source_id`` (OpenAlex).
+- ``resolve_paper_url``: DOI-first, fallback a OpenAlex, None si no hay nada.
+
+Marcador: ``unit`` (función pura, sin I/O).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from bib2graph.constants import doi_to_url, openalex_id_to_url, resolve_paper_url
+
+
+@pytest.mark.unit
+def test_doi_to_url_none_y_vacio() -> None:
+    """doi_to_url devuelve None para None y para string vacío."""
+    assert doi_to_url(None) is None
+    assert doi_to_url("") is None
+
+
+@pytest.mark.unit
+def test_openalex_id_to_url_deriva_correctamente() -> None:
+    """openalex_id_to_url deriva https://openalex.org/<id> desde un id corto."""
+    assert openalex_id_to_url("W12345") == "https://openalex.org/W12345"
+
+
+@pytest.mark.unit
+def test_openalex_id_to_url_none_y_vacio() -> None:
+    """openalex_id_to_url devuelve None para None y para string vacío."""
+    assert openalex_id_to_url(None) is None
+    assert openalex_id_to_url("") is None
+
+
+@pytest.mark.unit
+def test_resolve_paper_url_doi_first() -> None:
+    """Con DOI y source_id presentes, resolve_paper_url prefiere el DOI (#203)."""
+    url = resolve_paper_url("10.1234/ejemplo", "W12345")
+    assert url == "https://doi.org/10.1234/ejemplo"
+
+
+@pytest.mark.unit
+def test_resolve_paper_url_fallback_openalex_sin_doi() -> None:
+    """Sin DOI, resolve_paper_url cae a la URL de OpenAlex vía source_id (#203)."""
+    url = resolve_paper_url(None, "W12345")
+    assert url == "https://openalex.org/W12345"
+
+
+@pytest.mark.unit
+def test_resolve_paper_url_none_sin_doi_ni_source_id() -> None:
+    """Sin DOI ni source_id, resolve_paper_url no inventa una URL."""
+    assert resolve_paper_url(None, None) is None
+    assert resolve_paper_url("", "") is None

--- a/tests/unit/test_decorate.py
+++ b/tests/unit/test_decorate.py
@@ -709,3 +709,180 @@ def test_export_graphml_incluye_doi_url(tmp_path: Path) -> None:
     assert "url" not in reloaded.nodes["PNODOI"], (
         "url no debería aparecer en PNODOI tras round-trip GraphML"
     )
+
+
+# ---------------------------------------------------------------------------
+# URL fallback a OpenAlex + campos adicionales en nodos.csv (#203)
+# ---------------------------------------------------------------------------
+
+
+def _make_table_url_fallback() -> pa.Table:
+    """Tabla con: paper con DOI, paper sin DOI pero con source_id de OpenAlex,
+    y paper sin DOI ni source_id (sin URL posible). Todos comparten refs para
+    quedar conectados en el acoplamiento bibliográfico.
+    """
+    rows = [
+        {
+            "id": "PDOI",
+            "source_id": "W111",
+            "doi": "10.1234/con-doi",
+            "title": "Paper con DOI",
+            "year": 2024,
+            "abstract": None,
+            "source": "Revista de Ejemplo",
+            "language": None,
+            "publisher": None,
+            "research_areas": None,
+            "is_seed": True,
+            "curation_status": "accepted",
+            "provenance": None,
+            "authors_raw": ["Ana Pérez", "José Muñoz"],
+            "authors_id": ["a1", "a2"],
+            "authors_affiliations": None,
+            "keywords_raw": None,
+            "keywords_id": ["bibliometría", "análisis de redes"],
+            "institutions_raw": None,
+            "institutions_id": None,
+            "references_id": ["R_shared"],
+            "references_doi": None,
+            "cited_by_id": ["C1", "C2", "C3"],
+        },
+        {
+            "id": "POA",
+            "source_id": "W222",
+            "doi": None,
+            "title": "Paper sin DOI, con OpenAlex id",
+            "year": 2023,
+            "abstract": None,
+            "source": None,
+            "language": None,
+            "publisher": None,
+            "research_areas": None,
+            "is_seed": True,
+            "curation_status": "candidate",
+            "provenance": None,
+            "authors_raw": None,
+            "authors_id": None,
+            "authors_affiliations": None,
+            "keywords_raw": None,
+            "keywords_id": None,
+            "institutions_raw": None,
+            "institutions_id": None,
+            "references_id": ["R_shared"],
+            "references_doi": None,
+            "cited_by_id": None,
+        },
+        {
+            "id": "PNADA",
+            "source_id": None,
+            "doi": None,
+            "title": "Paper sin DOI ni OpenAlex id",
+            "year": 2022,
+            "abstract": None,
+            "source": None,
+            "language": None,
+            "publisher": None,
+            "research_areas": None,
+            "is_seed": False,
+            "curation_status": "rejected",
+            "provenance": None,
+            "authors_raw": None,
+            "authors_id": None,
+            "authors_affiliations": None,
+            "keywords_raw": None,
+            "keywords_id": None,
+            "institutions_raw": None,
+            "institutions_id": None,
+            "references_id": ["R_shared"],
+            "references_doi": None,
+            "cited_by_id": None,
+        },
+    ]
+    return pa.Table.from_pylist(rows, schema=CORPUS_SCHEMA)
+
+
+@pytest.mark.unit
+def test_url_doi_first_sobre_source_id() -> None:
+    """Con DOI y source_id ambos presentes, url usa el DOI (#203)."""
+    table = _make_table_url_fallback()
+    projector = BibliographicCouplingProjector()
+    g = projector.project(table)
+    decorate_graph(g, table, NetworkKind.BIBLIOGRAPHIC_COUPLING)
+
+    assert g.nodes["PDOI"]["url"] == "https://doi.org/10.1234/con-doi"
+
+
+@pytest.mark.unit
+def test_url_fallback_openalex_sin_doi() -> None:
+    """Sin DOI pero con source_id de OpenAlex, url cae al link de OpenAlex (#203)."""
+    table = _make_table_url_fallback()
+    projector = BibliographicCouplingProjector()
+    g = projector.project(table)
+    decorate_graph(g, table, NetworkKind.BIBLIOGRAPHIC_COUPLING)
+
+    assert "doi" not in g.nodes["POA"], "no debe inventar un doi ausente"
+    assert g.nodes["POA"]["url"] == "https://openalex.org/W222"
+
+
+@pytest.mark.unit
+def test_sin_doi_ni_source_id_no_hay_url() -> None:
+    """Sin DOI ni source_id, el nodo no recibe url (no se inventa nada, #203)."""
+    table = _make_table_url_fallback()
+    projector = BibliographicCouplingProjector()
+    g = projector.project(table)
+    decorate_graph(g, table, NetworkKind.BIBLIOGRAPHIC_COUPLING)
+
+    assert "url" not in g.nodes["PNADA"]
+    assert "doi" not in g.nodes["PNADA"]
+
+
+@pytest.mark.unit
+def test_campos_adicionales_venue_authors_keywords_cited_by_count() -> None:
+    """Nodos de paper traen venue/authors/keywords/cited_by_count cuando hay datos (#203)."""
+    table = _make_table_url_fallback()
+    projector = BibliographicCouplingProjector()
+    g = projector.project(table)
+    decorate_graph(g, table, NetworkKind.BIBLIOGRAPHIC_COUPLING)
+
+    attrs = g.nodes["PDOI"]
+    assert attrs["venue"] == "Revista de Ejemplo"
+    assert attrs["authors"] == "Ana Pérez|José Muñoz"
+    assert attrs["keywords"] == "bibliometría|análisis de redes"
+    assert attrs["cited_by_count"] == 3
+
+    # El nodo sin ninguno de esos datos no trae claves basura (criterio "vacío = ausente")
+    attrs_vacio = g.nodes["POA"]
+    assert "venue" not in attrs_vacio
+    assert "authors" not in attrs_vacio
+    assert "keywords" not in attrs_vacio
+    assert "cited_by_count" not in attrs_vacio
+
+
+@pytest.mark.unit
+def test_export_csv_incluye_url_fallback_y_campos_nuevos(tmp_path: Path) -> None:
+    """nodos.csv trae url (DOI-first/OpenAlex-fallback) + venue/authors/keywords/
+    cited_by_count, con tildes intactas vía BOM UTF-8 (#203)."""
+    table = _make_table_url_fallback()
+    projector = BibliographicCouplingProjector()
+    g = projector.project(table)
+    decorate_graph(g, table, NetworkKind.BIBLIOGRAPHIC_COUPLING)
+
+    CsvExporter().export(g, {}, tmp_path)
+
+    raw = (tmp_path / "nodos.csv").read_bytes()
+    assert raw.startswith(b"\xef\xbb\xbf"), "nodos.csv debe empezar con BOM UTF-8"
+
+    content = (tmp_path / "nodos.csv").read_text(encoding="utf-8-sig")
+    header = content.splitlines()[0]
+    for col in ("url", "venue", "authors", "keywords", "cited_by_count"):
+        assert col in header, (
+            f"columna {col!r} ausente en nodos.csv; header: {header!r}"
+        )
+
+    # DOI-first
+    assert "https://doi.org/10.1234/con-doi" in content
+    # Fallback a OpenAlex para el paper sin DOI
+    assert "https://openalex.org/W222" in content
+    # Tildes sobreviven el round-trip (autores/keywords con acentos)
+    assert "Ana Pérez|José Muñoz" in content
+    assert "bibliometría|análisis de redes" in content

--- a/tests/unit/test_skill_add.py
+++ b/tests/unit/test_skill_add.py
@@ -523,3 +523,195 @@ def test_skill_add_salida_humana_es_explicita(
     assert "seed→chain→build→read" in out or "ciclo" in out.lower(), (
         "La salida debe explicar a grandes rasgos cómo opera bib2graph."
     )
+
+
+# ---------------------------------------------------------------------------
+# 13. --provider agnóstico del proveedor (ADR 0046, #193)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_skill_add_default_provider_es_claude_code(tmp_path: Path) -> None:
+    """Sin --provider, run_skill_add usa 'claude-code' — compat 0039 intacta."""
+    data = run_skill_add(scope="user", force=False, home=tmp_path)
+
+    assert data["provider"] == "claude-code"
+    install_path = Path(data["install_path"])
+    assert install_path == tmp_path / ".claude" / "skills" / "bib2graph"
+
+
+@pytest.mark.unit
+def test_skill_add_provider_opencode_scope_project(tmp_path: Path) -> None:
+    """--provider opencode --project instala en <cwd>/.opencode/skills/bib2graph/."""
+    data = run_skill_add(
+        scope="project", force=False, provider="opencode", cwd=tmp_path
+    )
+
+    assert data["provider"] == "opencode"
+    install_path = Path(data["install_path"])
+    assert install_path == tmp_path / ".opencode" / "skills" / "bib2graph"
+
+    skill_md = install_path / "SKILL.md"
+    assert skill_md.exists(), f"SKILL.md no fue copiado a {skill_md}"
+
+
+@pytest.mark.unit
+def test_skill_add_provider_opencode_scope_user(tmp_path: Path) -> None:
+    """--provider opencode --user instala en ~/.config/opencode/skills/bib2graph/."""
+    data = run_skill_add(scope="user", force=False, provider="opencode", home=tmp_path)
+
+    assert data["provider"] == "opencode"
+    install_path = Path(data["install_path"])
+    assert install_path == tmp_path / ".config" / "opencode" / "skills" / "bib2graph"
+    assert (install_path / "SKILL.md").exists()
+
+
+@pytest.mark.unit
+def test_skill_add_provider_opencode_mismo_contenido_que_claude_code(
+    tmp_path: Path,
+) -> None:
+    """La skill instalada vía --provider opencode es idéntica a la de claude-code.
+
+    Transform = identidad (ADR 0046): mismo SKILL.md, distinta carpeta.
+    """
+    home_cc = tmp_path / "home_cc"
+    home_oc = tmp_path / "home_oc"
+    home_cc.mkdir()
+    home_oc.mkdir()
+
+    d_cc = run_skill_add(scope="user", force=False, home=home_cc)
+    d_oc = run_skill_add(scope="user", force=False, provider="opencode", home=home_oc)
+
+    content_cc = Path(d_cc["skill_md"]).read_text(encoding="utf-8")
+    content_oc = Path(d_oc["skill_md"]).read_text(encoding="utf-8")
+    assert content_cc == content_oc, (
+        "El SKILL.md instalado por cada provider debe ser byte-idéntico "
+        "(transform=identidad, ADR 0046)."
+    )
+
+
+@pytest.mark.unit
+def test_skill_add_provider_opencode_via_cli(tmp_path: Path, runner: CliRunner) -> None:
+    """``b2g skill add --provider opencode`` vía CLI instala en .opencode/skills/."""
+    with patch.object(Path, "cwd", return_value=tmp_path):
+        result = runner.invoke(
+            b2g,
+            ["skill", "add", "--provider", "opencode", "--project"],
+            catch_exceptions=False,
+        )
+
+    assert result.exit_code == 0, (
+        f"Falló con exit {result.exit_code}: {result.output!r}"
+    )
+    skill_md = tmp_path / ".opencode" / "skills" / "bib2graph" / "SKILL.md"
+    assert skill_md.exists(), f"SKILL.md no fue instalado en {skill_md}"
+
+
+@pytest.mark.unit
+def test_skill_add_provider_claude_code_explicito_sin_cambios(
+    tmp_path: Path,
+) -> None:
+    """--provider claude-code explícito se comporta igual que el default."""
+    data = run_skill_add(
+        scope="user", force=False, provider="claude-code", home=tmp_path
+    )
+    assert data["provider"] == "claude-code"
+    install_path = Path(data["install_path"])
+    assert install_path == tmp_path / ".claude" / "skills" / "bib2graph"
+
+
+@pytest.mark.unit
+def test_skill_add_provider_desconocido_falla(tmp_path: Path) -> None:
+    """Un --provider no soportado lanza UsageError accionable."""
+    from bib2graph.cli._errors import UsageError
+
+    with pytest.raises(UsageError) as exc_info:
+        run_skill_add(scope="user", force=False, provider="cursor", home=tmp_path)
+
+    assert "cursor" in str(exc_info.value)
+    assert "skill providers" in str(exc_info.value)
+
+
+@pytest.mark.unit
+def test_skill_add_provider_desconocido_via_cli_exit_no_cero(
+    tmp_path: Path, runner: CliRunner
+) -> None:
+    """``b2g skill add --provider desconocido`` vía CLI falla con exit != 0.
+
+    Click valida contra ``click.Choice`` antes de invocar la función.
+    """
+    result = runner.invoke(b2g, ["skill", "add", "--provider", "cursor"])
+    assert result.exit_code != 0
+
+
+@pytest.mark.unit
+def test_skill_add_provider_opencode_idempotente(tmp_path: Path) -> None:
+    """Re-correr --provider opencode con la vendida ya instalada → no-op."""
+    d1 = run_skill_add(scope="user", force=False, provider="opencode", home=tmp_path)
+    assert d1["installed"] is True
+
+    d2 = run_skill_add(scope="user", force=False, provider="opencode", home=tmp_path)
+    assert d2["installed"] is False
+    assert d2["already_present"] is True
+
+
+# ---------------------------------------------------------------------------
+# 14. b2g skill providers (ADR 0046, #193)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_skill_providers_aparece_en_skill_help(runner: CliRunner) -> None:
+    """``providers`` aparece listado en ``b2g skill --help``."""
+    result = runner.invoke(b2g, ["skill", "--help"])
+    assert result.exit_code == 0
+    assert "providers" in result.output
+
+
+@pytest.mark.unit
+def test_skill_providers_lista_ambos_providers(runner: CliRunner) -> None:
+    """``b2g skill providers`` lista claude-code y opencode."""
+    result = runner.invoke(b2g, ["skill", "providers"], catch_exceptions=False)
+    assert result.exit_code == 0, f"Falló: {result.output!r}"
+    assert "claude-code" in result.output
+    assert "opencode" in result.output
+
+
+@pytest.mark.unit
+def test_skill_providers_json_envelope_valido(runner: CliRunner) -> None:
+    """``b2g skill providers --json`` emite envelope schema='1' con ambos providers."""
+    result = runner.invoke(
+        b2g, ["skill", "providers", "--json"], catch_exceptions=False
+    )
+    assert result.exit_code == 0, f"Falló: {result.output!r}"
+
+    lines = [ln for ln in result.stdout.splitlines() if ln.strip()]
+    assert len(lines) == 1, (
+        f"Se esperaba 1 línea en stdout, se obtuvieron {len(lines)}:\n{result.stdout!r}"
+    )
+
+    envelope: dict[str, Any] = json.loads(lines[0])
+    assert envelope.get("schema") == "1"
+    assert envelope.get("ok") is True
+    assert envelope.get("command") == "skill providers"
+    assert envelope.get("exit_code") == 0
+
+    data = envelope.get("data", {})
+    assert data.get("default_provider") == "claude-code"
+    names = {p["name"] for p in data.get("providers", [])}
+    assert names == {"claude-code", "opencode"}
+
+    claude_entry = next(p for p in data["providers"] if p["name"] == "claude-code")
+    assert claude_entry["default"] is True
+    opencode_entry = next(p for p in data["providers"] if p["name"] == "opencode")
+    assert opencode_entry["default"] is False
+
+
+@pytest.mark.unit
+def test_skill_providers_no_requiere_workspace(
+    tmp_path: Path, runner: CliRunner
+) -> None:
+    """``skill providers`` corre OK sin workspace.json (comando meta)."""
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        result = runner.invoke(b2g, ["skill", "providers"], catch_exceptions=False)
+    assert result.exit_code == 0


### PR DESCRIPTION
Bloque C del 0.12.0 — salida amable. Dos features independientes.

**#203 — export CSV (feedback hispano):**
- `url` ahora es DOI-first con **fallback a OpenAlex** (`resolve_paper_url`) cuando no hay DOI.
- Nodos de paper suman `venue`, `authors`, `keywords`, `cited_by_count` en CSV/GraphML.
- BOM UTF-8 (`utf-8-sig`) para Excel-Windows ya existía (#214); tests cubren el round-trip de tildes.

**#193 — `b2g skill add --provider` (ADR 0046):**
- provider como **dato** (no ramas `if`): `claude-code` (default) + `opencode` (transform=identidad, `.opencode/skills/`).
- Nuevo `b2g skill providers`. Version-lock skill==cli y default intactos.

**Gate verde (1243 passed).** `docs/API.md` sync en commit siguiente.

Closes #203, #193. Parte del Plan 0.12.0, Bloque C.
