### PR TITLE
docs(cli): corrige help stale que citaba 'b2g enrich' retirado (#207)

### DIFF
--- a/src/bib2graph/cli/commands/chain.py
+++ b/src/bib2graph/cli/commands/chain.py
@@ -44,9 +44,9 @@ def run_chain(
     Cuando ``preview=True``, estima el crecimiento potencial **sin fetchear**
     ni transicionar el estado del corpus.  La estimación backward es exacta
     (desde ``references_id``); la forward es exacta si el corpus tiene
-    ``cited_by_id`` poblado (pasó por ``b2g enrich`` o un ``chain forward``
-    previo, ADR 0048), o indica que se requiere fetch si ``cited_by_id``
-    está vacío.
+    ``cited_by_id`` poblado (por un ``chain forward`` previo o la pasada
+    cited_by de ``build``, ADR 0048), o indica que se requiere fetch si
+    ``cited_by_id`` está vacío.
 
     Args:
         store_path: Ruta al archivo ``.duckdb``.
@@ -345,8 +345,8 @@ def _run_chain_preview(
     help=(
         "Estima el crecimiento potencial SIN fetchear ni modificar el corpus "
         "(dry-run).  Backward: exacto desde references_id.  Forward: exacto "
-        "si el corpus tiene cited_by_id (requiere enrich previo), si no, "
-        "indica que se necesita fetch."
+        "si el corpus tiene cited_by_id (poblado por un chain forward previo), "
+        "si no, indica que se necesita fetch."
     ),
 )
 @click.option(

--- a/src/bib2graph/cli/commands/read.py
+++ b/src/bib2graph/cli/commands/read.py
@@ -302,8 +302,9 @@ def top_cmd(
                    descendente.  Default: bibliographic_coupling (robusto en
                    one-shot frío, no requiere enrich previo).
       cocitation — top N pares de co-citación por peso, SIEMPRE desde la red
-                   cocitation (requiere 'b2g enrich' previo para tener
-                   cited_by_id).  Si la red está vacía → bloque vacío con
+                   cocitation (requiere cited_by_id poblado: por un
+                   'b2g chain --direction forward' previo o la pasada cited_by
+                   de 'b2g build').  Si la red está vacía → bloque vacío con
                    reason/fix_command (honest-empty, exit 0).
 
     No requiere 'b2g build' previo: recomputa en tiempo de lectura.


### PR DESCRIPTION
Corrige el `--help` stale detectado en la auditoría AX del capstone e2e 0.12.0 (**fricción #3**).

El `--help` de `read top` (bloque cocitation) y de `chain --preview` todavía decían que la co-citación **"requiere `b2g enrich` previo"** — pero `enrich` fue retirado por la poda #207, y #270 volvió ese paso innecesario. Ahora apuntan a la vía real: `cited_by_id` se puebla con `chain --direction forward` o la pasada `cited_by` de `build`.

Solo help/docstrings (sin lógica). Entra a 0.12.0 antes del corte para no shippear una referencia a un comando que ya no existe.
