### PR TITLE
feat(equations): tabla equations de 1ª clase + equation_hash en metadata Arrow (#291, #292)

### DIFF
--- a/src/bib2graph/backends/base.py
+++ b/src/bib2graph/backends/base.py
@@ -211,3 +211,45 @@ class TabularBackend(Protocol):
             Lista de tuplas ``(paper_id, engine, id)`` en orden no definido.
         """
         ...
+
+    def persist_equation(
+        self,
+        equation_id: str,
+        *,
+        engine: str,
+        raw_query: str,
+        params_json: str,
+        label: str | None = None,
+        created_at: str | None = None,
+    ) -> None:
+        """Persiste una ecuación de búsqueda en la tabla lateral ``equations`` (ADR 0050 D1).
+
+        Idempotente: escribir el mismo ``equation_id`` dos veces reemplaza la
+        fila (upsert), no duplica. La tabla ``equations`` es lateral al
+        ``CORPUS_SCHEMA`` — no participa de ``corpus_hash`` ni de la
+        identidad del corpus (R2, ADR 0017).
+
+        Args:
+            equation_id: PK, formato ``eq-<YYYYMMDDTHHMMSS>`` (mismo formato
+                que ``provenance.equation_id`` hoy).
+            engine: Motor que ejecutó la búsqueda (p. ej. ``'openalex'``).
+            raw_query: La ecuación CRUDA tal como la escribió el usuario,
+                ANTES de traducir a filtros del motor.
+            params_json: JSON string con los parámetros (``exclude``,
+                ``max_results``, ``native``, ``min_year``, ``max_year``,
+                ``executed_query``, ``translation_report``).
+            label: Etiqueta humana opcional.
+            created_at: Timestamp ISO8601 UTC de creación. Si es ``None``,
+                la implementación usa ``datetime.now(UTC)`` como fallback.
+        """
+        ...
+
+    def load_equations(self) -> list[dict[str, object]]:
+        """Devuelve todas las ecuaciones persistidas en la tabla ``equations``.
+
+        Returns:
+            Lista de dicts con las claves ``equation_id``, ``engine``,
+            ``raw_query``, ``params_json``, ``label``, ``created_at``, en
+            orden de inserción.
+        """
+        ...

--- a/src/bib2graph/backends/duckdb.py
+++ b/src/bib2graph/backends/duckdb.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 
 import contextlib
 import json
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Literal
 
@@ -41,6 +42,7 @@ from bib2graph.backends.memory import (
     _merge_curation_status,
     _merge_provenance,
     _merge_rows,
+    build_equation_metadata,
     compute_corpus_hash,
 )
 from bib2graph.constants import LIST_COLUMNS, CurationStatus
@@ -147,6 +149,21 @@ CREATE TABLE IF NOT EXISTS enricher_log (
     name        VARCHAR NOT NULL,
     params_json VARCHAR NOT NULL DEFAULT '{}',
     recorded_at TIMESTAMPTZ NOT NULL DEFAULT now()
+)
+"""
+
+# ADR 0050 (D1): tabla lateral de ecuaciones de búsqueda de 1ª clase.
+# PK equation_id: escritura idempotente vía INSERT OR REPLACE (upsert).
+# Lateral al corpus: NO entra en CORPUS_SCHEMA ni en corpus_hash (R2, ADR 0017).
+_DDL_EQUATIONS = """
+CREATE TABLE IF NOT EXISTS equations (
+    equation_id VARCHAR NOT NULL PRIMARY KEY,
+    engine      VARCHAR NOT NULL,
+    raw_query   VARCHAR NOT NULL,
+    params_json VARCHAR NOT NULL DEFAULT '{}',
+    label       VARCHAR,
+    created_at  VARCHAR NOT NULL,
+    _seq        BIGINT
 )
 """
 
@@ -476,6 +493,7 @@ class DuckDBBackend:
         self._con.execute(_DDL_EXTERNAL_IDS)
         self._con.execute(_DDL_FILTER_LOG)
         self._con.execute(_DDL_ENRICHER_LOG)
+        self._con.execute(_DDL_EQUATIONS)
         self._register_udfs()
 
     def _register_udfs(self) -> None:
@@ -636,6 +654,33 @@ class DuckDBBackend:
                     "VALUES (?, ?, ?)",
                     [er_name, er_params, er_at],
                 )
+            equation_rows = self._con.execute(
+                "SELECT equation_id, engine, raw_query, params_json, label, "
+                "created_at, _seq FROM equations ORDER BY _seq"
+            ).fetchall()
+            for (
+                eq_id_val,
+                eq_engine_val,
+                eq_raw_query_val,
+                eq_params_val,
+                eq_label_val,
+                eq_created_val,
+                eq_seq_val,
+            ) in equation_rows:
+                new_backend._con.execute(
+                    "INSERT INTO equations "
+                    "(equation_id, engine, raw_query, params_json, label, "
+                    "created_at, _seq) VALUES (?, ?, ?, ?, ?, ?, ?)",
+                    [
+                        eq_id_val,
+                        eq_engine_val,
+                        eq_raw_query_val,
+                        eq_params_val,
+                        eq_label_val,
+                        eq_created_val,
+                        eq_seq_val,
+                    ],
+                )
             return new_backend
         else:
             new_backend = DuckDBBackend.__new__(DuckDBBackend)
@@ -652,11 +697,25 @@ class DuckDBBackend:
         Impone el schema exacto de ``CORPUS_SCHEMA`` (orden y tipos).
         Valida con ``validate_table`` antes de devolver.
 
+        ADR 0050 (D3): puebla la metadata del schema Arrow con
+        ``equation_hash`` cuando hay exactamente una ecuación registrada en
+        la tabla lateral ``equations``. Con 0 o >1 ecuaciones, la metadata se
+        omite silenciosamente aquí (no se inventa un hash no verificable);
+        ``build_equation_metadata`` sigue disponible para que el punto de
+        consumo real (p. ej. el comando de export) emita el ``warning``
+        accionable al usuario en el momento en que corresponde — no en cada
+        llamada interna de ``to_arrow()`` del pipeline (que ocurre docenas de
+        veces por invocación y no es un evento visible al usuario).
+
         Returns:
