### PR TITLE
fix(release): sincroniza uv.lock en el PR de release (#294)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# uv.lock es autogenerado con finales de línea LF. Fijarlo evita que un `uv lock`/`uv sync`
+# en Windows lo reescriba a CRLF y ensucie el diff (warning "LF will be replaced by CRLF").
+uv.lock text eol=lf

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,6 +18,9 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
+      # PR de release recién abierto/actualizado (JSON con headBranchName, number, …).
+      # Vacío cuando no hay PR pendiente. Lo consume `sync-lockfile`.
+      pr: ${{ steps.release.outputs.pr }}
     steps:
       - uses: googleapis/release-please-action@v4
         id: release
@@ -33,6 +36,38 @@ jobs:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+  # Sincroniza uv.lock DENTRO del PR de release. release-please (release-type: python)
+  # bumpea pyproject.toml/CHANGELOG pero NO conoce uv.lock; sin esto el campo de versión
+  # del paquete raíz en el lockfile drifta un release por vez (#294). Corre `uv lock` sobre
+  # la rama del PR de release y empuja el lockfile ahí, para que bump y lock viajen juntos.
+  sync-lockfile:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.pr != '' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ fromJSON(needs.release-please.outputs.pr).headBranchName }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          python-version: "3.11"
+      - name: Sincroniza uv.lock con el bump de versión y push
+        run: |
+          uv lock
+          if git diff --quiet -- uv.lock; then
+            echo "uv.lock ya estaba sincronizado; nada que empujar."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add uv.lock
+          git commit -m "chore(release): sincroniza uv.lock con el bump de versión"
+          git push
 
   # Publica a PyPI SOLO cuando release-please efectivamente cortó un Release.
   # Corre en el MISMO workflow run (el push a main al mergear el release PR), así que

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -75,6 +75,9 @@ Las releases las maneja [`release-please`](https://github.com/googleapis/release
 2. `release-please` abre/actualiza un PR de release con:
    - `CHANGELOG.md` actualizado (sección nueva con Added/Changed/Fixed/...).
    - Bump de versión en `pyproject.toml`.
+   - `uv.lock` sincronizado con ese bump: como `release-please` no conoce el lockfile,
+     el job `sync-lockfile` corre `uv lock` sobre la rama del PR de release y empuja el
+     lockfile ahí (sin esto el campo de versión del lockfile driftaba un release por vez, #294).
 3. Revisás el PR de release. Si está bien, lo mergeás.
 4. Al mergear, se taggea `vX.Y.Z` y se crea el **GitHub Release**.
 

--- a/uv.lock
+++ b/uv.lock
@@ -101,7 +101,7 @@ wheels = [
 
 [[package]]
 name = "bib2graph"
-version = "0.11.0"
+version = "0.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Cierra #294.

## Problema

`release-please` (`release-type: python`) bumpea `pyproject.toml` + `CHANGELOG.md` pero **no
conoce `uv.lock`**. Nada corría `uv lock` en el PR de release, así que el campo de versión del
paquete raíz en el lockfile driftaba **un release por vez** (se detectó el lockfile en `0.11.0`
con el proyecto ya en `0.13.0`). El CI corre `uv sync` (no `uv lock`), que no falla por ese
desajuste → el drift era silencioso.

## Solución

- **Nuevo job `sync-lockfile`** en `release-please.yml`: se dispara cuando release-please abre/
  actualiza su PR (output `pr`), hace checkout de la rama del PR de release, corre `uv lock` y
  **empuja el lockfile sobre ese mismo PR**. Bump y lock viajan juntos y pasan por el CI del release.
- **`.gitattributes`** fija `uv.lock text eol=lf` → mata el warning `LF will be replaced by CRLF`
  que ensuciaba el diff en Windows.
- **Reconcilia el `uv.lock` actual** a `0.13.0` (corrige el drift ya presente).
- **`VERSIONING.md`** documenta el nuevo paso.

## Notas de revisión

- Usa `fromJSON(needs.release-please.outputs.pr).headBranchName` para ubicar la rama del PR.
- Respeta el token existente (`RELEASE_PLEASE_TOKEN || GITHUB_TOKEN`), consistente con `back-merge`.
- Idempotente: si `uv lock` no cambia nada, no commitea ni pushea.

## Verificación

No se puede disparar un release real de prueba desde el PR. Se valida en el **próximo corte
(0.14.0)**: el PR de release debe traer el diff de `uv.lock` ya incluido, sin tocar nada a mano.

## Gate

Sin cambios en `src/`/`tests/` (infra + docs + lockfile). `ruff check` + `ruff format --check`
verdes; mypy/pytest no afectados. YAML del workflow validado (parsea, 4 jobs).
