### PR TITLE
feat(export): export del corpus a Arrow/Feather y BibTeX (#293)

### DIFF
--- a/src/bib2graph/cli/commands/export.py
+++ b/src/bib2graph/cli/commands/export.py
@@ -1,7 +1,15 @@
 """cli.commands.export — Subcomando ``b2g export``.
 
-Serializa los artefactos de build al formato pedido.
-NO transiciona el CycleState.
+Serializa artefactos al formato pedido. NO transiciona el CycleState.
+
+Dos familias de formato (ADR 0050 D4, issue #293):
+  - **Redes de build** (``graphml``/``csv``, ya existentes): releen
+    ``<workspace>/networks/<kind>/network.graphml`` — ya vienen scopeados
+    de ``b2g build --scope``; ``--scope`` de este comando se **ignora** para
+    estos formatos (con un warning si se pasa explícito).
+  - **Corpus** (``arrow``/``bibtex``, nuevos): serializan
+    ``corpus.scoped(scope).to_arrow()`` — ``--scope`` de este comando SÍ
+    aplica (vocab CLI ``seeds`` → ``seeds_only``, igual que ``build``).
 
 ADR 0029 — workspace:
   El directorio de salida es ``<workspace>/exports/`` por defecto.
@@ -12,6 +20,7 @@ ADR 0029 — workspace:
 from __future__ import annotations
 
 import json
+import sys
 from pathlib import Path
 from typing import Any, Literal
 
@@ -21,37 +30,57 @@ from bib2graph.cli._envelope import build_envelope, emit, emit_human
 from bib2graph.cli._errors import DataError, handle_errors
 from bib2graph.cli._options import json_mode, json_option
 from bib2graph.cli._store import (
+    open_store_readonly,
     resolve_workspace,
     workspace_echo,
     workspace_walkup_warning,
 )
 
+#: Formatos que serializan artefactos de build (redes); ignoran ``--scope``.
+_NETWORK_FORMATS = frozenset({"graphml", "csv"})
+#: Formatos que serializan el corpus; respetan ``--scope`` (ADR 0050 D4).
+_CORPUS_FORMATS = frozenset({"arrow", "bibtex"})
 
-def run_export(
-    store_path: str | Path,
-    *,
-    format: Literal["graphml", "csv"] = "graphml",
-    out_dir: str | Path,
-    networks_dir: str | Path | None = None,
-) -> dict[str, Any]:
-    """Relee artefactos de build y los serializa al formato pedido.
 
-    Lee los GraphML de ``<store_dir>/networks/<kind>/network.graphml``
-    (o el directorio dado) y exporta al formato pedido.
+def _map_scope(scope: str) -> str:
+    """Mapea el vocab de ``--scope`` (CLI) al vocab interno de ``corpus.scoped()``.
+
+    Mismo mapeo que ``cli.commands.build._map_scope`` (``seeds`` → ``seeds_only``).
 
     Args:
-        store_path: Ruta al archivo ``.duckdb``.
-        format: Formato de salida (``graphml`` o ``csv``).
+        scope: Valor del flag ``--scope`` (``all`` | ``accepted`` | ``seeds``).
+
+    Returns:
+        Vocabulario interno: ``all`` | ``accepted`` | ``seeds_only``.
+    """
+    if scope == "seeds":
+        return "seeds_only"
+    return scope
+
+
+def _export_networks(
+    format: str,
+    *,
+    out_dir: str | Path,
+    networks_dir: str | Path | None,
+    store_path: str | Path,
+) -> dict[str, Any]:
+    """Relee artefactos de build (redes) y los serializa a GraphML o CSV.
+
+    Args:
+        format: ``"graphml"`` o ``"csv"``.
         out_dir: Directorio de salida para los archivos exportados.
         networks_dir: Directorio base de artefactos de build (default:
             ``<store_dir>/networks/``).
+        store_path: Ruta al archivo ``.duckdb`` (para derivar el default de
+            ``networks_dir`` si no se pasa explícito).
 
     Returns:
-        Dict con ``format``, ``files_written`` y lista de archivos.
+        Dict con ``format``, ``out_dir``, ``files_written`` y
+        ``networks_exported``.
 
     Raises:
         DataError: Si no hay artefactos de build disponibles.
-        StoreError: Si el store está bloqueado.
     """
     import networkx as nx
 
@@ -122,14 +151,158 @@ def run_export(
     }
 
 
+def _export_corpus(
+    format: str,
+    *,
+    out_dir: str | Path,
+    store_path: str | Path,
+    scope: str,
+) -> dict[str, Any]:
+    """Serializa el corpus (scopeado) a Arrow (Feather) o BibTeX.
+
+    Args:
+        format: ``"arrow"`` o ``"bibtex"``.
+        out_dir: Directorio de salida para el archivo exportado.
+        store_path: Ruta al archivo ``.duckdb``.
+        scope: Vocab interno de scope (``all``/``accepted``/``seeds_only``).
+
+    Returns:
+        Dict con ``format``, ``out_dir``, ``files_written`` y ``rows_exported``.
+
+    Raises:
+        ImportError: Si falta ``bibtexparser`` (formato ``bibtex``, extra
+            ``[bibtex]``).
+    """
+    from bib2graph.exporters.arrow import ArrowExporter
+    from bib2graph.exporters.bibtex import BibtexExporter
+
+    store = open_store_readonly(store_path)
+    try:
+        corpus = store.load().scoped(scope)
+        # Materializar la tabla ANTES de cerrar el store: para scope='all',
+        # corpus.scoped() devuelve el mismo Corpus respaldado por el
+        # DuckDBBackend vivo (lazy); to_arrow() debe correr con la conexión
+        # todavía abierta.
+        table = corpus.to_arrow()
+    finally:
+        store.close()
+
+    out_path = Path(out_dir)
+    out_path.mkdir(parents=True, exist_ok=True)
+
+    if format == "arrow":
+        dest = out_path / "corpus.arrow"
+        ArrowExporter().export(table, dest)
+    elif format == "bibtex":
+        dest = out_path / "corpus.bib"
+        BibtexExporter().export(table, dest)
+    else:
+        raise DataError(f"Formato '{format}' no reconocido. Usá 'arrow' o 'bibtex'.")
+
+    return {
+        "format": format,
+        "out_dir": str(out_path),
+        "files_written": [str(dest)],
+        "rows_exported": table.num_rows,
+    }
+
+
+def run_export(
+    store_path: str | Path,
+    *,
+    format: Literal["graphml", "csv", "arrow", "bibtex"] = "graphml",
+    out_dir: str | Path,
+    networks_dir: str | Path | None = None,
+    scope: str = "all",
+    scope_explicit: bool = False,
+) -> dict[str, Any]:
+    """Serializa artefactos al formato pedido.
+
+    Para ``graphml``/``csv`` relee los artefactos de build de
+    ``<store_dir>/networks/<kind>/network.graphml`` (``scope`` se ignora:
+    esos artefactos ya vienen scopeados de ``b2g build --scope``).
+
+    Para ``arrow``/``bibtex`` (ADR 0050 D4) serializa
+    ``corpus.scoped(scope).to_arrow()`` del store vivo — ``scope`` sí aplica.
+
+    Args:
+        store_path: Ruta al archivo ``.duckdb``.
+        format: Formato de salida (``graphml``, ``csv``, ``arrow`` o
+            ``bibtex``).
+        out_dir: Directorio de salida para los archivos exportados.
+        networks_dir: Directorio base de artefactos de build (solo
+            ``graphml``/``csv``; default: ``<store_dir>/networks/``).
+        scope: Vocab interno de scope (``all``/``accepted``/``seeds_only``).
+            Solo aplica a ``arrow``/``bibtex`` (ADR 0050 D4).
+        scope_explicit: ``True`` si el caller pasó ``--scope`` explícito en
+            la CLI. Se usa para emitir el warning de scope-ignorado cuando
+            ``format`` es de red y el usuario igual pasó ``--scope``.
+
+    Returns:
+        Dict con ``format``, ``out_dir``, ``files_written`` y, según la
+        familia de formato, ``networks_exported`` (redes) o ``rows_exported``
+        (corpus). Incluye ``warnings`` (lista, puede ser vacía).
+
+    Raises:
+        DataError: Si no hay artefactos de build disponibles (redes) o el
+            formato no se reconoce.
+        StoreError: Si el store está bloqueado.
+        ImportError: Si falta ``bibtexparser`` (formato ``bibtex``).
+    """
+    warnings: list[str] = []
+
+    if format in _NETWORK_FORMATS:
+        if scope_explicit:
+            warnings.append(
+                f"--scope se ignora con --format {format}: las redes de build ya "
+                "vienen scopeadas por 'b2g build --scope'. --scope solo aplica a "
+                "--format arrow|bibtex (ADR 0050 D4)."
+            )
+        data = _export_networks(
+            format,
+            out_dir=out_dir,
+            networks_dir=networks_dir,
+            store_path=store_path,
+        )
+    elif format in _CORPUS_FORMATS:
+        data = _export_corpus(
+            format,
+            out_dir=out_dir,
+            store_path=store_path,
+            scope=scope,
+        )
+    else:
+        raise DataError(
+            f"Formato '{format}' no reconocido. Usá 'graphml', 'csv', 'arrow' o 'bibtex'."
+        )
+
+    data["warnings"] = warnings
+    return data
+
+
 @click.command("export")
 @click.option(
     "--format",
     "fmt",
-    type=click.Choice(["graphml", "csv"]),
+    type=click.Choice(["graphml", "csv", "arrow", "bibtex"]),
     default="graphml",
     show_default=True,
-    help="Formato de salida.",
+    help=(
+        "Formato de salida. 'graphml'/'csv' serializan redes de build; "
+        "'arrow'/'bibtex' serializan el CORPUS (ADR 0050 D4)."
+    ),
+)
+@click.option(
+    "--scope",
+    "scope",
+    type=click.Choice(["all", "accepted", "seeds"]),
+    default=None,
+    help=(
+        "Filtra el corpus antes de exportar. Solo aplica a --format arrow|bibtex "
+        "(ADR 0050 D4); se IGNORA con --format graphml|csv (esas redes ya vienen "
+        "scopeadas por 'b2g build --scope'). 'all' = corpus completo (default); "
+        "'accepted' = semillas + aceptados; 'seeds' = solo semillas."
+    ),
 )
 @click.option(
     "--out-dir",
@@ -145,12 +318,18 @@ def run_export(
 def export_cmd(
     ctx: click.Context,
     fmt: str,
+    scope: str | None,
     out_dir: str | None,
     json_output: bool,
 ) -> None:
-    """Serializa artefactos de build al formato pedido (GraphML o CSV).
+    """Serializa artefactos al formato pedido.
 
     No transiciona el CycleState.
+
+    - 'graphml'/'csv': re-emiten las redes de build (ya scopeadas por
+      ``b2g build --scope``).
+    - 'arrow'/'bibtex' (ADR 0050 D4): serializan el CORPUS del store vivo,
+      scopeado por ``--scope`` de este comando.
 
     El directorio de salida por defecto es ``<workspace>/exports/``.
     Con ``--out-dir`` se puede especificar un directorio alternativo.
@@ -159,27 +338,39 @@ def export_cmd(
     ws = resolve_workspace(ctx.obj)
     effective_out_dir: Path = Path(out_dir) if out_dir is not None else ws.exports_dir
 
+    scope_explicit = scope is not None
+    internal_scope = _map_scope(scope) if scope is not None else "all"
+
     data = run_export(
         ws.library_path,
         format=fmt,  # type: ignore[arg-type]
         out_dir=effective_out_dir,
         networks_dir=ws.networks_dir,
+        scope=internal_scope,
+        scope_explicit=scope_explicit,
     )
 
     # ADR 0045 (#259): eco de workspace + warning accionable en walk-up.
     data["workspace"] = workspace_echo(ws)
 
     if json_mode(json_output):
+        all_warnings: list[str] = list(data.get("warnings") or [])
+        all_warnings.extend(workspace_walkup_warning(ws))
         envelope = build_envelope(
             command="export",
             ok=True,
             data=data,
             exit_code=0,
-            warnings=workspace_walkup_warning(ws) or None,
+            warnings=all_warnings or None,
         )
         emit(envelope)
     else:
-        emit_human(f"Exportados {data['networks_exported']} redes en formato {fmt}")
+        for w in data.get("warnings", []):
+            print(f"ADVERTENCIA: {w}", file=sys.stderr)
+        if "networks_exported" in data:
+            emit_human(f"Exportados {data['networks_exported']} redes en formato {fmt}")
+        else:
+            emit_human(f"Exportadas {data['rows_exported']} filas en formato {fmt}")
         emit_human(f"Directorio: {data['out_dir']}")
         for f in data["files_written"]:
             emit_human(f"  {f}")

--- a/src/bib2graph/exporters/__init__.py
+++ b/src/bib2graph/exporters/__init__.py
@@ -1,15 +1,22 @@
-"""exporters — exportadores de redes bibliométricas (Hito 2).
+"""exporters — exportadores de redes y de corpus (Hito 2 + ADR 0050 D4).
 
 Expone ``GraphMLExporter`` (para Gephi/VOSviewer/Cytoscape) y
-``CsvExporter`` (para pandas). Ver API.md §9 y decisión D5.
+``CsvExporter`` (para pandas) para redes de build (API.md §9, decisión D5).
+
+Expone ``ArrowExporter`` (Feather/Arrow IPC) y ``BibtexExporter`` (``.bib``)
+para el CORPUS scopeado (ADR 0050 D4, issue #293).
 """
 
 from __future__ import annotations
 
+from bib2graph.exporters.arrow import ArrowExporter
+from bib2graph.exporters.bibtex import BibtexExporter
 from bib2graph.exporters.csv import CsvExporter
 from bib2graph.exporters.graphml import GraphMLExporter
 
 __all__ = [
+    "ArrowExporter",
+    "BibtexExporter",
     "CsvExporter",
     "GraphMLExporter",
 ]

--- a/src/bib2graph/exporters/arrow.py
+++ b/src/bib2graph/exporters/arrow.py
@@ -3,7 +3,7 @@
 Implementa ``ArrowExporter`` según ADR 0050 D4. Serializa la tabla que
 ``Corpus.to_arrow()`` produce (schema + metadata ya poblados por la
 proyección) a un único archivo ``.arrow`` (Arrow IPC / Feather),
-autoverificable para consumidores externos (Atalaya).
+autoverificable para consumidores externos (un consumidor programático).
 
 Es un artefacto DISTINTO de ``snapshot create`` (parquet + manifest.json,
 reproducibilidad interna, ADR 0017/0030): este exportador NO toca el

--- a/src/bib2graph/exporters/arrow.py
+++ b/src/bib2graph/exporters/arrow.py
@@ -1,0 +1,49 @@
+"""arrow — exportador del corpus a un archivo Arrow IPC (Feather).
+
+Implementa ``ArrowExporter`` según ADR 0050 D4. Serializa la tabla que
+``Corpus.to_arrow()`` produce (schema + metadata ya poblados por la
+proyección) a un único archivo ``.arrow`` (Arrow IPC / Feather),
+autoverificable para consumidores externos (Atalaya).
+
+Es un artefacto DISTINTO de ``snapshot create`` (parquet + manifest.json,
+reproducibilidad interna, ADR 0017/0030): este exportador NO toca el
+schema ni agrega/computa metadata — solo serializa la tabla tal como
+``to_arrow()`` la entrega. ``pyarrow.feather.write_feather`` preserva la
+metadata del schema (incluido cualquier ``equation_hash``/objeto ecuación
+que la otra pieza del contrato, #291/#292, haya poblado) sin intervención
+de este módulo.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pyarrow as pa
+
+
+class ArrowExporter:
+    """Exporta una tabla Arrow del corpus a un archivo Feather (Arrow IPC).
+
+    No modifica el schema ni la tabla: solo la serializa. La metadata del
+    schema (si la tabla la trae) viaja intacta dentro del archivo.
+    """
+
+    def export(self, table: pa.Table, out_path: str | Path) -> Path:
+        """Escribe ``table`` a ``out_path`` en formato Feather (Arrow IPC).
+
+        Args:
+            table: Tabla Arrow a serializar (típicamente
+                ``corpus.scoped(scope).to_arrow()``).
+            out_path: Ruta del archivo de salida (p. ej.
+                ``<exports_dir>/corpus.arrow``). El directorio padre se
+                crea si no existe.
+
+        Returns:
+            La ``Path`` del archivo escrito.
+        """
+        from pyarrow import feather
+
+        resolved = Path(out_path)
+        resolved.parent.mkdir(parents=True, exist_ok=True)
+        feather.write_feather(table, str(resolved))  # type: ignore[no-untyped-call]
+        return resolved

--- a/src/bib2graph/exporters/bibtex.py
+++ b/src/bib2graph/exporters/bibtex.py
@@ -1,0 +1,136 @@
+"""bibtex — exportador del corpus a un archivo ``.bib`` (BibTeX).
+
+Implementa ``BibtexExporter`` según ADR 0050 D4 (defaults congelados por el
+PO, resolución 2026-07-25, punto 6):
+
+- **entry-type inferido**, con ``@article`` como default cuando no hay señal
+  para inferir otro tipo (heurística mínima: si hay ``booktitle``/no hay
+  ``journal`` → ``@inproceedings``, si no → ``@article``).
+- **citekey = el ``id`` interno del paper** (``doi:…``/``src:…``/``tt:…``,
+  D1 de ADR 0013): estable y sin colisiones. El DOI va como campo, no como
+  citekey.
+- **campos mínimos universales:** ``title``, ``author``, ``year``, ``doi``,
+  ``journal`` (venue), ``url``. ``keywords``/``abstract`` quedan fuera del
+  MVP.
+- **scope = el corpus tal como llega** (ya scopeado por el caller vía
+  ``Corpus.scoped``): las entradas con metadata incompleta se emiten con los
+  campos que haya, sin filtrar.
+
+Import de ``bibtexparser`` PEREZOSO (mismo patrón que ``sources/bibtex.py``):
+se hace dentro de ``export()`` para no acoplar el núcleo al extra
+``[bibtex]``; error claro si falta.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pyarrow as pa
+
+from bib2graph.constants import Col
+
+
+def _infer_entry_type(row: dict[str, Any]) -> str:
+    """Infiere el ``ENTRYTYPE`` BibTeX de una fila del corpus.
+
+    Default congelado (ADR 0050 D4): ``article`` cuando no hay señal para
+    inferir otro tipo. Única señal disponible en el MVP: si el venue vino
+    de un ``booktitle`` (proceedings) en vez de ``journal`` no se puede
+    distinguir en el schema canónico (ambos colapsan a ``source``), así que
+    se usa siempre ``article`` — el schema no trae hoy un campo que permita
+    diferenciar de forma confiable.
+
+    Args:
+        row: Fila del corpus (dict, una entrada de ``table.to_pylist()``).
+
+    Returns:
+        ``"article"`` (default del MVP; ver ADR 0050 D4 punto 6a).
+    """
+    return "article"
+
+
+def _row_to_entry(row: dict[str, Any]) -> dict[str, str]:
+    """Mapea una fila del corpus canónico a una entrada bibtexparser.
+
+    Campos mínimos universales (ADR 0050 D4 punto 6c): ``title``, ``author``,
+    ``year``, ``doi``, ``journal`` (venue = ``source``), ``url`` (derivado
+    del DOI si está presente). Entradas con metadata incompleta emiten solo
+    los campos presentes (no se rellenan placeholders).
+
+    Args:
+        row: Fila del corpus (dict de ``table.to_pylist()``).
+
+    Returns:
+        Dict de campos bibtexparser (incluye ``ENTRYTYPE``/``ID``).
+    """
+    entry: dict[str, str] = {
+        "ENTRYTYPE": _infer_entry_type(row),
+        "ID": str(row[Col.ID]),
+    }
+
+    title = row.get(Col.TITLE)
+    if title:
+        entry["title"] = str(title)
+
+    authors_raw = row.get(Col.AUTHORS_RAW)
+    if authors_raw:
+        entry["author"] = " and ".join(str(a) for a in authors_raw)
+
+    year = row.get(Col.YEAR)
+    if year is not None:
+        entry["year"] = str(year)
+
+    doi = row.get(Col.DOI)
+    if doi:
+        entry["doi"] = str(doi)
+        entry["url"] = f"https://doi.org/{doi}"
+
+    venue = row.get(Col.SOURCE)
+    if venue:
+        entry["journal"] = str(venue)
+
+    return entry
+
+
+class BibtexExporter:
+    """Exporta la tabla Arrow de un corpus (scopeado) a un archivo ``.bib``."""
+
+    def export(self, table: pa.Table, out_path: str | Path) -> Path:
+        """Escribe ``table`` a ``out_path`` como ``.bib`` parseable.
+
+        Args:
+            table: Tabla Arrow del corpus (típicamente
+                ``corpus.scoped(scope).to_arrow()``).
+            out_path: Ruta del archivo de salida (p. ej.
+                ``<exports_dir>/corpus.bib``). El directorio padre se crea
+                si no existe.
+
+        Returns:
+            La ``Path`` del archivo escrito.
+
+        Raises:
+            ImportError: Si ``bibtexparser`` no está instalado (extra
+                ``[bibtex]``).
+        """
+        try:
+            import bibtexparser
+            from bibtexparser.bwriter import BibTexWriter
+        except ImportError as exc:
+            raise ImportError(
+                "bibtexparser no está instalado. "
+                'Instalá el extra: pip install "bib2graph[bibtex]" '
+                "o uv sync --extra bibtex"
+            ) from exc
+
+        rows = table.to_pylist()
+        db = bibtexparser.bibdatabase.BibDatabase()
+        db.entries = [_row_to_entry(row) for row in rows]
+
+        writer = BibTexWriter()
+        writer.order_entries_by = None  # preservar el orden del corpus
+
+        resolved = Path(out_path)
+        resolved.parent.mkdir(parents=True, exist_ok=True)
+        resolved.write_text(writer.write(db), encoding="utf-8")
+        return resolved

--- a/tests/unit/test_export_corpus_arrow_bibtex.py
+++ b/tests/unit/test_export_corpus_arrow_bibtex.py
@@ -1,0 +1,535 @@
+"""Tests TDD — ``b2g export --format arrow|bibtex`` (ADR 0050 D4, issue #293).
+
+Cubre:
+1. ``--format arrow``: escribe un Feather (Arrow IPC) que se relee con
+   ``pyarrow.feather.read_table``; columnas del schema presentes; metadata
+   de schema preservada cuando ``to_arrow()`` la trae (genérico — no asume
+   ``equation_hash`` presente, eso es de la otra pieza del contrato).
+2. ``--format bibtex``: el ``.bib`` parsea con ``bibtexparser``; citekeys =
+   ``id`` interno; entry-type ``@article`` por default; entradas con
+   metadata incompleta se emiten igual (no se filtran).
+3. ``--scope``: aplicado en arrow/bibtex (distinto Nº de filas); ignorado
+   (con warning) en graphml/csv.
+4. Envelope ``--json`` consistente: ``{format, out_dir, files_written,
+   workspace}``.
+
+Marcador: ``unit`` (DuckDB en tmp_path, sin red real).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pyarrow as pa
+import pytest
+from click.testing import CliRunner
+
+from bib2graph.schemas import CORPUS_SCHEMA
+
+pytestmark = pytest.mark.unit
+
+# ---------------------------------------------------------------------------
+# Helpers compartidos (mismo patrón que test_maturity.py)
+# ---------------------------------------------------------------------------
+
+
+def _row(
+    id: str,
+    *,
+    title: str = "Paper",
+    is_seed: bool = True,
+    curation_status: str = "candidate",
+    doi: str | None = None,
+    year: int | None = 2020,
+    source: str | None = None,
+    authors_raw: list[str] | None = None,
+    references_id: list[str] | None = None,
+) -> dict[str, Any]:
+    """Fila mínima con schema canónico completo."""
+    return {
+        "id": id,
+        "source_id": None,
+        "doi": doi,
+        "title": title,
+        "year": year,
+        "abstract": None,
+        "source": source,
+        "language": None,
+        "publisher": None,
+        "research_areas": None,
+        "is_seed": is_seed,
+        "curation_status": curation_status,
+        "provenance": None,
+        "authors_raw": authors_raw,
+        "authors_id": None,
+        "authors_affiliations": None,
+        "keywords_raw": None,
+        "keywords_id": None,
+        "institutions_raw": None,
+        "institutions_id": None,
+        "references_id": references_id,
+        "references_doi": None,
+        "cited_by_id": None,
+    }
+
+
+def _seed_store(store_path: Path, rows: list[dict[str, Any]]) -> None:
+    """Persiste filas en un DuckDB temporal."""
+    from bib2graph.corpus import Corpus
+    from bib2graph.stores.duckdb import DuckDBStore
+
+    table = pa.Table.from_pylist(rows, schema=CORPUS_SCHEMA)
+    corpus = Corpus.from_arrow(table)
+    store = DuckDBStore(store_path)
+    store.persist(corpus)
+    store.close()
+
+
+def _init_workspace(tmp_path: Path, name: str = "ws") -> Any:
+    """Crea y devuelve un Workspace inicializado en tmp_path."""
+    from bib2graph.workspace import Workspace
+
+    ws_dir = tmp_path / name
+    return Workspace.init(ws_dir, name)
+
+
+def _mixed_rows() -> list[dict[str, Any]]:
+    """3 papers: 2 semillas (1 aceptada, 1 candidata) + 1 no-semilla aceptado."""
+    return [
+        _row(
+            "doi:p1",
+            title="Seed accepted",
+            is_seed=True,
+            curation_status="accepted",
+            doi="10.1/p1",
+            year=2019,
+            source="Journal A",
+            authors_raw=["Smith, John"],
+        ),
+        _row(
+            "doi:p2",
+            title="Seed candidate",
+            is_seed=True,
+            curation_status="candidate",
+        ),
+        _row(
+            "doi:p3",
+            title="Chained accepted",
+            is_seed=False,
+            curation_status="accepted",
+        ),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# 1. --format arrow
+# ---------------------------------------------------------------------------
+
+
+class TestExportFormatArrow:
+    def test_arrow_escribe_feather_legible(self, tmp_path: Path) -> None:
+        """--format arrow escribe un Feather releíble con las columnas del schema."""
+        from bib2graph.cli import b2g
+
+        ws = _init_workspace(tmp_path)
+        _seed_store(ws.library_path, _mixed_rows())
+
+        runner = CliRunner()
+        result = runner.invoke(
+            b2g,
+            ["--workspace", str(ws.root), "export", "--format", "arrow", "--json"],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, f"Error: {result.output}"
+        envelope = json.loads(result.output)
+        assert envelope["ok"] is True
+        data = envelope["data"]
+        assert data["format"] == "arrow"
+
+        files_written = data["files_written"]
+        assert len(files_written) == 1
+        arrow_path = Path(files_written[0])
+        assert arrow_path.exists()
+        assert arrow_path.suffix == ".arrow"
+
+        import pyarrow.feather as feather
+
+        reread = feather.read_table(str(arrow_path))
+        assert set(reread.schema.names) == set(CORPUS_SCHEMA.names)
+        assert reread.num_rows == 3
+
+    def test_arrow_preserva_metadata_de_schema_si_presente(
+        self, tmp_path: Path
+    ) -> None:
+        """Si to_arrow() trae metadata de schema, el Feather la preserva.
+
+        Genérico: NO asume equation_hash presente (eso lo testea la pieza
+        de #291/#292); solo verifica que CUALQUIER metadata puesta en el
+        schema por to_arrow() sobrevive la serialización/deserialización.
+        """
+        from bib2graph.corpus import Corpus
+        from bib2graph.exporters.arrow import ArrowExporter
+
+        rows = _mixed_rows()
+        table = pa.Table.from_pylist(rows, schema=CORPUS_SCHEMA)
+        corpus = Corpus.from_arrow(table)
+        live_table = corpus.to_arrow()
+
+        # Si la tabla que produce to_arrow() ya trae metadata, debe sobrevivir.
+        # Si no trae ninguna (según el estado actual de to_arrow(), pieza en
+        # paralelo), el test igual es válido: metadata None -> None.
+        out_path = tmp_path / "corpus.arrow"
+        ArrowExporter().export(live_table, out_path)
+
+        import pyarrow.feather as feather
+
+        reread = feather.read_table(str(out_path))
+        assert reread.schema.metadata == live_table.schema.metadata
+
+    def test_arrow_respeta_scope(self, tmp_path: Path) -> None:
+        """--scope seeds exporta solo las 2 filas is_seed=True."""
+        from bib2graph.cli import b2g
+
+        ws = _init_workspace(tmp_path)
+        _seed_store(ws.library_path, _mixed_rows())
+
+        runner = CliRunner()
+        result = runner.invoke(
+            b2g,
+            [
+                "--workspace",
+                str(ws.root),
+                "export",
+                "--format",
+                "arrow",
+                "--scope",
+                "seeds",
+                "--json",
+            ],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, f"Error: {result.output}"
+        envelope = json.loads(result.output)
+        data = envelope["data"]
+        assert data["rows_exported"] == 2
+
+        import pyarrow.feather as feather
+
+        arrow_path = Path(data["files_written"][0])
+        reread = feather.read_table(str(arrow_path))
+        assert reread.num_rows == 2
+
+    def test_arrow_scope_accepted_distinto_de_seeds(self, tmp_path: Path) -> None:
+        """--scope accepted (seeds + aceptados) difiere en Nº de filas de seeds."""
+        from bib2graph.cli import b2g
+
+        ws = _init_workspace(tmp_path)
+        _seed_store(ws.library_path, _mixed_rows())
+        runner = CliRunner()
+
+        result_accepted = runner.invoke(
+            b2g,
+            [
+                "--workspace",
+                str(ws.root),
+                "export",
+                "--format",
+                "arrow",
+                "--scope",
+                "accepted",
+                "--out-dir",
+                str(ws.root / "exports_accepted"),
+                "--json",
+            ],
+            catch_exceptions=False,
+        )
+        assert result_accepted.exit_code == 0
+        data_accepted = json.loads(result_accepted.output)["data"]
+        # accepted = is_seed OR curation_status==accepted: p1 (seed+accepted),
+        # p2 (seed), p3 (accepted, no seed) => las 3 filas.
+        assert data_accepted["rows_exported"] == 3
+
+        result_all = runner.invoke(
+            b2g,
+            [
+                "--workspace",
+                str(ws.root),
+                "export",
+                "--format",
+                "arrow",
+                "--scope",
+                "all",
+                "--out-dir",
+                str(ws.root / "exports_all"),
+                "--json",
+            ],
+            catch_exceptions=False,
+        )
+        data_all = json.loads(result_all.output)["data"]
+        assert data_all["rows_exported"] == 3
+
+    def test_arrow_out_dir_default_es_exports_dir_del_workspace(
+        self, tmp_path: Path
+    ) -> None:
+        """Sin --out-dir, corpus.arrow va a <workspace>/exports/."""
+        from bib2graph.cli import b2g
+
+        ws = _init_workspace(tmp_path)
+        _seed_store(ws.library_path, _mixed_rows())
+
+        runner = CliRunner()
+        result = runner.invoke(
+            b2g,
+            ["--workspace", str(ws.root), "export", "--format", "arrow", "--json"],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+        data = json.loads(result.output)["data"]
+        assert Path(data["out_dir"]) == ws.exports_dir
+        assert (ws.exports_dir / "corpus.arrow").exists()
+
+
+# ---------------------------------------------------------------------------
+# 2. --format bibtex
+# ---------------------------------------------------------------------------
+
+
+class TestExportFormatBibtex:
+    def test_bibtex_parsea_y_citekeys_son_ids_internos(self, tmp_path: Path) -> None:
+        """El .bib generado parsea con bibtexparser; citekeys = id interno."""
+        pytest.importorskip("bibtexparser")
+        from bib2graph.cli import b2g
+
+        ws = _init_workspace(tmp_path)
+        _seed_store(ws.library_path, _mixed_rows())
+
+        runner = CliRunner()
+        result = runner.invoke(
+            b2g,
+            ["--workspace", str(ws.root), "export", "--format", "bibtex", "--json"],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, f"Error: {result.output}"
+        data = json.loads(result.output)["data"]
+        assert data["format"] == "bibtex"
+        bib_path = Path(data["files_written"][0])
+        assert bib_path.exists()
+        assert bib_path.suffix == ".bib"
+
+        import bibtexparser
+
+        parsed = bibtexparser.loads(bib_path.read_text(encoding="utf-8"))
+        assert len(parsed.entries) == 3
+        ids = {e["ID"] for e in parsed.entries}
+        assert ids == {"doi:p1", "doi:p2", "doi:p3"}
+
+    def test_bibtex_entry_type_article_por_default(self, tmp_path: Path) -> None:
+        """Sin señal para inferir otro tipo, el ENTRYTYPE es 'article'."""
+        pytest.importorskip("bibtexparser")
+        from bib2graph.cli import b2g
+
+        ws = _init_workspace(tmp_path)
+        _seed_store(ws.library_path, _mixed_rows())
+
+        runner = CliRunner()
+        result = runner.invoke(
+            b2g,
+            ["--workspace", str(ws.root), "export", "--format", "bibtex", "--json"],
+            catch_exceptions=False,
+        )
+        data = json.loads(result.output)["data"]
+        bib_path = Path(data["files_written"][0])
+
+        import bibtexparser
+
+        parsed = bibtexparser.loads(bib_path.read_text(encoding="utf-8"))
+        for entry in parsed.entries:
+            assert entry["ENTRYTYPE"] == "article"
+
+    def test_bibtex_campos_minimos_presentes_para_fila_completa(
+        self, tmp_path: Path
+    ) -> None:
+        """La fila con metadata completa trae title/author/year/doi/journal/url."""
+        pytest.importorskip("bibtexparser")
+        from bib2graph.cli import b2g
+
+        ws = _init_workspace(tmp_path)
+        _seed_store(ws.library_path, _mixed_rows())
+
+        runner = CliRunner()
+        result = runner.invoke(
+            b2g,
+            ["--workspace", str(ws.root), "export", "--format", "bibtex", "--json"],
+            catch_exceptions=False,
+        )
+        data = json.loads(result.output)["data"]
+        bib_path = Path(data["files_written"][0])
+
+        import bibtexparser
+
+        parsed = bibtexparser.loads(bib_path.read_text(encoding="utf-8"))
+        entry_p1 = next(e for e in parsed.entries if e["ID"] == "doi:p1")
+        assert entry_p1["title"] == "Seed accepted"
+        assert entry_p1["author"] == "Smith, John"
+        assert entry_p1["year"] == "2019"
+        assert entry_p1["doi"] == "10.1/p1"
+        assert entry_p1["journal"] == "Journal A"
+        assert "doi.org" in entry_p1["url"]
+
+    def test_bibtex_entradas_incompletas_no_se_filtran(self, tmp_path: Path) -> None:
+        """Entradas con metadata incompleta se emiten con los campos que haya."""
+        pytest.importorskip("bibtexparser")
+        from bib2graph.cli import b2g
+
+        ws = _init_workspace(tmp_path)
+        _seed_store(ws.library_path, _mixed_rows())
+
+        runner = CliRunner()
+        result = runner.invoke(
+            b2g,
+            ["--workspace", str(ws.root), "export", "--format", "bibtex", "--json"],
+            catch_exceptions=False,
+        )
+        data = json.loads(result.output)["data"]
+        bib_path = Path(data["files_written"][0])
+
+        import bibtexparser
+
+        parsed = bibtexparser.loads(bib_path.read_text(encoding="utf-8"))
+        # p2 no tiene doi/author/journal — debe seguir presente con lo que hay.
+        entry_p2 = next(e for e in parsed.entries if e["ID"] == "doi:p2")
+        assert entry_p2["title"] == "Seed candidate"
+        assert "doi" not in entry_p2
+        assert "author" not in entry_p2
+
+    def test_bibtex_respeta_scope(self, tmp_path: Path) -> None:
+        """--scope seeds exporta solo 2 entradas al .bib."""
+        pytest.importorskip("bibtexparser")
+        from bib2graph.cli import b2g
+
+        ws = _init_workspace(tmp_path)
+        _seed_store(ws.library_path, _mixed_rows())
+
+        runner = CliRunner()
+        result = runner.invoke(
+            b2g,
+            [
+                "--workspace",
+                str(ws.root),
+                "export",
+                "--format",
+                "bibtex",
+                "--scope",
+                "seeds",
+                "--json",
+            ],
+            catch_exceptions=False,
+        )
+        data = json.loads(result.output)["data"]
+        assert data["rows_exported"] == 2
+
+        import bibtexparser
+
+        bib_path = Path(data["files_written"][0])
+        parsed = bibtexparser.loads(bib_path.read_text(encoding="utf-8"))
+        assert len(parsed.entries) == 2
+
+
+# ---------------------------------------------------------------------------
+# 3. --scope ignorado (con warning) para graphml/csv
+# ---------------------------------------------------------------------------
+
+
+class TestScopeIgnoradoParaFormatosDeRed:
+    def test_scope_con_graphml_emite_warning_y_no_falla(self, tmp_path: Path) -> None:
+        """--scope con --format graphml no rompe; emite warning accionable."""
+        from bib2graph.cli import b2g
+        from bib2graph.cli.commands.build import run_build
+
+        ws = _init_workspace(tmp_path)
+        _seed_store(
+            ws.library_path,
+            [
+                _row("doi:p1", references_id=["R1", "R2"]),
+                _row("doi:p2", references_id=["R1", "R3"]),
+            ],
+        )
+        run_build(ws.library_path, out_dir=ws.networks_dir)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            b2g,
+            [
+                "--workspace",
+                str(ws.root),
+                "export",
+                "--format",
+                "graphml",
+                "--scope",
+                "seeds",
+                "--json",
+            ],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, f"Error: {result.output}"
+        envelope = json.loads(result.output)
+        assert envelope["ok"] is True
+        warnings_list = envelope.get("warnings") or []
+        assert any("--scope" in w and "graphml" in w for w in warnings_list)
+
+    def test_sin_scope_no_hay_warning_para_graphml(self, tmp_path: Path) -> None:
+        """Sin --scope explícito, no se emite el warning de scope-ignorado."""
+        from bib2graph.cli import b2g
+        from bib2graph.cli.commands.build import run_build
+
+        ws = _init_workspace(tmp_path)
+        _seed_store(
+            ws.library_path,
+            [
+                _row("doi:p1", references_id=["R1", "R2"]),
+                _row("doi:p2", references_id=["R1", "R3"]),
+            ],
+        )
+        run_build(ws.library_path, out_dir=ws.networks_dir)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            b2g,
+            ["--workspace", str(ws.root), "export", "--format", "graphml", "--json"],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+        envelope = json.loads(result.output)
+        warnings_list = envelope.get("warnings") or []
+        assert not any("--scope" in w for w in warnings_list)
+
+
+# ---------------------------------------------------------------------------
+# 4. Envelope --json consistente
+# ---------------------------------------------------------------------------
+
+
+class TestEnvelopeJson:
+    def test_envelope_arrow_tiene_claves_esperadas(self, tmp_path: Path) -> None:
+        """Envelope --json expone format/out_dir/files_written/workspace."""
+        from bib2graph.cli import b2g
+
+        ws = _init_workspace(tmp_path)
+        _seed_store(ws.library_path, _mixed_rows())
+
+        runner = CliRunner()
+        result = runner.invoke(
+            b2g,
+            ["--workspace", str(ws.root), "export", "--format", "arrow", "--json"],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+        envelope = json.loads(result.output)
+        assert envelope["schema"] == "1"
+        data = envelope["data"]
+        assert "format" in data
+        assert "out_dir" in data
+        assert "files_written" in data
+        assert "workspace" in data


### PR DESCRIPTION
Cierra #293. Implementa D4 del ADR 0050.

## Qué

Extiende `b2g export --format` con dos formatos que serializan el **corpus** (no las redes):

- **`--format arrow`** → `corpus.scoped(scope).to_arrow()` a `<exports_dir>/corpus.arrow` con `pyarrow.feather.write_feather` (Feather/IPC, no parquet). **Passthrough puro**: no toca schema ni metadata, los preserva tal cual vengan de `to_arrow()` — la metadata (`equation_hash`) la pone #291/#292 y el Feather la arrastra sola.
- **`--format bibtex`** → `<exports_dir>/corpus.bib` parseable (`bibtexparser`, import perezoso). Citekey = `id` interno; `@article` por default; campos `title/author/year/doi/journal/url`; entradas incompletas se emiten con lo que haya.
- **`--scope`** (`all|accepted|seeds`) nuevo en `export`: aplica a `arrow`/`bibtex`; **ignorado con `warning`** en `graphml`/`csv`.

## Archivos

- `cli/commands/export.py` — `run_export` bifurca en `_export_networks` (intacto) y `_export_corpus` (nuevo); `export_cmd` gana `--scope`.
- `exporters/arrow.py`, `exporters/bibtex.py` (nuevos) + `exporters/__init__.py`.
- `tests/unit/test_export_corpus_arrow_bibtex.py` (13 tests).

## Notas de revisión

- `_export_corpus` materializa la tabla **antes** de cerrar el store (el `Corpus` de `store.load()` es lazy sobre el `DuckDBBackend` vivo).
- `entry-type` siempre `@article` en el MVP: el schema no distingue `journal`/`booktitle`, no hay señal para inferir `@inproceedings` (limitación documentada).
- `_map_scope` quedó duplicado con `build.py` (3 líneas) — deliberado para no tocar territorio de otra pieza; candidato a DRY posterior.

## Gate

ruff / format / mypy limpios; `pytest` subset (export/CLI/build/workspace/cycle) → **251 passed**. CI corre el completo.

Sync de `docs/API.md` §2 (formatos, `--scope`, envelope `rows_exported`) → architect, tras merge del ADR 0050.