-            Tabla Arrow con el schema canónico del Corpus (sin ``_seq``).
+            Tabla Arrow con el schema canónico del Corpus (sin ``_seq``), con
+            la metadata de schema poblada (o no) según la regla de D3.
         """
         table = _arrow_table_from_con(self._con)
         validate_table(table)
+        metadata, _warning = build_equation_metadata(self.load_equations())
+        if metadata:
+            table = table.replace_schema_metadata(metadata)
         return table
 
     def add_paper(self, row: dict[str, object]) -> DuckDBBackend:
@@ -1093,6 +1152,77 @@ class DuckDBBackend:
             {
                 "name": r[0],
                 "params": json.loads(r[1]),
+            }
+            for r in rows
+        ]
+
+    # Extensiones propias: equations (ADR 0050 D1)
+
+    def persist_equation(
+        self,
+        equation_id: str,
+        *,
+        engine: str,
+        raw_query: str,
+        params_json: str,
+        label: str | None = None,
+        created_at: str | None = None,
+    ) -> None:
+        """Persiste (upsert) una ecuación en la tabla lateral ``equations``.
+
+        Idempotente vía ``INSERT OR REPLACE`` por ``equation_id`` (PK):
+        re-escribir la misma ecuación reemplaza la fila sin duplicar.  El
+        ``_seq`` se asigna solo la primera vez (orden de primera aparición);
+        un re-persist del mismo ``equation_id`` conserva su ``_seq`` original.
+
+        Args:
+            equation_id: PK de la ecuación.
+            engine: Motor que ejecutó la búsqueda.
+            raw_query: Ecuación cruda tal como la escribió el usuario.
+            params_json: JSON string con los parámetros de la ecuación.
+            label: Etiqueta humana opcional.
+            created_at: Timestamp ISO8601 UTC.  Si es ``None``, se usa
+                ``datetime.now(UTC)`` como fallback.
+        """
+        resolved_at = (
+            created_at if created_at is not None else datetime.now(UTC).isoformat()
+        )
+        existing = self._con.execute(
+            "SELECT _seq FROM equations WHERE equation_id = ?", [equation_id]
+        ).fetchone()
+        if existing is not None:
+            seq = existing[0]
+        else:
+            result = self._con.execute(
+                "SELECT COALESCE(MAX(_seq), 0) FROM equations"
+            ).fetchone()
+            seq = int(result[0]) + 1 if result else 1
+        self._con.execute(
+            "INSERT OR REPLACE INTO equations "
+            "(equation_id, engine, raw_query, params_json, label, created_at, _seq) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            [equation_id, engine, raw_query, params_json, label, resolved_at, seq],
+        )
+
+    def load_equations(self) -> list[dict[str, object]]:
+        """Devuelve todas las ecuaciones persistidas, en orden de inserción.
+
+        Returns:
+            Lista de dicts con las claves ``equation_id``, ``engine``,
+            ``raw_query``, ``params_json``, ``label``, ``created_at``.
+        """
+        rows = self._con.execute(
+            "SELECT equation_id, engine, raw_query, params_json, label, created_at "
+            "FROM equations ORDER BY _seq"
+        ).fetchall()
+        return [
+            {
+                "equation_id": r[0],
+                "engine": r[1],
+                "raw_query": r[2],
+                "params_json": r[3],
+                "label": r[4],
+                "created_at": r[5],
             }
             for r in rows
         ]

--- a/src/bib2graph/backends/memory.py
+++ b/src/bib2graph/backends/memory.py
@@ -24,6 +24,14 @@ R2 (ADR 0017 enmendado):
   ``clock: Callable`` porque (a) simplifica la firma, (b) los tests
   inyectan el timestamp exacto sin construir closures, y (c) mantiene
   ergonomía para uso como librería (sin argumento → fallback razonable).
+
+ADR 0050 (D1/D3):
+- ``build_equation_metadata``: helper puro compartido por ``InMemoryBackend``
+  y ``DuckDBBackend`` para poblar la metadata de schema Arrow en
+  ``to_arrow()`` (``equation_hash``/``equation_hash_algo``/
+  ``equation_expression``/``equation_id``). Política congelada: 1 ecuación
+  → metadata presente; 0 o >1 → metadata ausente + warning (no mentir un
+  hash que Atalaya no podría verificar).
 """
 
 from __future__ import annotations
@@ -91,6 +99,54 @@ def compute_corpus_hash(table: pa.Table) -> str:
         normalized.append(norm_row)
     serialized = json.dumps(normalized, sort_keys=True, ensure_ascii=False, default=str)
     return hashlib.sha256(serialized.encode()).hexdigest()
+
+
+def build_equation_metadata(
+    equations: list[dict[str, object]],
+) -> tuple[dict[bytes, bytes], str | None]:
+    """Construye la metadata de schema Arrow para ``equation_hash`` (ADR 0050 D3).
+
+    Regla congelada (resolución del PO, 2026-07-25): exactamente **una**
+    ecuación en la tabla lateral ``equations`` → la metadata incluye
+    ``equation_hash``/``equation_hash_algo``/``equation_expression``/
+    ``equation_id``. **Cero o múltiples** ecuaciones → la metadata se omite
+    por completo y se devuelve un ``warning`` (nunca se inventa un hash que
+    Atalaya no podría verificar).
+
+    Normalización EXACTA del hash (contrato con Atalaya, su ADR 0008):
+    ``sha256(raw_query.strip().encode("utf-8")).hexdigest()``. Solo
+    ``str.strip()`` — nada de lower/NFC/colapsar espacios internos.
+
+    Args:
+        equations: Filas de la tabla lateral ``equations`` (cada dict con
+            al menos las claves ``equation_id`` y ``raw_query``).
+
+    Returns:
+        Tupla ``(metadata, warning)``: ``metadata`` es un dict ``bytes→bytes``
+        listo para ``pa.schema(...).with_metadata(...)`` (vacío si no aplica
+        la regla de 1 ecuación); ``warning`` es un mensaje accionable cuando
+        la metadata se omitió, o ``None`` cuando se pobló.
+    """
+    if len(equations) != 1:
+        warning = (
+            f"equation_hash omitido: el corpus tiene {len(equations)} ecuación(es) "
+            "registrada(s) en la tabla 'equations' (se requiere exactamente 1 para "
+            "emitir un equation_hash verificable)."
+        )
+        return {}, warning
+
+    eq = equations[0]
+    raw_query = str(eq.get("raw_query") or "")
+    equation_id = str(eq.get("equation_id") or "")
+    normalized = raw_query.strip()
+    equation_hash = hashlib.sha256(normalized.encode("utf-8")).hexdigest()
+    metadata = {
+        b"equation_hash": equation_hash.encode("utf-8"),
+        b"equation_hash_algo": b"sha256",
+        b"equation_expression": raw_query.encode("utf-8"),
+        b"equation_id": equation_id.encode("utf-8"),
+    }
+    return metadata, None
 
 
 def _parse_provenance(provenance_json: str | None) -> list[dict[str, object]]:
@@ -360,6 +416,7 @@ class InMemoryBackend:
         *,
         referenced_refs: list[str] | None = None,
         external_ids: dict[tuple[str, str], str] | None = None,
+        equations: list[dict[str, object]] | None = None,
     ) -> None:
         """Constructor interno.
 
@@ -372,24 +429,43 @@ class InMemoryBackend:
             external_ids: Diccionario ``{(paper_id, engine): id}`` con los IDs
                 externos registrados (ADR 0036 opción C).  Lateral al corpus:
                 no entra en CORPUS_SCHEMA ni en corpus_hash.
+            equations: Lista de dicts de la tabla lateral ``equations``
+                (ADR 0050 D1).  Lateral al corpus: no entra en CORPUS_SCHEMA
+                ni en corpus_hash.
         """
         self._table = table
         # #54: IDs backward observados, en orden de inserción, sin duplicados.
         self._referenced_refs: list[str] = list(referenced_refs or [])
         # ADR 0036: IDs externos por (paper_id, engine).  PK lógica (paper_id, engine).
         self._external_ids: dict[tuple[str, str], str] = dict(external_ids or {})
+        # ADR 0050 (D1): ecuaciones persistidas, en orden de inserción; PK equation_id.
+        self._equations: list[dict[str, object]] = list(equations or [])
 
     # ------------------------------------------------------------------
     # TabularBackend protocol
     # ------------------------------------------------------------------
 
     def to_arrow(self) -> pa.Table:
-        """Devuelve la tabla Arrow interna.
+        """Devuelve la tabla Arrow interna, con metadata de ecuación (ADR 0050 D3).
+
+        Puebla la metadata del schema Arrow con ``equation_hash`` cuando hay
+        exactamente una ecuación registrada en la tabla lateral ``equations``.
+        Con 0 o >1 ecuaciones, la metadata se omite silenciosamente aquí (no
+        se inventa un hash no verificable); ``build_equation_metadata`` sigue
+        disponible para que el punto de consumo real (p. ej. el comando de
+        export) emita el ``warning`` accionable al usuario en el momento en
+        que corresponde — no en cada llamada interna de ``to_arrow()`` del
+        pipeline (que ocurre docenas de veces por invocación y no es un
+        evento visible al usuario).
 
         Returns:
-            Tabla Arrow con el schema canónico.
+            Tabla Arrow con el schema canónico y la metadata de schema
+            poblada (o no) según la regla de D3.
         """
-        return self._table
+        metadata, _warning = build_equation_metadata(self._equations)
+        if not metadata:
+            return self._table
+        return self._table.replace_schema_metadata(metadata)
 
     def add_paper(self, row: dict[str, object]) -> InMemoryBackend:
         """Agrega una fila al backend y devuelve una nueva instancia.
@@ -406,6 +482,7 @@ class InMemoryBackend:
             _rows_to_table(existing),
             referenced_refs=self._referenced_refs,
             external_ids=self._external_ids,
+            equations=self._equations,
         )
 
     def merge(self, other_table: pa.Table) -> InMemoryBackend:
@@ -445,6 +522,7 @@ class InMemoryBackend:
             _rows_to_table(result_rows),
             referenced_refs=self._referenced_refs,
             external_ids=self._external_ids,
+            equations=self._equations,
         )
 
     def apply_curation(
@@ -480,6 +558,7 @@ class InMemoryBackend:
             _rows_to_table(updated),
             referenced_refs=self._referenced_refs,
             external_ids=self._external_ids,
+            equations=self._equations,
         )
 
     def filter_view(self, view: Literal["seeds", "candidates", "accepted"]) -> pa.Table:
@@ -609,3 +688,54 @@ class InMemoryBackend:
             (pid, engine, ext_id)
             for (pid, engine), ext_id in self._external_ids.items()
         ]
+
+    # Extensiones: equations (ADR 0050 D1)
+
+    def persist_equation(
+        self,
+        equation_id: str,
+        *,
+        engine: str,
+        raw_query: str,
+        params_json: str,
+        label: str | None = None,
+        created_at: str | None = None,
+    ) -> None:
+        """Persiste (upsert) una ecuación en la tabla lateral en memoria.
+
+        Idempotente: si ``equation_id`` ya existe, reemplaza la fila
+        (misma posición en la lista, preserva el orden de primera aparición).
+
+        Args:
+            equation_id: PK de la ecuación.
+            engine: Motor que ejecutó la búsqueda.
+            raw_query: Ecuación cruda tal como la escribió el usuario.
+            params_json: JSON string con los parámetros de la ecuación.
+            label: Etiqueta humana opcional.
+            created_at: Timestamp ISO8601 UTC.  Si es ``None``, se usa
+                ``datetime.now(UTC)`` como fallback.
+        """
+        resolved_at = (
+            created_at if created_at is not None else datetime.now(UTC).isoformat()
+        )
+        row: dict[str, object] = {
+            "equation_id": equation_id,
+            "engine": engine,
+            "raw_query": raw_query,
+            "params_json": params_json,
+            "label": label,
+            "created_at": resolved_at,
+        }
+        for i, existing in enumerate(self._equations):
+            if existing.get("equation_id") == equation_id:
+                self._equations[i] = row
+                return
+        self._equations.append(row)
+
+    def load_equations(self) -> list[dict[str, object]]:
+        """Devuelve todas las ecuaciones persistidas, en orden de inserción.
+
+        Returns:
+            Lista de dicts (copia defensiva) con las ecuaciones registradas.
+        """
+        return [dict(eq) for eq in self._equations]

--- a/src/bib2graph/backends/memory.py
+++ b/src/bib2graph/backends/memory.py
@@ -31,7 +31,7 @@ ADR 0050 (D1/D3):
   ``to_arrow()`` (``equation_hash``/``equation_hash_algo``/
   ``equation_expression``/``equation_id``). Política congelada: 1 ecuación
   → metadata presente; 0 o >1 → metadata ausente + warning (no mentir un
-  hash que Atalaya no podría verificar).
+  hash que el consumidor programático no podría verificar).
 """
 
 from __future__ import annotations
@@ -111,9 +111,9 @@ def build_equation_metadata(
     ``equation_hash``/``equation_hash_algo``/``equation_expression``/
     ``equation_id``. **Cero o múltiples** ecuaciones → la metadata se omite
     por completo y se devuelve un ``warning`` (nunca se inventa un hash que
-    Atalaya no podría verificar).
+    el consumidor programático no podría verificar).
 
-    Normalización EXACTA del hash (contrato con Atalaya, su ADR 0008):
+    Normalización EXACTA del hash (contrato de verificación del consumidor):
     ``sha256(raw_query.strip().encode("utf-8")).hexdigest()``. Solo
     ``str.strip()`` — nada de lower/NFC/colapsar espacios internos.
 

--- a/src/bib2graph/cli/commands/seed.py
+++ b/src/bib2graph/cli/commands/seed.py
@@ -22,6 +22,7 @@ Para cargar un corpus curado desde un parquet sin red, usá ``b2g snapshot resto
 
 from __future__ import annotations
 
+import json
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -145,6 +146,18 @@ def run_seed(
         merged_backend_close = getattr(merged._backend, "close", None)
         store.persist_replace(merged_deduped)
         store.backend.set_loop_state(new_state, cycle_round=new_round)
+
+        # ADR 0050 (D1): persistir la ecuación en la tabla lateral ``equations``
+        # de la biblioteca viva (antes solo se sellaba en el manifest del
+        # snapshot; ver `Corpus.snapshot`). Idempotente por `equation_id` (PK).
+        for eq_ref in result.corpus.manifest.equations:
+            store.backend.persist_equation(
+                eq_ref.equation_id,
+                engine=eq_ref.engine or "openalex",
+                raw_query=str(eq_ref.params.get("raw_query", equation)),
+                params_json=json.dumps(eq_ref.params, ensure_ascii=False),
+                created_at=eq_ref.created_at,
+            )
     finally:
         # Ver run_seed_from_bib: cierra explícitamente las conexiones DuckDB
         # para evitar segfault en Linux ante llamadas consecutivas al mismo archivo.

--- a/src/bib2graph/corpus.py
+++ b/src/bib2graph/corpus.py
@@ -124,11 +124,34 @@ def _rows_with_ids(rows: list[dict[str, object]]) -> list[dict[str, object]]:
 
 
 class EquationRef(BaseModel):
-    """Referencia a una ecuación de búsqueda ejecutada."""
+    """Referencia a una ecuación de búsqueda ejecutada.
+
+    ADR 0050 (D1): se extiende con ``engine``/``params``/``created_at`` para
+    persistirse en la tabla lateral ``equations`` del store vivo (no solo
+    sellarse en el ``Manifest`` del snapshot). ``query`` sigue siendo la
+    query EJECUTADA (traducida) por retrocompat con el uso histórico de este
+    campo; la ecuación CRUDA vive en ``params["raw_query"]`` (superconjunto,
+    ver ``params_json`` de la tabla ``equations``).
+
+    Fields:
+        equation_id: PK, formato ``eq-<YYYYMMDDTHHMMSS>`` (seed).
+        query: Query ejecutada (traducida) — campo histórico.
+        translation_report: Reporte de traducción (histórico).
+        engine: Motor que ejecutó la búsqueda (``'openalex'``; futuro
+            ``'s2'``/``'crossref'``). ``None`` si no aplica (compat).
+        params: Superconjunto de parámetros de la ecuación — incluye
+            ``raw_query``, ``exclude``, ``max_results``, ``native``,
+            ``min_year``, ``max_year``, ``executed_query``. Vacío por
+            defecto (compat con construcciones existentes).
+        created_at: Sello ISO8601 UTC de creación de la ecuación, o ``None``.
+    """
 
     equation_id: str
     query: str
     translation_report: list[str] = Field(default_factory=list)
+    engine: str | None = None
+    params: dict[str, object] = Field(default_factory=dict)
+    created_at: str | None = None
 
 
 class ChainingParams(BaseModel):

--- a/src/bib2graph/sources/openalex.py
+++ b/src/bib2graph/sources/openalex.py
@@ -544,7 +544,8 @@ class OpenAlexSource:
             query, native=native, exclude=exclude, min_year=min_year, max_year=max_year
         )
         equation_id = f"eq-{datetime.now(UTC).strftime('%Y%m%dT%H%M%S')}"
-        fetched_at = datetime.now(UTC).isoformat()
+        created_at = datetime.now(UTC).isoformat()
+        fetched_at = created_at
 
         # #287 fricción #3: seed reintenta ante 429/5xx con backoff (mismo camino
         # que el forward chaining).  Sin esto, cada 429 obligaba al agente a un
@@ -568,7 +569,22 @@ class OpenAlexSource:
             )
         corpus = Corpus.from_arrow(table)
 
-        # Actualizar Manifest con openalex_version y ecuación (ADR 0017)
+        # Actualizar Manifest con openalex_version y ecuación (ADR 0017; D1 ADR 0050)
+        # ``params`` es el superconjunto de parámetros de la ecuación (ADR 0050 D1):
+        # ``raw_query`` es la ecuación CRUDA (``query``, el argumento del usuario,
+        # ANTES de traducir) — es lo que Atalaya confirma y hashea (D3). La
+        # ``executed_query`` (traducida a filtros OpenAlex) queda en params para
+        # auditoría, no para el hash (ver ADR 0050 §Alternativas descartadas).
+        equation_params: dict[str, object] = {
+            "raw_query": query,
+            "exclude": exclude or [],
+            "max_results": self._max_results,
+            "native": native,
+            "min_year": min_year,
+            "max_year": max_year,
+            "executed_query": executed_query,
+            "translation_report": translation_report,
+        }
         updated_manifest = corpus.manifest.model_copy(
             update={
                 "openalex_version": openalex_version,
@@ -577,6 +593,9 @@ class OpenAlexSource:
                         equation_id=equation_id,
                         query=executed_query,
                         translation_report=translation_report,
+                        engine="openalex",
+                        params=equation_params,
+                        created_at=created_at,
                     )
                 ],
             }

--- a/src/bib2graph/sources/openalex.py
+++ b/src/bib2graph/sources/openalex.py
@@ -572,7 +572,7 @@ class OpenAlexSource:
         # Actualizar Manifest con openalex_version y ecuación (ADR 0017; D1 ADR 0050)
         # ``params`` es el superconjunto de parámetros de la ecuación (ADR 0050 D1):
         # ``raw_query`` es la ecuación CRUDA (``query``, el argumento del usuario,
-        # ANTES de traducir) — es lo que Atalaya confirma y hashea (D3). La
+        # ANTES de traducir) — es lo que el consumidor programático confirma y hashea (D3). La
         # ``executed_query`` (traducida a filtros OpenAlex) queda en params para
         # auditoría, no para el hash (ver ADR 0050 §Alternativas descartadas).
         equation_params: dict[str, object] = {

--- a/tests/unit/test_backends.py
+++ b/tests/unit/test_backends.py
@@ -427,3 +427,88 @@ def test_merge_solapado_preserva_hash_y_orden(backend_factory: BackendFactory) -
 
     ref_backend = InMemoryBackend(table_self).merge(table_other)
     assert merged.corpus_hash() == ref_backend.corpus_hash()
+
+
+# ---------------------------------------------------------------------------
+# ADR 0050 (D1) — tabla lateral ``equations`` de 1ª clase + FK
+# ---------------------------------------------------------------------------
+
+
+def test_persist_equation_y_load_equations(backend_factory: BackendFactory) -> None:
+    """``persist_equation`` + ``load_equations`` — round-trip básico."""
+    backend = backend_factory(_make_table([_make_row(id="oa:aaaabbbb11112222")]))
+
+    backend.persist_equation(
+        "eq-20260719T220850",
+        engine="openalex",
+        raw_query='"unequal exchange" OR "ecological debt"',
+        params_json='{"max_results": 150}',
+        label="mi-busqueda",
+        created_at="2026-07-19T22:08:50+00:00",
+    )
+
+    equations = backend.load_equations()
+    assert len(equations) == 1
+    eq = equations[0]
+    assert eq["equation_id"] == "eq-20260719T220850"
+    assert eq["engine"] == "openalex"
+    assert eq["raw_query"] == '"unequal exchange" OR "ecological debt"'
+    assert eq["params_json"] == '{"max_results": 150}'
+    assert eq["label"] == "mi-busqueda"
+    assert eq["created_at"] == "2026-07-19T22:08:50+00:00"
+
+
+def test_persist_equation_es_idempotente_por_pk(
+    backend_factory: BackendFactory,
+) -> None:
+    """Re-persistir el mismo ``equation_id`` reemplaza la fila (upsert), no duplica."""
+    backend = backend_factory(_make_table([_make_row(id="oa:aaaabbbb11112222")]))
+
+    backend.persist_equation(
+        "eq-1", engine="openalex", raw_query="query original", params_json="{}"
+    )
+    backend.persist_equation(
+        "eq-1", engine="openalex", raw_query="query actualizada", params_json="{}"
+    )
+
+    equations = backend.load_equations()
+    assert len(equations) == 1
+    assert equations[0]["raw_query"] == "query actualizada"
+
+
+def test_load_equations_multiples_preserva_orden(
+    backend_factory: BackendFactory,
+) -> None:
+    """Varias ecuaciones se listan en orden de primera aparición (PK equation_id)."""
+    backend = backend_factory(_make_table([_make_row(id="oa:aaaabbbb11112222")]))
+
+    backend.persist_equation("eq-1", engine="openalex", raw_query="a", params_json="{}")
+    backend.persist_equation("eq-2", engine="openalex", raw_query="b", params_json="{}")
+    backend.persist_equation("eq-3", engine="openalex", raw_query="c", params_json="{}")
+
+    equations = backend.load_equations()
+    assert [e["equation_id"] for e in equations] == ["eq-1", "eq-2", "eq-3"]
+
+
+def test_load_equations_vacio_sin_ecuaciones(backend_factory: BackendFactory) -> None:
+    """Sin ecuaciones persistidas, ``load_equations`` devuelve lista vacía."""
+    backend = backend_factory(_make_table([_make_row(id="oa:aaaabbbb11112222")]))
+
+    assert backend.load_equations() == []
+
+
+def test_equations_no_afecta_corpus_hash(backend_factory: BackendFactory) -> None:
+    """La tabla lateral ``equations`` no participa de ``corpus_hash`` (R2, ADR 0017).
+
+    Persistir una ecuación no debe cambiar el hash de contenido: es lateral,
+    igual que ``external_ids``/``referenced_but_not_fetched``.
+    """
+    table = _make_table([_make_row(id="oa:aaaabbbb11112222")])
+    backend = backend_factory(table)
+    hash_before = backend.corpus_hash()
+
+    backend.persist_equation(
+        "eq-1", engine="openalex", raw_query="ecolog*", params_json="{}"
+    )
+
+    assert backend.corpus_hash() == hash_before

--- a/tests/unit/test_equation_metadata.py
+++ b/tests/unit/test_equation_metadata.py
@@ -80,7 +80,7 @@ def test_build_equation_metadata_hash_correcto_una_ecuacion() -> None:
 @pytest.mark.unit
 def test_build_equation_metadata_strip_puro_no_colapsa_espacios_internos() -> None:
     """Normalización EXACTA: solo ``strip()`` — espacios al borde se eliminan,
-    los internos NO se colapsan (contrato bit a bit con Atalaya ADR 0008)."""
+    los internos NO se colapsan (contrato bit a bit con el consumidor programático)."""
     raw_query = "   ecological   debt   "
     expected_hash = hashlib.sha256(b"ecological   debt").hexdigest()
 
@@ -200,7 +200,7 @@ def test_to_arrow_no_altera_columnas_del_schema_canonico(
     backend_factory: BackendFactory,
 ) -> None:
     """La metadata es ADITIVA: las columnas/tipos de CORPUS_SCHEMA no cambian
-    (constraint duro de Atalaya, ADR 0050 §Constraints — agregar sí, renombrar/
+    (constraint duro del consumidor programático, ADR 0050 §Constraints — agregar sí, renombrar/
     estrechar/re-tipar NO)."""
     backend = backend_factory(_empty_table())
     backend.persist_equation("eq-1", engine="openalex", raw_query="a", params_json="{}")

--- a/tests/unit/test_equation_metadata.py
+++ b/tests/unit/test_equation_metadata.py
@@ -1,0 +1,266 @@
+"""Tests de ``equation_hash`` en la metadata de schema Arrow (ADR 0050 D3).
+
+Cubre:
+- ``build_equation_metadata`` (función pura, helper compartido por
+  ``InMemoryBackend``/``DuckDBBackend``): 1 ecuación → metadata correcta
+  (hash verificado a mano); 0 o >1 ecuaciones → metadata ausente + warning.
+- ``to_arrow()`` de ambos backends: la metadata viaja en el schema de la
+  tabla exportada.
+- ``corpus_hash`` NO cambia por la presencia de la tabla lateral
+  ``equations`` (R2, ADR 0013/0017: identidad = contenido, no procedencia;
+  la tabla lateral no participa de la identidad del corpus).
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Callable
+from typing import Any
+
+import pyarrow as pa
+import pytest
+
+from bib2graph.backends import InMemoryBackend, TabularBackend
+from bib2graph.backends.duckdb import DuckDBBackend
+from bib2graph.backends.memory import build_equation_metadata
+from bib2graph.schemas import CORPUS_SCHEMA
+
+BackendFactory = Callable[[pa.Table], TabularBackend]
+
+
+@pytest.fixture(
+    params=[
+        pytest.param(lambda t: InMemoryBackend(t), id="memory", marks=pytest.mark.unit),
+        pytest.param(
+            lambda t: DuckDBBackend(t), id="duckdb", marks=pytest.mark.integration
+        ),
+    ]
+)
+def backend_factory(request: pytest.FixtureRequest) -> BackendFactory:
+    """Devuelve una factory ``pa.Table → TabularBackend`` según el parámetro."""
+    factory: BackendFactory = request.param
+    return factory
+
+
+def _empty_table() -> pa.Table:
+    return pa.table({col: [] for col in CORPUS_SCHEMA.names}, schema=CORPUS_SCHEMA)
+
+
+# ---------------------------------------------------------------------------
+# build_equation_metadata — función pura
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_build_equation_metadata_hash_correcto_una_ecuacion() -> None:
+    """1 ecuación → metadata con equation_hash = sha256(raw_query.strip()) exacto."""
+    raw_query = '"unequal ecological exchange" OR "ecologically unequal exchange"'
+    expected_hash = hashlib.sha256(raw_query.strip().encode("utf-8")).hexdigest()
+
+    metadata, warning = build_equation_metadata(
+        [
+            {
+                "equation_id": "eq-20260719T220850",
+                "engine": "openalex",
+                "raw_query": raw_query,
+                "params_json": "{}",
+                "label": None,
+                "created_at": "2026-07-19T22:08:50+00:00",
+            }
+        ]
+    )
+
+    assert warning is None
+    assert metadata[b"equation_hash"] == expected_hash.encode("utf-8")
+    assert metadata[b"equation_hash_algo"] == b"sha256"
+    assert metadata[b"equation_expression"] == raw_query.encode("utf-8")
+    assert metadata[b"equation_id"] == b"eq-20260719T220850"
+
+
+@pytest.mark.unit
+def test_build_equation_metadata_strip_puro_no_colapsa_espacios_internos() -> None:
+    """Normalización EXACTA: solo ``strip()`` — espacios al borde se eliminan,
+    los internos NO se colapsan (contrato bit a bit con Atalaya ADR 0008)."""
+    raw_query = "   ecological   debt   "
+    expected_hash = hashlib.sha256(b"ecological   debt").hexdigest()
+
+    metadata, warning = build_equation_metadata(
+        [
+            {
+                "equation_id": "eq-1",
+                "engine": "openalex",
+                "raw_query": raw_query,
+                "params_json": "{}",
+                "label": None,
+                "created_at": None,
+            }
+        ]
+    )
+
+    assert warning is None
+    assert metadata[b"equation_hash"] == expected_hash.encode("utf-8")
+    # equation_expression conserva la ecuación CRUDA (sin strip), para trazabilidad.
+    assert metadata[b"equation_expression"] == raw_query.encode("utf-8")
+
+
+@pytest.mark.unit
+def test_build_equation_metadata_cero_ecuaciones_omite_y_advierte() -> None:
+    """0 ecuaciones → metadata vacía + warning (no se inventa un hash)."""
+    metadata, warning = build_equation_metadata([])
+
+    assert metadata == {}
+    assert warning is not None
+    assert "0 ecuaci" in warning
+
+
+@pytest.mark.unit
+def test_build_equation_metadata_multiples_ecuaciones_omite_y_advierte() -> None:
+    """>1 ecuaciones → metadata vacía + warning (no se puede elegir una sola)."""
+    equations = [
+        {
+            "equation_id": "eq-1",
+            "engine": "openalex",
+            "raw_query": "a",
+            "params_json": "{}",
+            "label": None,
+            "created_at": None,
+        },
+        {
+            "equation_id": "eq-2",
+            "engine": "openalex",
+            "raw_query": "b",
+            "params_json": "{}",
+            "label": None,
+            "created_at": None,
+        },
+    ]
+
+    metadata, warning = build_equation_metadata(equations)
+
+    assert metadata == {}
+    assert warning is not None
+    assert "2 ecuaci" in warning
+
+
+# ---------------------------------------------------------------------------
+# to_arrow() — paridad entre backends
+# ---------------------------------------------------------------------------
+
+
+def test_to_arrow_una_ecuacion_metadata_presente(
+    backend_factory: BackendFactory,
+) -> None:
+    """``to_arrow()`` de un corpus con 1 ecuación trae ``equation_hash`` correcto."""
+    raw_query = "  unequal exchange  "
+    expected_hash = hashlib.sha256(raw_query.strip().encode("utf-8")).hexdigest()
+
+    backend = backend_factory(_empty_table())
+    backend.persist_equation(
+        "eq-20260719T220850",
+        engine="openalex",
+        raw_query=raw_query,
+        params_json='{"max_results": 150}',
+    )
+
+    table = backend.to_arrow()
+    metadata: dict[bytes, bytes] = table.schema.metadata or {}
+
+    assert metadata.get(b"equation_hash") == expected_hash.encode("utf-8")
+    assert metadata.get(b"equation_hash_algo") == b"sha256"
+    assert metadata.get(b"equation_id") == b"eq-20260719T220850"
+
+
+def test_to_arrow_cero_ecuaciones_metadata_ausente(
+    backend_factory: BackendFactory,
+) -> None:
+    """``to_arrow()`` sin ecuaciones NO trae ``equation_hash`` en la metadata."""
+    backend = backend_factory(_empty_table())
+
+    table = backend.to_arrow()
+    metadata: dict[bytes, bytes] = table.schema.metadata or {}
+
+    assert b"equation_hash" not in metadata
+
+
+def test_to_arrow_multiples_ecuaciones_metadata_ausente(
+    backend_factory: BackendFactory,
+) -> None:
+    """``to_arrow()`` con >1 ecuaciones NO trae ``equation_hash`` (no mentir un hash)."""
+    backend = backend_factory(_empty_table())
+    backend.persist_equation("eq-1", engine="openalex", raw_query="a", params_json="{}")
+    backend.persist_equation("eq-2", engine="openalex", raw_query="b", params_json="{}")
+
+    table = backend.to_arrow()
+    metadata: dict[bytes, bytes] = table.schema.metadata or {}
+
+    assert b"equation_hash" not in metadata
+
+
+def test_to_arrow_no_altera_columnas_del_schema_canonico(
+    backend_factory: BackendFactory,
+) -> None:
+    """La metadata es ADITIVA: las columnas/tipos de CORPUS_SCHEMA no cambian
+    (constraint duro de Atalaya, ADR 0050 §Constraints — agregar sí, renombrar/
+    estrechar/re-tipar NO)."""
+    backend = backend_factory(_empty_table())
+    backend.persist_equation("eq-1", engine="openalex", raw_query="a", params_json="{}")
+
+    table = backend.to_arrow()
+
+    assert table.schema.names == CORPUS_SCHEMA.names
+    for expected_field, actual_field in zip(CORPUS_SCHEMA, table.schema, strict=True):
+        assert actual_field.type.equals(expected_field.type)
+        assert actual_field.nullable == expected_field.nullable
+
+
+# ---------------------------------------------------------------------------
+# corpus_hash — R2: la tabla lateral no participa de la identidad
+# ---------------------------------------------------------------------------
+
+
+def test_corpus_hash_no_cambia_con_tabla_equations(
+    backend_factory: BackendFactory,
+) -> None:
+    """``corpus_hash`` es idéntico con y sin ecuaciones persistidas (R2, ADR 0017).
+
+    La identidad del corpus es del contenido bibliográfico; la tabla lateral
+    ``equations`` (como ``external_ids``/``referenced_but_not_fetched``) es
+    procedencia/metadata operativa, no contenido.
+    """
+    row: dict[str, Any] = {
+        "id": "oa:aaaabbbb11112222",
+        "source_id": None,
+        "doi": None,
+        "title": "Título de prueba",
+        "year": 2020,
+        "abstract": None,
+        "source": None,
+        "language": None,
+        "publisher": None,
+        "research_areas": None,
+        "is_seed": True,
+        "curation_status": "candidate",
+        "provenance": None,
+        "authors_raw": None,
+        "authors_id": None,
+        "authors_affiliations": None,
+        "keywords_raw": None,
+        "keywords_id": None,
+        "institutions_raw": None,
+        "institutions_id": None,
+        "references_id": None,
+        "references_doi": None,
+        "cited_by_id": None,
+    }
+    table = pa.Table.from_pylist([row], schema=CORPUS_SCHEMA)
+
+    backend_a = backend_factory(table)
+    hash_sin_ecuacion = backend_a.corpus_hash()
+
+    backend_b = backend_factory(table)
+    backend_b.persist_equation(
+        "eq-1", engine="openalex", raw_query="ecolog*", params_json="{}"
+    )
+    hash_con_ecuacion = backend_b.corpus_hash()
+
+    assert hash_sin_ecuacion == hash_con_ecuacion

--- a/tests/unit/test_equations_persist_seed.py
+++ b/tests/unit/test_equations_persist_seed.py
@@ -86,8 +86,9 @@ def test_run_seed_persiste_ecuacion_en_tabla_lateral(tmp_path: Path) -> None:
 def test_run_seed_equation_hash_reproducible_desde_raw_query(tmp_path: Path) -> None:
     """El ``equation_hash`` de ``to_arrow()`` es reproducible desde la ecuación cruda.
 
-    Cierra el contrato Atalaya (ADR 0008): Atalaya recomputa el hash desde la
-    ecuación confirmada por el usuario y lo compara con el embebido en el Arrow.
+    Cierra el contrato de verificación del consumidor: el consumidor programático
+    recomputa el hash desde la ecuación confirmada por el usuario y lo compara con
+    el embebido en el Arrow.
     """
     from bib2graph.cli.commands.seed import run_seed
     from bib2graph.stores.duckdb import DuckDBStore

--- a/tests/unit/test_equations_persist_seed.py
+++ b/tests/unit/test_equations_persist_seed.py
@@ -1,0 +1,142 @@
+"""Tests de persistencia de la ecuación en la tabla lateral ``equations`` (#291/#292, ADR 0050 D1).
+
+Cubre que ``run_seed`` (OpenAlex, ``sources/openalex.py``) persiste la
+ecuación en la tabla lateral ``equations`` del store vivo — no solo la sella
+en el ``Manifest`` del snapshot (que hoy se pierde tras ``merge``, ver
+ADR 0050 §Contexto punto 1).
+
+Marcador: ``unit`` (DuckDB en tmp_path, transport mockeado, sin red real).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+
+pytestmark = pytest.mark.unit
+
+SAMPLE_WORKS: list[dict[str, Any]] = json.loads(
+    (Path(__file__).parent.parent / "fixtures" / "sample_works.json").read_text(
+        encoding="utf-8"
+    )
+)
+
+
+def _make_mock_transport(
+    works: list[dict[str, Any]] | None = None,
+) -> httpx.MockTransport:
+    """MockTransport que responde con los works dados (1 página + EOF)."""
+    if works is None:
+        works = SAMPLE_WORKS
+    calls: list[int] = [0]
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls[0] += 1
+        if calls[0] == 1:
+            body = {
+                "results": works,
+                "meta": {"count": len(works), "next_cursor": None},
+            }
+        else:
+            body = {"results": [], "meta": {"count": 0, "next_cursor": None}}
+        return httpx.Response(
+            200,
+            json=body,
+            headers={"x-openalex-api-version": "2026-06-17"},
+        )
+
+    return httpx.MockTransport(handler)
+
+
+def test_run_seed_persiste_ecuacion_en_tabla_lateral(tmp_path: Path) -> None:
+    """``run_seed`` persiste la ecuación cruda en ``store.backend.load_equations()``."""
+    from bib2graph.cli.commands.seed import run_seed
+    from bib2graph.stores.duckdb import DuckDBStore
+
+    transport = _make_mock_transport()
+    store_path = tmp_path / "test.duckdb"
+    raw_equation = "unequal exchange"
+
+    data = run_seed(store_path, raw_equation, transport=transport)
+
+    store = DuckDBStore(store_path)
+    try:
+        equations = store.backend.load_equations()
+    finally:
+        store.close()
+
+    assert len(equations) == 1
+    eq = equations[0]
+    assert eq["engine"] == "openalex"
+    # raw_query es la ecuación CRUDA (antes de traducir), no la ejecutada.
+    assert eq["raw_query"] == raw_equation
+    assert eq["raw_query"] != data["executed_query"]
+    params = json.loads(str(eq["params_json"]))
+    assert params["raw_query"] == raw_equation
+    assert params["executed_query"] == data["executed_query"]
+    assert eq["equation_id"].startswith("eq-")
+    assert eq["created_at"]
+
+
+def test_run_seed_equation_hash_reproducible_desde_raw_query(tmp_path: Path) -> None:
+    """El ``equation_hash`` de ``to_arrow()`` es reproducible desde la ecuación cruda.
+
+    Cierra el contrato Atalaya (ADR 0008): Atalaya recomputa el hash desde la
+    ecuación confirmada por el usuario y lo compara con el embebido en el Arrow.
+    """
+    from bib2graph.cli.commands.seed import run_seed
+    from bib2graph.stores.duckdb import DuckDBStore
+
+    transport = _make_mock_transport()
+    store_path = tmp_path / "test.duckdb"
+    raw_equation = "unequal exchange"
+    expected_hash = hashlib.sha256(raw_equation.strip().encode("utf-8")).hexdigest()
+
+    run_seed(store_path, raw_equation, transport=transport)
+
+    store = DuckDBStore(store_path)
+    try:
+        table = store.backend.to_arrow()
+    finally:
+        store.close()
+
+    metadata = table.schema.metadata or {}
+    assert metadata.get(b"equation_hash") == expected_hash.encode("utf-8")
+
+
+def test_run_seed_reseed_con_nueva_ecuacion_acumula_en_equations(
+    tmp_path: Path,
+) -> None:
+    """Dos ``run_seed`` (reseed) acumulan ecuaciones en la tabla lateral (no se pierden).
+
+    ``equation_id`` tiene precisión de segundo (``eq-<YYYYMMDDTHHMMSS>``): si
+    ambas siembras caen en el mismo segundo, coinciden por PK y la segunda
+    reemplaza (upsert) — no rompe la trazabilidad porque el ``raw_query`` de la
+    fila persistida siempre coincide con la ÚLTIMA siembra de ese segundo. El
+    invariante que importa es que NINGUNA ecuación se pierda en silencio:
+    al menos 1 fila, y su ``raw_query`` corresponde a una de las dos sembradas.
+    """
+    from bib2graph.cli.commands.seed import run_seed
+    from bib2graph.stores.duckdb import DuckDBStore
+
+    store_path = tmp_path / "test.duckdb"
+
+    run_seed(store_path, "ecology", transport=_make_mock_transport())
+    run_seed(store_path, "environmental justice", transport=_make_mock_transport())
+
+    store = DuckDBStore(store_path)
+    try:
+        equations = store.backend.load_equations()
+    finally:
+        store.close()
+
+    assert len(equations) >= 1
+    raw_queries = {eq["raw_query"] for eq in equations}
+    assert raw_queries <= {"ecology", "environmental justice"}
+    # La última ecuación sembrada siempre debe estar presente (nunca se pierde).
+    assert "environmental justice" in raw_queries


### PR DESCRIPTION
Cierra #291 (D1) y #292. Implementa D1 + D3 del ADR 0050. **Aditivo** — no toca columnas del Arrow.

## D1 — tabla `equations` de 1ª clase (#291)
- `TabularBackend` (Protocol) gana `persist_equation(...)` / `load_equations()`.
- `InMemoryBackend`: lista lateral `_equations` con upsert idempotente por `equation_id`, propagada en `add_paper`/`merge`/`apply_curation`.
- `DuckDBBackend`: tabla SQL `equations` (PK `equation_id`, `_seq` para orden), replicada en `_clone()`.
- `EquationRef` (vive en `corpus.py`, no `schemas.py`) extendida con `engine`/`params`/`created_at` (defaults retrocompatibles).
- `OpenAlexSource.seed()` puebla `params` con `raw_query` (ecuación cruda) + `executed_query`/`exclude`/`max_results`; `run_seed` persiste la ecuación en la biblioteca viva (cierra el gap: hoy `Manifest.equations` se perdía tras `merge`).

## D3 — `equation_hash` en metadata Arrow (#292)
- Función pura `build_equation_metadata(equations) -> (metadata, warning)`, usada por ambos `to_arrow()`.
- Normalización **exacta**: `sha256(raw_query.strip().encode("utf-8")).hexdigest()` — solo `strip()`.
- 1 ecuación → metadata (`equation_hash`/`_algo`/`_expression`/`_id`); 0 o >1 → omitida (warning como valor de retorno).

## Fuera de alcance (por diseño)
- **D2 (`source_kind`/`hop`) NO implementado** — diferido a 0.15.0; `chaining_hop` y overloads `chaining:*` intactos.
- No toca `export.py`/`exporters/` (#293). El warning de cara al usuario en el export queda para cablearse (llamar `build_equation_metadata` o leer `table.schema.metadata`).
- BibTeX no persiste ecuación (no tiene).

## Gate
ruff/format/mypy limpios; **1217 unit + 44 integration passed**. CI corre el completo.

## Para el architect
- `docs/API.md`: objeto `equations` + FK + metadata Arrow como contrato congelado.
- Nota: `EquationRef` vive en `corpus.py` (discrepancia menor con el ADR, que dice `schemas.py`).