### PR TITLE
fix(0.14.0): consolida QA + hallazgos arquitectónicos (equations round-trip completo, canal único de warnings)

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -65,8 +65,13 @@ en `bib2graph.cycle`), `transitions_available`, `curation_available` (`accept`/`
 disponibles, curación transversal), `round` (contador de ronda con `reseed`), conteos por
 `curation_status`, `workspace: {root, source}` (el bloque hoy es **universal** en los comandos del
 ciclo, ADR 0045 #259 — ver §Envelope), `networks_cache_stale: bool` (+ `warnings` accionable
-cuando la cache de `networks/` quedó obsoleta — avisa, NO regenera) y `referenced_not_fetched` (nº de
-IDs que el backward chaining observó sin materializar; §4/§5). Todos campos aditivos, `schema="1"`
+cuando la cache de `networks/` quedó obsoleta — avisa, NO regenera), `referenced_not_fetched` (nº de
+IDs que el backward chaining observó sin materializar; §4/§5) y **`equations`** (lista de las
+ecuaciones registradas en el store, leída de `backend.load_equations()`; QA 0.14.0 #2, ADR 0050 D1):
+cada entrada es `{equation_id, raw_query, engine, created_at}`; **siempre presente** (`[]` si no hay
+ecuaciones, sin romper). En modo humano se imprime la sección **"Ecuaciones registradas (N):"**. Así
+la procedencia deja de ser invisible (antes solo se veía en la metadata del `.arrow` exportado) **sin
+agregar un verbo** (es estado, no una acción — ADR 0037). Todos campos aditivos, `schema="1"`
 intacto. **`validate`** chequea la consistencia del workspace (read-only).
 
 **`init`** (ADR [0029](decisiones/0029-workspace-por-investigacion.md)): scaffold de un workspace.
@@ -242,10 +247,11 @@ build --scope`); si se pasa `--scope` explícito con un formato de red, `export`
 accionable (no error). `--scope` es propio de `export` — es distinto del `build --scope` de §build.
 
 **Envelope `--json`** (aditivo, `schema="1"` intacto): `data = {format, out_dir, files_written,
-warnings, workspace}` **más una clave según la familia** — **`rows_exported`** (nº de filas del corpus)
+workspace}` **más una clave según la familia** — **`rows_exported`** (nº de filas del corpus)
 para `arrow`/`bibtex`, **`networks_exported`** (nº de redes) para `graphml`/`csv`. **Son claves
-distintas, NO unificadas:** el consumidor sabe por cuál mira qué familia exportó. `--out-dir` override
-(default `ws.exports_dir`).
+distintas, NO unificadas:** el consumidor sabe por cuál mira qué familia exportó. Los avisos (p. ej.
+`--scope` ignorado con `graphml`/`csv`, o `equation_hash` omitido) van en el **`warnings` top-level del
+envelope, NO en `data`** (canal único, §Envelope). `--out-dir` override (default `ws.exports_dir`).
 
 `build` tiene **dos modos**: **quick** (sin `--spec`) y **declarativo** (**`build --spec <redes.yaml>`**:
 `load_specs` con clave raíz `networks:` → `Networks.build` por red; helper único `_build_from_spec_file`).
@@ -419,7 +425,17 @@ JSON** con `schema="1"`:
 }
 ```
 
-En error conocido: `ok=false`, `data={}`, `error={"code": <CODE>, "message": <accionable>}`. Los exit
+En error conocido: `ok=false`, `data={}`, `error={"code": <CODE>, "message": <accionable>}`.
+
+**Canal único de `warnings` (ADR 0021 §C, enmienda QA 0.14.0 #3).** Los avisos no fatales van
+**SIEMPRE** en el campo **`warnings` top-level** del envelope y **NUNCA** duplicados dentro de `data`:
+el consumidor mira **un solo lugar**. Aunque un servicio interno (`run_export`/`run_build`) devuelva un
+`data["warnings"]` propio (lo conserva para sus tests), la **superficie CLI lo extrae** (`pop`, no
+`get`) antes de emitir, así el texto sobrevive en un único lugar. **Excepción por diseño:**
+`data["empty_networks"]` de `build` **no** es un warning sino un diagnóstico estructurado por-red
+(`{kind, reason, fix_command}`) que vive en `data`, separado del canal `warnings` (§build).
+
+Los exit
 codes se mapean **por tipo de error** (ADR 0021 §D): `DataError`→2, `ImportError`/`DependencyError`/
 `NotImplementedError`→3, `httpx.HTTPError`→4, `StoreLockedError`/`OSError`→5. `AttributeError` **no** se
 mapea (un bug real no se disfraza de "capacidad faltante"); la capacidad-de-source-faltante se convierte
@@ -901,8 +917,10 @@ class Manifest(BaseModel):
     equations: list[EquationRef] = []            # ecuaciones + query OpenAlex ejecutada + reporte de traducción
                                                   # EquationRef vive en `bib2graph.corpus` (NO en `schemas`).
                                                   # ADR 0050 D1: extendida con engine/params/created_at;
-                                                  # además se PERSISTE en la tabla `equations` del store vivo
-                                                  # (§1.5), no solo se sella en el snapshot.
+                                                  # se PERSISTE en la tabla `equations` del store vivo (§1.5)
+                                                  # y `DuckDBStore.load()` la RECONSTRUYE de vuelta (D1
+                                                  # completo, QA 0.14.0 #1): el snapshot sella la tabla
+                                                  # fielmente, no `[]`.
     chaining: ChainingParams | None = None       # profundidad, topes, dirección
     preprocessors: list[PreprocRef] = []         # normalize + thesaurus aplicados
     filters: list[FilterStep] = []               # criterios incl/excl con conteos (flujo PRISMA)
@@ -1013,6 +1031,12 @@ equivalente en `InMemoryBackend`. Schema de la tabla `equations` (PK `equation_i
   REPLACE` en DuckDB, upsert por posición en InMemory). El `raw_query` que se persiste es la ecuación
   cruda; `params_json` serializa `EquationRef.params`.
 - **El chaining NO crea filas en `equations`** (un citante forrajeado no vino de una ecuación).
+- **Round-trip completo (D1, QA 0.14.0 #1).** `DuckDBStore.load()` **reconstruye `manifest.equations`**
+  desde esta tabla al rehidratar (mismo patrón que `filters`/`enrichers`, ver §4 "Procedencia del
+  Manifest persistida entre cargas"). Por eso el `manifest.json` que sella `snapshot create` **refleja
+  fielmente la tabla `equations`**, no un `[]` vacío: la persistencia y la carga cierran el ciclo, la
+  procedencia sobrevive entre sesiones. (`b2g status` la expone directo de `load_equations()`, sin
+  pasar por el manifest reconstruido; ver §Convenciones CLI · `status`.)
 
 **`EquationRef`** (`bib2graph.corpus`, **NO** `schemas`) es la vista Python de esta fila, reusada en el
 `Manifest` del snapshot (§1.3). ADR 0050 D1 la **extiende** (aditivo, retrocompat):
@@ -1357,6 +1381,13 @@ los **reconstruye** al rehidratar, para que sobrevivan a un ciclo persist/load:
   `load_enricher_refs()` (#141), **mismo patrón** que `filters`: la pasada de enriquecimiento
   (`chain` refs→DOI, `build` co-citación) sella sus `EnricherRef` y `load()` los recompone, así el
   snapshot reporta qué enriquecimiento se aplicó sin re-correrlo.
+- **`manifest.equations`** ⇄ tabla **`equations`** (§1.5) — vía `DuckDBBackend.persist_equation()` /
+  `load_equations()` (QA 0.14.0 #1, ADR 0050 D1), **mismo patrón**: `seed --equation`/`--spec` sella
+  la fila y **`load()` reconstruye `manifest.equations`** al rehidratar. Así el `manifest.json` del
+  snapshot **refleja fielmente la tabla lateral `equations`** (D1 completo): antes era un bug —la
+  tabla se poblaba pero `load()` no la leía de vuelta, y un `snapshot create` posterior sellaba
+  `equations: []` pese a haber ecuaciones registradas, perdiendo la procedencia—. `load_equations()`
+  nunca lanza por tabla ausente (stores pre-D1 devuelven `[]`, retrocompat sin excepciones).
 
 **Extensiones del `DuckDBBackend`, FUERA del Protocol `Store`/`TabularBackend`** (se acceden vía
 `store.backend.…`): son específicas de DuckDB y no parte del contrato genérico:

--- a/docs/API.md
+++ b/docs/API.md
@@ -294,8 +294,10 @@ transición la define el verbo.
   schema_version, maturity}`.
 - **`snapshot restore --from-corpus <parquet>`** (= ex verbo plano `restore`): **rehidrata un corpus ya
   curado SIN red** (lee con `CORPUS_SCHEMA`, `Corpus.from_arrow`, merge+dedup+persist; cero llamadas a
-  OpenAlex). **Preserva la curación** (`decision`/`curation_status`/`is_seed`, D3). **Transiciona a
-  `FILTERED`** (reusa la transición permisiva `filter`; válida desde cualquier estado, incluido store
+  OpenAlex). **Preserva la curación** (`decision`/`curation_status`/`is_seed`, D3) y **reconstruye la
+  tabla `equations`** (D1, ADR 0050) desde el `manifest.json` **hermano** del parquet si existe —graceful:
+  sin manifest hermano (o `equations` ausente) → 0 ecuaciones, sin error—, cerrando el round-trip de
+  procedencia con `snapshot create`. **Transiciona a `FILTERED`** (reusa la transición permisiva `filter`; válida desde cualquier estado, incluido store
   vacío). Parquet inexistente o schema no canónico → `DataError` exit 2. `data = {papers_loaded,
   total_papers, state, round}`. (El verbo suelto `b2g restore` se retiró en 0.12.0; su capacidad es
   `b2g snapshot restore`.)

--- a/docs/decisiones/0021-cli-agente-native-contrato.md
+++ b/docs/decisiones/0021-cli-agente-native-contrato.md
@@ -301,3 +301,27 @@ cosas que el AS-BUILT explicita:
 En código se unificó el flag vía un decorador compartido `@json_option` (`cli/_options.py`, con
 `json_mode(local_flag)` que resuelve flag-o-entorno); es refactor interno, **no** cambia el contrato
 externo. Documentado en `docs/API.md` §convenciones CLI (Envelope JSON / `B2G_JSON`).
+
+## Enmienda — canal único de `warnings` en el envelope (QA 0.14.0, hallazgo #3)
+
+> Enmienda **aclaratoria** del §C. Fija una norma que el §C ya implicaba pero no escribía; **no**
+> cambia la forma del envelope ni bumpea `schema` (sigue `"1"`). Cierra un drift observado en QA: los
+> envelopes de `export` y `build` duplicaban el mismo texto de aviso en `data.warnings` **y** en el
+> `warnings` top-level.
+
+El §C define **`warnings`** como campo top-level del envelope (avisos no fatales). Esta enmienda fija
+que ese es el **único canal canónico**:
+
+- En modo `--json`, los `warnings` van **SIEMPRE** en el campo **`warnings` top-level** del envelope y
+  **NUNCA** duplicados dentro de `data`. Un consumidor mira **un solo lugar**; no hay que unir
+  `data.warnings` con `warnings`.
+- Si un servicio interno (`run_export`/`run_build`) devuelve un `data["warnings"]` propio (lo conserva
+  para sus tests unitarios), la **superficie CLI lo extrae con `pop`** —no `get`— antes de emitir, así
+  el texto sobrevive en **un** solo lugar (el top-level) y `data` no lo lleva
+  (`cli/commands/export.py`, `cli/commands/build.py`).
+- **Excepción por diseño — `data["empty_networks"]`** (`build`) **no es un warning**: es un
+  diagnóstico estructurado por-red (`{kind, reason, fix_command}`) que vive en `data`, separado del
+  canal de `warnings` (ADR 0037; ver `docs/API.md` §build). No se duplica en `warnings`.
+
+Aplica a **todos** los comandos del ciclo; los avisos ya canónicos por top-level (walk-up del cwd, ADR
+0045 #259; `networks_cache_stale` de `status`) no cambian. Documentado en `docs/API.md` §Envelope JSON.

--- a/src/bib2graph/cli/_scope.py
+++ b/src/bib2graph/cli/_scope.py
@@ -1,0 +1,25 @@
+"""cli._scope — Helper compartido de mapeo de vocab ``--scope``.
+
+Extraído de ``cli.commands.build`` y ``cli.commands.export`` (ambos tenían
+una copia literal del mismo mapeo) para evitar divergencia (DRY, hallazgo de
+revisión arquitectónica 0.14.0).
+"""
+
+from __future__ import annotations
+
+
+def map_scope(scope: str) -> str:
+    """Mapea el vocab de ``--scope`` (CLI) al vocab interno de ``corpus.scoped()``.
+
+    ``--scope`` usa ``seeds`` (forma corta), mientras que ``corpus.scoped()``
+    espera ``seeds_only``.  Los demás valores son idénticos en ambos vocabs.
+
+    Args:
+        scope: Valor del flag ``--scope`` (``all`` | ``accepted`` | ``seeds``).
+
+    Returns:
+        Vocabulario interno: ``all`` | ``accepted`` | ``seeds_only``.
+    """
+    if scope == "seeds":
+        return "seeds_only"
+    return scope

--- a/src/bib2graph/cli/commands/build.py
+++ b/src/bib2graph/cli/commands/build.py
@@ -47,6 +47,7 @@ from bib2graph.cli._enrich import enrich_corpus
 from bib2graph.cli._envelope import build_envelope, emit, emit_human
 from bib2graph.cli._errors import DataError, DependencyError, handle_errors
 from bib2graph.cli._options import json_mode, json_option
+from bib2graph.cli._scope import map_scope as _map_scope
 from bib2graph.cli._store import (
     open_store,
     resolve_workspace,
@@ -57,23 +58,6 @@ from bib2graph.cli._store import (
 if TYPE_CHECKING:
     from bib2graph.corpus import Corpus
     from bib2graph.networks.spec import NetworkArtifact
-
-
-def _map_scope(scope: str) -> str:
-    """Mapea el vocab de ``--scope`` (CLI) al vocab interno de ``corpus.scoped()``.
-
-    ``--scope`` usa ``seeds`` (forma corta), mientras que ``corpus.scoped()``
-    espera ``seeds_only``.  Los demás valores son idénticos en ambos vocabs.
-
-    Args:
-        scope: Valor del flag ``--scope`` (``all`` | ``accepted`` | ``seeds``).
-
-    Returns:
-        Vocabulario interno: ``all`` | ``accepted`` | ``seeds_only``.
-    """
-    if scope == "seeds":
-        return "seeds_only"
-    return scope
 
 
 # Helper compartido: carga de specs YAML + construcción de artefactos

--- a/src/bib2graph/cli/commands/build.py
+++ b/src/bib2graph/cli/commands/build.py
@@ -682,9 +682,13 @@ def build_cmd(
     # ADR 0045 (#259): eco de workspace + warning accionable en walk-up.
     data["workspace"] = workspace_echo(ws)
 
+    # Canal único de warnings: viven en el top-level del envelope, NO duplicados en
+    # data (mismo criterio que export.py). run_build conserva data["warnings"] para
+    # sus tests; el pop ocurre solo en la superficie CLI, tras el retorno de run_build.
+    build_warns: list[str] = list(data.pop("warnings", None) or [])
+
     if json_mode(json_output):
-        all_warnings: list[str] = list(data.get("warnings") or [])
-        all_warnings.extend(workspace_walkup_warning(ws))
+        all_warnings: list[str] = build_warns + list(workspace_walkup_warning(ws))
         envelope = build_envelope(
             command="build",
             ok=True,
@@ -695,7 +699,7 @@ def build_cmd(
         emit(envelope)
     else:
         # Warnings van a stderr en modo humano (ADR 0021 §C; patrón de status.py).
-        for w in data.get("warnings", []):
+        for w in build_warns:
             print(f"ADVERTENCIA: {w}", file=sys.stderr)
         for en in data.get("empty_networks", []):
             fix = f" Sugerencia: {en['fix_command']}" if en.get("fix_command") else ""

--- a/src/bib2graph/cli/commands/export.py
+++ b/src/bib2graph/cli/commands/export.py
@@ -279,7 +279,12 @@ def run_export(
         )
 
     # Fusionar (no pisar): _export_corpus ya puede traer sus propios warnings
-    # (p. ej. equation_hash omitido, ADR 0050 D3) en data["warnings"].
+    # (p. ej. equation_hash omitido, ADR 0050 D3) en data["warnings"]. Este
+    # dict es el contrato de ``run_export`` (usado directo en tests, sin
+    # pasar por el envelope) — mantiene ``data["warnings"]`` como fuente única
+    # de verdad para callers no-CLI. QA 0.14.0 (hallazgo #3): es el caller CLI
+    # (``export_cmd``) quien debe evitar duplicarlas al construir el envelope
+    # (ver ahí: se extraen de ``data`` en vez de copiarse a un canal aparte).
     data["warnings"] = warnings + list(data.get("warnings") or [])
     return data
 
@@ -357,8 +362,17 @@ def export_cmd(
     # ADR 0045 (#259): eco de workspace + warning accionable en walk-up.
     data["workspace"] = workspace_echo(ws)
 
+    # QA 0.14.0 (hallazgo #3): el envelope tiene UN solo canal canónico de
+    # warnings — el ``warnings`` top-level (ADR 0021 §C). Antes ``data``
+    # (con su propia clave ``warnings``, p. ej. el aviso de equation_hash
+    # omitido, ADR 0050 D3) se pasaba completo como ``data=data`` Y además
+    # se copiaban las mismas warnings al top-level, duplicando el texto en
+    # ``data.warnings`` y en ``warnings``. Se extraen (``pop``, no ``get``)
+    # de ``data`` para que sobrevivan en un solo lugar.
+    data_warnings: list[str] = list(data.pop("warnings", None) or [])
+
     if json_mode(json_output):
-        all_warnings: list[str] = list(data.get("warnings") or [])
+        all_warnings: list[str] = list(data_warnings)
         all_warnings.extend(workspace_walkup_warning(ws))
         envelope = build_envelope(
             command="export",
@@ -369,7 +383,7 @@ def export_cmd(
         )
         emit(envelope)
     else:
-        for w in data.get("warnings", []):
+        for w in data_warnings:
             print(f"ADVERTENCIA: {w}", file=sys.stderr)
         if "networks_exported" in data:
             emit_human(f"Exportados {data['networks_exported']} redes en formato {fmt}")

--- a/src/bib2graph/cli/commands/export.py
+++ b/src/bib2graph/cli/commands/export.py
@@ -29,6 +29,7 @@ import click
 from bib2graph.cli._envelope import build_envelope, emit, emit_human
 from bib2graph.cli._errors import DataError, handle_errors
 from bib2graph.cli._options import json_mode, json_option
+from bib2graph.cli._scope import map_scope as _map_scope
 from bib2graph.cli._store import (
     open_store_readonly,
     resolve_workspace,
@@ -40,22 +41,6 @@ from bib2graph.cli._store import (
 _NETWORK_FORMATS = frozenset({"graphml", "csv"})
 #: Formatos que serializan el corpus; respetan ``--scope`` (ADR 0050 D4).
 _CORPUS_FORMATS = frozenset({"arrow", "bibtex"})
-
-
-def _map_scope(scope: str) -> str:
-    """Mapea el vocab de ``--scope`` (CLI) al vocab interno de ``corpus.scoped()``.
-
-    Mismo mapeo que ``cli.commands.build._map_scope`` (``seeds`` → ``seeds_only``).
-
-    Args:
-        scope: Valor del flag ``--scope`` (``all`` | ``accepted`` | ``seeds``).
-
-    Returns:
-        Vocabulario interno: ``all`` | ``accepted`` | ``seeds_only``.
-    """
-    if scope == "seeds":
-        return "seeds_only"
-    return scope
 
 
 def _export_networks(
@@ -167,14 +152,22 @@ def _export_corpus(
         scope: Vocab interno de scope (``all``/``accepted``/``seeds_only``).
 
     Returns:
-        Dict con ``format``, ``out_dir``, ``files_written`` y ``rows_exported``.
+        Dict con ``format``, ``out_dir``, ``files_written``, ``rows_exported``
+        y ``warnings`` (lista, puede ser vacía). Para ``format == "arrow"``
+        incluye el warning accionable de ``build_equation_metadata`` cuando el
+        corpus tiene 0 o >1 ecuaciones registradas (ADR 0050 D3): el
+        ``equation_hash`` se omite en ese caso y el usuario debe saberlo, en
+        vez de descubrirlo en silencio al inspeccionar el ``.arrow``.
 
     Raises:
         ImportError: Si falta ``bibtexparser`` (formato ``bibtex``, extra
             ``[bibtex]``).
     """
+    from bib2graph.backends.memory import build_equation_metadata
     from bib2graph.exporters.arrow import ArrowExporter
     from bib2graph.exporters.bibtex import BibtexExporter
+
+    corpus_warnings: list[str] = []
 
     store = open_store_readonly(store_path)
     try:
@@ -184,6 +177,14 @@ def _export_corpus(
         # DuckDBBackend vivo (lazy); to_arrow() debe correr con la conexión
         # todavía abierta.
         table = corpus.to_arrow()
+        if format == "arrow":
+            # to_arrow() ya puebla equation_hash en la metadata cuando aplica
+            # (ADR 0050 D3), pero descarta el warning ahí a propósito (no es
+            # ruidoso para llamadas internas). Este es el punto de consumo
+            # real visible al usuario: propagamos el warning si corresponde.
+            _metadata, warning = build_equation_metadata(store.backend.load_equations())
+            if warning is not None:
+                corpus_warnings.append(warning)
     finally:
         store.close()
 
@@ -204,6 +205,7 @@ def _export_corpus(
         "out_dir": str(out_path),
         "files_written": [str(dest)],
         "rows_exported": table.num_rows,
+        "warnings": corpus_warnings,
     }
 
 
@@ -276,7 +278,9 @@ def run_export(
             f"Formato '{format}' no reconocido. Usá 'graphml', 'csv', 'arrow' o 'bibtex'."
         )
 
-    data["warnings"] = warnings
+    # Fusionar (no pisar): _export_corpus ya puede traer sus propios warnings
+    # (p. ej. equation_hash omitido, ADR 0050 D3) en data["warnings"].
+    data["warnings"] = warnings + list(data.get("warnings") or [])
     return data
 
 

--- a/src/bib2graph/cli/commands/status.py
+++ b/src/bib2graph/cli/commands/status.py
@@ -11,6 +11,12 @@ R3: el mapa honesto del lazo (ADR 0016 enmendado).  Muestra:
 - contador de ronda,
 - conteos por curation_status.
 
+QA 0.14.0 (hallazgo #2, ADR 0050 D1): las ecuaciones registradas en la tabla
+lateral ``equations`` eran invisibles salvo inspeccionando la metadata del
+``.arrow`` exportado. ``status`` ahora las expone (``data["equations"]`` en
+JSON, sección "Ecuaciones registradas" en modo humano) sin agregar un verbo
+nuevo (ADR 0037, poda a 10 verbos): es información de estado, no una acción.
+
 ADR 0029 (aditivo): el envelope incluye ``workspace`` con el workspace
 resuelto (root, source) para que el agente sepa de dónde salió la biblioteca.
 Mantiene ``schema="1"`` (campos nuevos son aditivos, no rompen agentes).
@@ -66,7 +72,9 @@ def run_status(store_path: str | Path) -> dict[str, Any]:
     Returns:
         Dict con ``loop_state``, ``transitions_available``, ``curation_available``,
         ``round``, ``counts_by_status``, ``total_papers``, ``next_best_action``,
-        ``readiness``, ``build_preview``.
+        ``readiness``, ``build_preview``, ``equations`` (lista de dicts con
+        ``equation_id``, ``raw_query``, ``engine``, ``created_at``; ``[]`` si el
+        store no tiene ecuaciones registradas, sin romper — hallazgo #2 QA 0.14.0).
 
     Raises:
         StoreError: Si el store está bloqueado.
@@ -111,6 +119,21 @@ def run_status(store_path: str | Path) -> dict[str, Any]:
     action = next_best_action(loop_state)
 
     build_prev = predict_build_preview(corpus)
+
+    # QA 0.14.0 (hallazgo #2, ADR 0050 D1): exponer las ecuaciones registradas
+    # en la tabla lateral ``equations`` — hoy invisibles salvo en la metadata
+    # del .arrow exportado. Se lee directo de ``load_equations()`` (no del
+    # manifest reconstruido) para reflejar la tabla lateral tal cual está en
+    # disco, independiente del fix del hallazgo #1.
+    equations = [
+        {
+            "equation_id": eq["equation_id"],
+            "raw_query": eq["raw_query"],
+            "engine": eq["engine"],
+            "created_at": eq["created_at"],
+        }
+        for eq in store.backend.load_equations()
+    ]
 
     # readiness: si el próximo paso va a DAR FRUTO (no solo si está permitido).
     # Caso crítico "build": ready si al menos 1 red no sería vacía.
@@ -165,6 +188,7 @@ def run_status(store_path: str | Path) -> dict[str, Any]:
         "next_best_action": action,
         "readiness": readiness,
         "build_preview": build_prev,
+        "equations": equations,
     }
 
 
@@ -265,5 +289,11 @@ def status_cmd(
                 if entry["would_be_empty"] and entry["reason"]:
                     line += f" — {entry['reason']} → {entry['fix_command']}"
                 emit_human(line)
+        equations = data.get("equations", [])
+        emit_human(f"Ecuaciones registradas ({len(equations)}):")
+        for eq in equations:
+            raw_query = str(eq["raw_query"])
+            recortado = raw_query if len(raw_query) <= 60 else raw_query[:57] + "..."
+            emit_human(f"  {eq['equation_id']} · {recortado} · {eq['engine']}")
         for w in warnings:
             print(f"AVISO: {w}", file=sys.stderr)

--- a/src/bib2graph/service/snapshot.py
+++ b/src/bib2graph/service/snapshot.py
@@ -19,13 +19,72 @@ el shim ``b2g restore`` también delega acá (fuente única — ADR 0038 §163).
 
 from __future__ import annotations
 
+import json
 from datetime import datetime
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from bib2graph.preprocessors.pipeline import normalize_and_dedup
 from bib2graph.service.errors import DataError
 from bib2graph.service.store import open_store as _open_store
+
+if TYPE_CHECKING:
+    from bib2graph.stores.duckdb import DuckDBStore
+
+
+def _restore_equations_from_sibling_manifest(
+    store: DuckDBStore, corpus_path: Path
+) -> None:
+    """Reconstruye la tabla lateral ``equations`` desde el manifest hermano.
+
+    ``snapshot create`` escribe ``corpus.parquet`` y ``manifest.json`` en el
+    MISMO directorio (ver ``Corpus.snapshot``): el manifest sella
+    ``equations`` (lista de ``EquationRef``), pero el parquet NO las lleva
+    (son laterales al ``CORPUS_SCHEMA`` — R2/ADR 0017). Este helper busca ese
+    ``manifest.json`` hermano y, si existe y declara ecuaciones, las
+    re-persiste vía ``backend.persist_equation`` — mismo mapeo de campos que
+    ``run_seed`` (``cli/commands/seed.py``): ``engine`` (fallback
+    ``"openalex"``), ``raw_query`` desde ``params["raw_query"]`` (fallback al
+    ``query`` histórico si el manifest no tiene ese campo), ``params_json``
+    con el dict ``params`` completo serializado, y ``created_at``.
+
+    Idempotente (``persist_equation`` hace upsert por ``equation_id`` — PK),
+    así que restaurar el mismo snapshot dos veces no duplica filas.
+
+    Graceful: si no hay ``manifest.json`` hermano (parquet curado externo
+    suelto, sin snapshot de bib2graph detrás) o el manifest no declara
+    ``equations``, no hace nada — no reconstruye ecuaciones, no lanza.
+
+    Args:
+        store: Store destino ya abierto (con el corpus mergeado persistido).
+        corpus_path: Ruta al parquet pasado a ``run_restore``
+            (``--from-corpus``); el manifest se busca en su mismo directorio.
+    """
+    manifest_path = corpus_path.parent / "manifest.json"
+    if not manifest_path.exists():
+        return
+
+    try:
+        manifest_data = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        # Manifest hermano corrupto/ilegible: graceful, no reconstruye equations.
+        return
+
+    equations = manifest_data.get("equations") or []
+    for eq in equations:
+        params = eq.get("params") or {}
+        raw_query = params.get("raw_query", eq.get("query"))
+        if raw_query is None:
+            # EquationRef sin query recuperable (manifest degenerado): salteala,
+            # no hay valor no-nulo aceptable para la columna NOT NULL.
+            continue
+        store.backend.persist_equation(
+            str(eq["equation_id"]),
+            engine=str(eq.get("engine") or "openalex"),
+            raw_query=str(raw_query),
+            params_json=json.dumps(params, ensure_ascii=False),
+            created_at=eq.get("created_at"),
+        )
 
 
 def run_snapshot(
@@ -81,6 +140,21 @@ def run_restore(
     Preserva las columnas de curación del parquet
     (``decision`` / ``curation_status`` / ``is_seed``): el merge de ``Corpus``
     respeta el ``curation_status`` más reciente (D3 del merge).
+
+    QA 0.14.0 (hallazgo #1 continuado, ADR 0050 D1): si existe un
+    ``manifest.json`` hermano del parquet (mismo directorio, producido por
+    ``snapshot create``) y declara ``equations``, cada una se re-persiste en
+    la tabla lateral ``equations`` del store destino vía
+    ``backend.persist_equation`` — mismo mapeo de campos que usa ``run_seed``
+    (``cli/commands/seed.py``) al sembrar: ``params["raw_query"]`` (fallback al
+    ``query`` histórico si el manifest es más viejo y no tiene ese campo) y
+    ``params`` completo serializado a ``params_json``. Sin esto, un
+    ``snapshot restore`` recuperaba las filas del corpus pero
+    ``backend.load_equations()`` quedaba en 0 (las ecuaciones solo viven en
+    el manifest, no en el parquet — la tabla ``equations`` es lateral al
+    ``CORPUS_SCHEMA``, R2/ADR 0017). Es **graceful**: si no hay manifest
+    hermano (p.ej. un parquet curado externo suelto) o no declara
+    ``equations``, restore no reconstruye nada — 0 ecuaciones, sin excepción.
 
     No instancia ``OpenAlexSource``, no hace requests.  Es el camino offline
     para rehidratar un corpus curado exportado con ``b2g snapshot create``.
@@ -161,6 +235,8 @@ def run_restore(
         merged_backend_close = getattr(merged_deduped._backend, "close", None)
         store.persist_replace(merged_deduped)
         store.backend.set_loop_state(new_state, cycle_round=new_round)
+
+        _restore_equations_from_sibling_manifest(store, resolved)
     finally:
         # Ver run_seed_from_bib: cierra explícitamente las conexiones DuckDB
         # para evitar segfault en Linux ante llamadas consecutivas al mismo archivo.

--- a/src/bib2graph/stores/duckdb.py
+++ b/src/bib2graph/stores/duckdb.py
@@ -80,13 +80,21 @@ class DuckDBStore:
         los pasos PRISMA persistan entre sesiones.
         Ref #141: reconstruye ``manifest.enrichers`` desde ``enricher_log`` para
         que los ``EnricherRef`` persistan entre sesiones.
+        QA 0.14.0 (hallazgo #1, ADR 0050 D1): reconstruye ``manifest.equations``
+        desde la tabla lateral ``equations`` para que los ``EquationRef``
+        persistan entre sesiones (antes se perdían: la tabla lateral se
+        poblaba en ``seed``, pero ``load()`` nunca la leía de vuelta hacia el
+        manifest, así que un ``snapshot create`` posterior sellaba
+        ``equations: []`` pese a haber ecuaciones registradas).
 
         Returns:
             El ``Corpus`` acumulado en el store.
         """
+        import json
+
         import pyarrow as pa
 
-        from bib2graph.corpus import EnricherRef, FilterStep
+        from bib2graph.corpus import EnricherRef, EquationRef, FilterStep
 
         table = self._backend.to_arrow()
         if len(table) == 0:
@@ -121,6 +129,44 @@ class DuckDBStore:
             ]
             new_manifest = corpus.manifest.model_copy(
                 update={"enrichers": enricher_refs}
+            )
+            corpus = corpus.with_manifest(new_manifest)
+
+        # QA 0.14.0 (hallazgo #1, ADR 0050 D1): reconstruye manifest.equations
+        # desde la tabla lateral ``equations``. La tabla se crea con
+        # ``CREATE TABLE IF NOT EXISTS`` en todo DuckDBBackend (incluidos
+        # stores viejos pre-D1): ``load_equations()`` nunca lanza por tabla
+        # ausente, simplemente devuelve ``[]`` cuando no hay ecuaciones
+        # registradas — retrocompat sin excepciones.
+        raw_equations = self._backend.load_equations()
+        if raw_equations:
+            equation_refs = []
+            for eq in raw_equations:
+                eq_params = dict(json.loads(str(eq["params_json"] or "{}")))
+                # ``query`` es histórico: la query EJECUTADA (traducida), no la
+                # cruda (ver docstring de EquationRef). ``params["executed_query"]``
+                # la conserva; si falta (ecuación persistida sin ese campo), el
+                # mejor fallback disponible es ``raw_query``.
+                executed_query = eq_params.get("executed_query")
+                translation_report = eq_params.get("translation_report") or []
+                equation_refs.append(
+                    EquationRef(
+                        equation_id=str(eq["equation_id"]),
+                        query=str(executed_query)
+                        if executed_query is not None
+                        else str(eq["raw_query"]),
+                        translation_report=[str(x) for x in translation_report],
+                        engine=str(eq["engine"])
+                        if eq.get("engine") is not None
+                        else None,
+                        params=eq_params,
+                        created_at=str(eq["created_at"])
+                        if eq.get("created_at") is not None
+                        else None,
+                    )
+                )
+            new_manifest = corpus.manifest.model_copy(
+                update={"equations": equation_refs}
             )
             corpus = corpus.with_manifest(new_manifest)
 

--- a/tests/unit/test_build_absorber_networks.py
+++ b/tests/unit/test_build_absorber_networks.py
@@ -621,6 +621,43 @@ class TestJsonOutput:
         # Los warnings están en el envelope, no sueltos en stdout
         assert isinstance(envelope.get("warnings"), list)
 
+    def test_json_warnings_canal_unico_no_duplicado_en_data(
+        self, tmp_path: Path
+    ) -> None:
+        """Los warnings viven SOLO en el top-level del envelope, NUNCA duplicados
+        también dentro de ``data`` (mismo criterio que export.py; QA 0.14.0)."""
+        from click.testing import CliRunner
+
+        from bib2graph.cli import b2g
+        from bib2graph.workspace import Workspace
+
+        ws_dir = tmp_path / "ws"
+        ws = Workspace.init(ws_dir, "test")
+        # Semillas con referencias pero sin cited_by → dispara el hint de cocitación.
+        _seed_store(ws.library_path, _rows_con_referencias())
+
+        runner = CliRunner()
+        result = runner.invoke(
+            b2g,
+            ["--workspace", str(ws_dir), "build", "--json"],
+        )
+
+        assert result.exit_code == 0
+        envelope = json.loads(result.output)
+
+        # Canal único: 'warnings' NO debe existir dentro de data (se movió al top-level).
+        assert "warnings" not in envelope["data"], (
+            "data.warnings no debe existir: el canal único es el top-level del envelope. "
+            f"data keys={list(envelope['data'].keys())}"
+        )
+        # Y el warning de cocitación sí aparece en el top-level (una sola vez).
+        assert any(
+            "cocita" in w.lower() or "cited_by" in w.lower()
+            for w in envelope.get("warnings", [])
+        ), (
+            f"esperaba el hint de cocitación en top-level warnings={envelope.get('warnings')}"
+        )
+
     def test_json_data_tiene_scope_y_corpus_scope(self, tmp_path: Path) -> None:
         """data incluye 'scope' (nuevo) y 'corpus_scope' (backward compat)."""
         from click.testing import CliRunner

--- a/tests/unit/test_cli_scope_helper.py
+++ b/tests/unit/test_cli_scope_helper.py
@@ -1,0 +1,37 @@
+"""Tests — ``cli._scope.map_scope`` (helper compartido, DRY entre build/export).
+
+Antes de esta extracción, ``build.py`` y ``export.py`` tenían cada uno una
+copia literal idéntica de este mapeo (hallazgo de revisión arquitectónica
+0.14.0). Este test cubre el helper único; ``build.py``/``export.py`` lo
+importan con el alias histórico ``_map_scope`` (ver
+``test_build_absorber_networks.py::test_map_scope_seeds_a_seeds_only`` para
+el contrato re-exportado desde ``build``).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+class TestMapScope:
+    def test_seeds_mapea_a_seeds_only(self) -> None:
+        from bib2graph.cli._scope import map_scope
+
+        assert map_scope("seeds") == "seeds_only"
+
+    def test_all_y_accepted_pasan_sin_cambio(self) -> None:
+        from bib2graph.cli._scope import map_scope
+
+        assert map_scope("all") == "all"
+        assert map_scope("accepted") == "accepted"
+
+    def test_build_y_export_reexportan_el_mismo_helper(self) -> None:
+        """build._map_scope y export._map_scope son el mismo objeto (no copias)."""
+        from bib2graph.cli._scope import map_scope
+        from bib2graph.cli.commands.build import _map_scope as build_map_scope
+        from bib2graph.cli.commands.export import _map_scope as export_map_scope
+
+        assert build_map_scope is map_scope
+        assert export_map_scope is map_scope

--- a/tests/unit/test_equations_persist_seed.py
+++ b/tests/unit/test_equations_persist_seed.py
@@ -141,3 +141,131 @@ def test_run_seed_reseed_con_nueva_ecuacion_acumula_en_equations(
     assert raw_queries <= {"ecology", "environmental justice"}
     # La última ecuación sembrada siempre debe estar presente (nunca se pierde).
     assert "environmental justice" in raw_queries
+
+
+# ---------------------------------------------------------------------------
+# QA 0.14.0 hallazgo #1: DuckDBStore.load() reconstruye manifest.equations
+# desde la tabla lateral ``equations`` (antes solo reconstruía filters/enrichers).
+# ---------------------------------------------------------------------------
+
+
+def test_load_reconstruye_manifest_equations_desde_tabla_lateral(
+    tmp_path: Path,
+) -> None:
+    """Cargar el store en un ``Corpus`` NUEVO refleja las ecuaciones sembradas.
+
+    Bug confirmado en QA: tras sembrar, ``backend.load_equations()`` devuelve
+    las filas, pero ``corpus.manifest.equations`` (del ``Corpus`` recién
+    cargado en una sesión nueva) quedaba en ``[]`` — la reconstrucción de
+    filters/enrichers existía, la de equations no.
+    """
+    from bib2graph.cli.commands.seed import run_seed
+    from bib2graph.stores.duckdb import DuckDBStore
+
+    store_path = tmp_path / "test.duckdb"
+    run_seed(store_path, "unequal exchange", transport=_make_mock_transport())
+
+    # Sesión NUEVA: instancia de store distinta, simula reabrir el archivo.
+    store = DuckDBStore(store_path)
+    try:
+        corpus = store.load()
+    finally:
+        store.close()
+
+    assert len(corpus.manifest.equations) == 1
+    eq_ref = corpus.manifest.equations[0]
+    assert eq_ref.equation_id.startswith("eq-")
+    assert eq_ref.engine == "openalex"
+    assert eq_ref.params.get("raw_query") == "unequal exchange"
+    assert eq_ref.created_at
+
+
+def test_load_reconstruye_manifest_equations_con_dos_ecuaciones(
+    tmp_path: Path,
+) -> None:
+    """Dos siembras (ecuaciones distintas) reconstruyen 2 ``EquationRef``."""
+    from bib2graph.cli.commands.seed import run_seed
+    from bib2graph.stores.duckdb import DuckDBStore
+
+    store_path = tmp_path / "test.duckdb"
+    run_seed(store_path, "ecology", transport=_make_mock_transport())
+    run_seed(store_path, "environmental justice", transport=_make_mock_transport())
+
+    store = DuckDBStore(store_path)
+    try:
+        corpus = store.load()
+    finally:
+        store.close()
+
+    # Puede colapsar a 1 fila si ambas siembras caen en el mismo segundo
+    # (mismo equation_id, ver test de arriba); el invariante es que refleja
+    # exactamente lo que hay en la tabla lateral.
+    store2 = DuckDBStore(store_path)
+    try:
+        raw_equations = store2.backend.load_equations()
+    finally:
+        store2.close()
+
+    assert len(corpus.manifest.equations) == len(raw_equations)
+    raw_queries_manifest = {
+        eq.params.get("raw_query") for eq in corpus.manifest.equations
+    }
+    raw_queries_table = {eq["raw_query"] for eq in raw_equations}
+    assert raw_queries_manifest == raw_queries_table
+
+
+def test_snapshot_create_sella_ecuaciones_no_vacio(tmp_path: Path) -> None:
+    """``snapshot create`` sella ``equations`` en ``manifest.json`` (no vacío).
+
+    Cierra el bug de punta a punta: antes, el snapshot sellaba
+    ``"equations": []`` en ``manifest.json`` pese a haber ecuaciones
+    registradas en la biblioteca viva.
+    """
+    import json as _json
+
+    from bib2graph.cli.commands.seed import run_seed
+    from bib2graph.service.snapshot import run_snapshot
+    from bib2graph.stores.duckdb import DuckDBStore
+
+    store_path = tmp_path / "test.duckdb"
+    run_seed(store_path, "unequal exchange", transport=_make_mock_transport())
+
+    snap_dir = tmp_path / "snap"
+    run_snapshot(store_path, out_dir=snap_dir)
+
+    manifest_path = snap_dir / "manifest.json"
+    assert manifest_path.exists()
+    manifest_data = _json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert manifest_data["equations"], (
+        "manifest.json debe sellar las ecuaciones registradas (no vacío)"
+    )
+    assert manifest_data["equations"][0]["params"]["raw_query"] == "unequal exchange"
+
+    # DuckDBStore usado directo (no vía run_seed) para verificar además que
+    # el manifest reconstruido en memoria coincide con lo sellado en disco.
+    store = DuckDBStore(store_path)
+    try:
+        corpus = store.load()
+    finally:
+        store.close()
+    assert len(corpus.manifest.equations) == len(manifest_data["equations"])
+
+
+def test_load_store_sin_tabla_equations_no_rompe(tmp_path: Path) -> None:
+    """Store sin ecuaciones registradas → ``manifest.equations == []`` sin excepción.
+
+    Cubre retrocompat: la tabla ``equations`` se crea siempre con
+    ``CREATE TABLE IF NOT EXISTS`` al abrir el ``DuckDBBackend`` (incluso en
+    stores viejos pre-ADR 0050 D1), así que ``load_equations()`` nunca lanza
+    por tabla ausente — simplemente no hay filas.
+    """
+    from bib2graph.stores.duckdb import DuckDBStore
+
+    store_path = tmp_path / "empty.duckdb"
+    store = DuckDBStore(store_path)
+    try:
+        corpus = store.load()
+    finally:
+        store.close()
+
+    assert corpus.manifest.equations == []

--- a/tests/unit/test_equations_persist_seed.py
+++ b/tests/unit/test_equations_persist_seed.py
@@ -269,3 +269,114 @@ def test_load_store_sin_tabla_equations_no_rompe(tmp_path: Path) -> None:
         store.close()
 
     assert corpus.manifest.equations == []
+
+
+# ---------------------------------------------------------------------------
+# Deuda de cobertura 0.14.0: ``DuckDBBackend._clone()`` preserva ``equations``.
+# ---------------------------------------------------------------------------
+
+
+def test_clone_via_add_paper_preserva_tabla_equations(tmp_path: Path) -> None:
+    """``add_paper`` dispara ``_clone()``; las ecuaciones persistidas sobreviven.
+
+    ``add_paper`` llama internamente a ``self._clone()`` antes de insertar la
+    fila nueva (ver ``DuckDBBackend.add_paper``). Este test asevera que ese
+    clonado — que copia explícitamente ``loop_state_log``,
+    ``referenced_but_not_fetched``, ``external_ids``, ``filter_log``,
+    ``enricher_log`` y ``equations`` fila por fila — efectivamente conserva
+    las ecuaciones sembradas antes de la operación, en el mismo orden
+    (``equation_id``/``raw_query``).
+    """
+    from bib2graph.backends.duckdb import DuckDBBackend
+
+    store_path = tmp_path / "clone_equations.duckdb"
+    backend = DuckDBBackend(path=store_path)
+    backend.persist_equation(
+        "eq-0001", engine="openalex", raw_query="ecology", params_json="{}"
+    )
+    backend.persist_equation(
+        "eq-0002",
+        engine="openalex",
+        raw_query="environmental justice",
+        params_json="{}",
+    )
+
+    # Dispara _clone() por la vía pública normal (add_paper clona antes de
+    # insertar). El backend devuelto es una instancia NUEVA (semántica de valor).
+    new_backend = backend.add_paper(
+        {
+            "id": "doi:new-paper",
+            "title": "New paper via add_paper",
+            "is_seed": True,
+            "curation_status": "candidate",
+        }
+    )
+
+    equations = new_backend.load_equations()
+    assert [eq["equation_id"] for eq in equations] == ["eq-0001", "eq-0002"]
+    assert [eq["raw_query"] for eq in equations] == ["ecology", "environmental justice"]
+
+    backend.close()
+    new_backend.close()
+
+
+def test_persist_replace_no_borra_tabla_equations(tmp_path: Path) -> None:
+    """``DuckDBStore.persist_replace`` (``DELETE FROM corpus``) NO toca ``equations``.
+
+    ``persist_replace`` -> ``overwrite_corpus`` hace ``DELETE FROM corpus``
+    seguido de un INSERT masivo del contenido final. La tabla lateral
+    ``equations`` (ADR 0050 D1) es una tabla HERMANA, no la tabla ``corpus``:
+    este test asevera explícitamente que el ``DELETE`` acotado a ``corpus``
+    no arrastra las ecuaciones ya registradas.
+    """
+    import pyarrow as pa
+
+    from bib2graph.corpus import Corpus
+    from bib2graph.schemas import CORPUS_SCHEMA
+    from bib2graph.stores.duckdb import DuckDBStore
+
+    store_path = tmp_path / "replace_equations.duckdb"
+    store = DuckDBStore(store_path)
+    store.backend.persist_equation(
+        "eq-0001", engine="openalex", raw_query="unequal exchange", params_json="{}"
+    )
+
+    row = {
+        "id": "doi:p1",
+        "source_id": None,
+        "doi": None,
+        "title": "Paper P1",
+        "year": 2020,
+        "abstract": None,
+        "source": None,
+        "language": None,
+        "publisher": None,
+        "research_areas": None,
+        "is_seed": True,
+        "curation_status": "candidate",
+        "provenance": None,
+        "authors_raw": None,
+        "authors_id": None,
+        "authors_affiliations": None,
+        "keywords_raw": None,
+        "keywords_id": None,
+        "institutions_raw": None,
+        "institutions_id": None,
+        "references_id": None,
+        "references_doi": None,
+        "cited_by_id": None,
+    }
+    table = pa.Table.from_pylist([row], schema=CORPUS_SCHEMA)
+    corpus = Corpus.from_arrow(table)
+
+    # persist_replace hace DELETE FROM corpus + INSERT masivo (overwrite_corpus).
+    store.persist_replace(corpus)
+
+    equations_after = store.backend.load_equations()
+    corpus_after = store.backend.to_arrow()
+    store.close()
+
+    assert len(corpus_after) == 1
+    assert len(equations_after) == 1
+    assert equations_after[0]["equation_id"] == "eq-0001"
+    assert equations_after[0]["raw_query"] == "unequal exchange"

--- a/tests/unit/test_export_corpus_arrow_bibtex.py
+++ b/tests/unit/test_export_corpus_arrow_bibtex.py
@@ -656,6 +656,168 @@ class TestExportFormatBibtex:
 
 
 # ---------------------------------------------------------------------------
+# 2b. Deuda de cobertura 0.14.0: corpus vacío / scope sin filas.
+# ---------------------------------------------------------------------------
+
+
+class TestExportCorpusVacioOScopeSinFilas:
+    """Bordes no cubiertos: store sin papers, y ``--scope`` que da 0 filas.
+
+    Ninguno de los dos casos debe crashear: ``export`` produce un artefacto
+    válido (schema presente en arrow; .bib vacío parseable) con 0 filas,
+    exit 0 y envelope ok.
+    """
+
+    def test_arrow_corpus_vacio_produce_arrow_valido_0_filas(
+        self, tmp_path: Path
+    ) -> None:
+        """Store sin papers -> --format arrow no crashea; .arrow con 0 filas."""
+        from bib2graph.cli import b2g
+        from bib2graph.stores.duckdb import DuckDBStore
+
+        ws = _init_workspace(tmp_path)
+        # Store inicializado (DDL creado) pero sin persistir ningún paper:
+        # abrir y cerrar basta para materializar el archivo .duckdb vacío.
+        store = DuckDBStore(ws.library_path)
+        store.close()
+
+        runner = CliRunner()
+        result = runner.invoke(
+            b2g,
+            ["--workspace", str(ws.root), "export", "--format", "arrow", "--json"],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, f"Error: {result.output}"
+        envelope = json.loads(result.output)
+        assert envelope["ok"] is True
+        data = envelope["data"]
+        assert data["rows_exported"] == 0
+
+        import pyarrow.feather as feather
+
+        arrow_path = Path(data["files_written"][0])
+        assert arrow_path.exists()
+        reread = feather.read_table(str(arrow_path))
+        assert set(reread.schema.names) == set(CORPUS_SCHEMA.names)
+        assert reread.num_rows == 0
+
+    def test_bibtex_corpus_vacio_produce_bib_valido_0_entradas(
+        self, tmp_path: Path
+    ) -> None:
+        """Store sin papers -> --format bibtex no crashea; .bib vacío parseable."""
+        pytest.importorskip("bibtexparser")
+        from bib2graph.cli import b2g
+        from bib2graph.stores.duckdb import DuckDBStore
+
+        ws = _init_workspace(tmp_path)
+        store = DuckDBStore(ws.library_path)
+        store.close()
+
+        runner = CliRunner()
+        result = runner.invoke(
+            b2g,
+            ["--workspace", str(ws.root), "export", "--format", "bibtex", "--json"],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, f"Error: {result.output}"
+        envelope = json.loads(result.output)
+        assert envelope["ok"] is True
+        data = envelope["data"]
+        assert data["rows_exported"] == 0
+
+        import bibtexparser
+
+        bib_path = Path(data["files_written"][0])
+        assert bib_path.exists()
+        parsed = bibtexparser.loads(bib_path.read_text(encoding="utf-8"))
+        assert len(parsed.entries) == 0
+
+    def test_scope_seeds_sin_semillas_exporta_arrow_con_0_filas(
+        self, tmp_path: Path
+    ) -> None:
+        """Corpus con papers pero NINGUNO semilla + --scope seeds -> 0 filas, sin crash."""
+        from bib2graph.cli import b2g
+
+        ws = _init_workspace(tmp_path)
+        _seed_store(
+            ws.library_path,
+            [
+                _row("doi:p1", is_seed=False, curation_status="accepted"),
+                _row("doi:p2", is_seed=False, curation_status="candidate"),
+            ],
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(
+            b2g,
+            [
+                "--workspace",
+                str(ws.root),
+                "export",
+                "--format",
+                "arrow",
+                "--scope",
+                "seeds",
+                "--json",
+            ],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, f"Error: {result.output}"
+        envelope = json.loads(result.output)
+        assert envelope["ok"] is True
+        data = envelope["data"]
+        assert data["rows_exported"] == 0
+
+        import pyarrow.feather as feather
+
+        arrow_path = Path(data["files_written"][0])
+        reread = feather.read_table(str(arrow_path))
+        assert reread.num_rows == 0
+
+    def test_scope_seeds_sin_semillas_exporta_bibtex_con_0_entradas(
+        self, tmp_path: Path
+    ) -> None:
+        """Idem anterior pero --format bibtex: .bib vacío parseable, sin crash."""
+        pytest.importorskip("bibtexparser")
+        from bib2graph.cli import b2g
+
+        ws = _init_workspace(tmp_path)
+        _seed_store(
+            ws.library_path,
+            [
+                _row("doi:p1", is_seed=False, curation_status="accepted"),
+            ],
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(
+            b2g,
+            [
+                "--workspace",
+                str(ws.root),
+                "export",
+                "--format",
+                "bibtex",
+                "--scope",
+                "seeds",
+                "--json",
+            ],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, f"Error: {result.output}"
+        envelope = json.loads(result.output)
+        assert envelope["ok"] is True
+        data = envelope["data"]
+        assert data["rows_exported"] == 0
+
+        import bibtexparser
+
+        bib_path = Path(data["files_written"][0])
+        parsed = bibtexparser.loads(bib_path.read_text(encoding="utf-8"))
+        assert len(parsed.entries) == 0
+
+
+# ---------------------------------------------------------------------------
 # 3. --scope ignorado (con warning) para graphml/csv
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_export_corpus_arrow_bibtex.py
+++ b/tests/unit/test_export_corpus_arrow_bibtex.py
@@ -95,6 +95,26 @@ def _init_workspace(tmp_path: Path, name: str = "ws") -> Any:
     return Workspace.init(ws_dir, name)
 
 
+def _persist_equations(store_path: Path, equation_ids: list[str]) -> None:
+    """Persiste N ecuaciones (tabla lateral ``equations``, ADR 0050 D1) en el store.
+
+    Args:
+        store_path: Ruta al archivo ``.duckdb``.
+        equation_ids: IDs de ecuación a persistir (0, 1 o varios).
+    """
+    from bib2graph.stores.duckdb import DuckDBStore
+
+    store = DuckDBStore(store_path)
+    for eq_id in equation_ids:
+        store.backend.persist_equation(
+            eq_id,
+            engine="openalex",
+            raw_query=f"query for {eq_id}",
+            params_json="{}",
+        )
+    store.close()
+
+
 def _mixed_rows() -> list[dict[str, Any]]:
     """3 papers: 2 semillas (1 aceptada, 1 candidata) + 1 no-semilla aceptado."""
     return [
@@ -289,6 +309,120 @@ class TestExportFormatArrow:
         data = json.loads(result.output)["data"]
         assert Path(data["out_dir"]) == ws.exports_dir
         assert (ws.exports_dir / "corpus.arrow").exists()
+
+
+# ---------------------------------------------------------------------------
+# 1b. --format arrow — warning de equation_hash omitido (ADR 0050 D3, #291/#292)
+# ---------------------------------------------------------------------------
+
+
+class TestExportArrowEquationHashWarning:
+    """El comando ``export`` es el punto de consumo real de
+    ``build_equation_metadata``: ``to_arrow()`` puebla ``equation_hash`` en la
+    metadata del schema cuando hay exactamente 1 ecuación, pero descarta el
+    warning a propósito (no ruidoso para llamadas internas). El comando debe
+    recuperar ese warning y propagarlo en el envelope cuando hay 0 o >1
+    ecuaciones registradas."""
+
+    def test_cero_ecuaciones_emite_warning_en_envelope(self, tmp_path: Path) -> None:
+        """0 ecuaciones registradas -> warning de equation_hash omitido en --json."""
+        from bib2graph.cli import b2g
+
+        ws = _init_workspace(tmp_path)
+        _seed_store(ws.library_path, _mixed_rows())
+        # Sin persistir ninguna ecuación.
+
+        runner = CliRunner()
+        result = runner.invoke(
+            b2g,
+            ["--workspace", str(ws.root), "export", "--format", "arrow", "--json"],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, f"Error: {result.output}"
+        envelope = json.loads(result.output)
+        warnings_list = envelope.get("warnings") or []
+        assert any("equation_hash" in w and "0 ecuaci" in w for w in warnings_list)
+
+        import pyarrow.feather as feather
+
+        arrow_path = Path(envelope["data"]["files_written"][0])
+        reread = feather.read_table(str(arrow_path))
+        metadata = reread.schema.metadata or {}
+        assert b"equation_hash" not in metadata
+
+    def test_multiples_ecuaciones_emite_warning_en_envelope(
+        self, tmp_path: Path
+    ) -> None:
+        """>1 ecuaciones registradas -> warning de equation_hash omitido en --json."""
+        from bib2graph.cli import b2g
+
+        ws = _init_workspace(tmp_path)
+        _seed_store(ws.library_path, _mixed_rows())
+        _persist_equations(ws.library_path, ["eq-1", "eq-2"])
+
+        runner = CliRunner()
+        result = runner.invoke(
+            b2g,
+            ["--workspace", str(ws.root), "export", "--format", "arrow", "--json"],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, f"Error: {result.output}"
+        envelope = json.loads(result.output)
+        warnings_list = envelope.get("warnings") or []
+        assert any("equation_hash" in w and "2 ecuaci" in w for w in warnings_list)
+
+        import pyarrow.feather as feather
+
+        arrow_path = Path(envelope["data"]["files_written"][0])
+        reread = feather.read_table(str(arrow_path))
+        metadata = reread.schema.metadata or {}
+        assert b"equation_hash" not in metadata
+
+    def test_una_ecuacion_no_hay_warning_y_hash_presente(self, tmp_path: Path) -> None:
+        """1 ecuación registrada -> sin warning; el .arrow trae equation_hash."""
+        from bib2graph.cli import b2g
+
+        ws = _init_workspace(tmp_path)
+        _seed_store(ws.library_path, _mixed_rows())
+        _persist_equations(ws.library_path, ["eq-1"])
+
+        runner = CliRunner()
+        result = runner.invoke(
+            b2g,
+            ["--workspace", str(ws.root), "export", "--format", "arrow", "--json"],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, f"Error: {result.output}"
+        envelope = json.loads(result.output)
+        warnings_list = envelope.get("warnings") or []
+        assert not any("equation_hash" in w for w in warnings_list)
+
+        import pyarrow.feather as feather
+
+        arrow_path = Path(envelope["data"]["files_written"][0])
+        reread = feather.read_table(str(arrow_path))
+        metadata = reread.schema.metadata or {}
+        assert metadata.get(b"equation_hash") is not None
+
+    def test_bibtex_no_calcula_ni_advierte_equation_hash(self, tmp_path: Path) -> None:
+        """--format bibtex NO necesita el warning: no embebe equation_hash."""
+        pytest.importorskip("bibtexparser")
+        from bib2graph.cli import b2g
+
+        ws = _init_workspace(tmp_path)
+        _seed_store(ws.library_path, _mixed_rows())
+        # Sin ecuaciones -- si bibtex disparara el mismo chequeo, advertiría.
+
+        runner = CliRunner()
+        result = runner.invoke(
+            b2g,
+            ["--workspace", str(ws.root), "export", "--format", "bibtex", "--json"],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, f"Error: {result.output}"
+        envelope = json.loads(result.output)
+        warnings_list = envelope.get("warnings") or []
+        assert not any("equation_hash" in w for w in warnings_list)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_export_corpus_arrow_bibtex.py
+++ b/tests/unit/test_export_corpus_arrow_bibtex.py
@@ -426,6 +426,90 @@ class TestExportArrowEquationHashWarning:
 
 
 # ---------------------------------------------------------------------------
+# 1c. QA 0.14.0 (hallazgo #3): el warning de equation_hash NO se duplica
+# entre data.warnings y el warnings top-level del envelope.
+# ---------------------------------------------------------------------------
+
+
+class TestExportWarningNoDuplicado:
+    """El envelope tiene UN solo canal canónico de warnings (el top-level,
+    ADR 0021 §C). Antes ``data`` (que ya traía su propia clave ``warnings``
+    para el aviso de equation_hash omitido) se pasaba entero al envelope Y
+    las mismas warnings se copiaban también al top-level, duplicando el
+    texto en ambos lugares."""
+
+    def test_equation_hash_warning_aparece_una_sola_vez(self, tmp_path: Path) -> None:
+        """2 ecuaciones -> el warning de equation_hash aparece EXACTAMENTE 1 vez."""
+        from bib2graph.cli import b2g
+
+        ws = _init_workspace(tmp_path)
+        _seed_store(ws.library_path, _mixed_rows())
+        _persist_equations(ws.library_path, ["eq-1", "eq-2"])
+
+        runner = CliRunner()
+        result = runner.invoke(
+            b2g,
+            ["--workspace", str(ws.root), "export", "--format", "arrow", "--json"],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, f"Error: {result.output}"
+        envelope = json.loads(result.output)
+
+        # No duplicado en data: la clave "warnings" no debe sobrevivir en data
+        # (el canal canónico es SOLO el top-level).
+        assert "warnings" not in envelope["data"]
+
+        top_level_warnings = envelope.get("warnings") or []
+        equation_hash_warnings = [w for w in top_level_warnings if "equation_hash" in w]
+        assert len(equation_hash_warnings) == 1, (
+            f"El warning de equation_hash debe aparecer 1 sola vez, "
+            f"apareció {len(equation_hash_warnings)} veces: {equation_hash_warnings}"
+        )
+
+    def test_scope_ignorado_warning_tampoco_se_duplica(self, tmp_path: Path) -> None:
+        """El warning de scope-ignorado (graphml/csv) tampoco se duplica."""
+        from bib2graph.cli import b2g
+        from bib2graph.cli.commands.build import run_build
+
+        ws = _init_workspace(tmp_path)
+        _seed_store(
+            ws.library_path,
+            [
+                _row("doi:p1", references_id=["R1", "R2"]),
+                _row("doi:p2", references_id=["R1", "R3"]),
+            ],
+        )
+        run_build(ws.library_path, out_dir=ws.networks_dir)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            b2g,
+            [
+                "--workspace",
+                str(ws.root),
+                "export",
+                "--format",
+                "graphml",
+                "--scope",
+                "seeds",
+                "--json",
+            ],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, f"Error: {result.output}"
+        envelope = json.loads(result.output)
+
+        assert "warnings" not in envelope["data"]
+
+        top_level_warnings = envelope.get("warnings") or []
+        scope_warnings = [w for w in top_level_warnings if "--scope" in w]
+        assert len(scope_warnings) == 1, (
+            f"El warning de --scope debe aparecer 1 sola vez, "
+            f"apareció {len(scope_warnings)} veces: {scope_warnings}"
+        )
+
+
+# ---------------------------------------------------------------------------
 # 2. --format bibtex
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_restore.py
+++ b/tests/unit/test_restore.py
@@ -15,6 +15,10 @@ Casos cubiertos (movidos desde test_equation_spec.py + extendidos):
 6. El estado FILTERED habilita build aguas abajo (FSM permisiva: apply_transition
    desde FILTERED → build → BUILT es válido).
 7. b2g snapshot restore requiere --from-corpus (no hay modo sin argumento).
+8. QA 0.14.0 (ADR 0050 D1, eslabón final): ``snapshot restore`` reconstruye las
+   ecuaciones desde el ``manifest.json`` hermano del parquet — antes se perdían
+   (round-trip create→restore dejaba ``load_equations() == 0``). Graceful si
+   no hay manifest hermano.
 
 Filosofía (AGENTS.md): se testea la FUNCIÓN detrás del comando, NO el parser
 Click. CliRunner solo donde hay integración de flag necesaria.
@@ -501,3 +505,184 @@ def test_run_restore_con_estado_previo_preserva_ronda(tmp_path: Path) -> None:
     )
     assert store2.backend.loop_state() == CycleState.FILTERED
     assert store2.backend.loop_round() == 2
+
+
+# ---------------------------------------------------------------------------
+# 9. QA 0.14.0 (ADR 0050 D1, eslabón final): snapshot restore reconstruye
+#    equations desde el manifest.json hermano del parquet.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_snapshot_restore_reconstruye_equations_round_trip(tmp_path: Path) -> None:
+    """Round-trip: sembrar 2 ecuaciones → snapshot create → snapshot restore
+    en un store/workspace FRESCO → ``load_equations()`` refleja las mismas
+    ecuaciones (equation_id/raw_query) y ``manifest.equations`` no está vacío.
+
+    Cierra el eslabón final de ADR 0050 D1: ``snapshot create`` ya sellaba
+    ``equations`` en el manifest y ``DuckDBStore.load()`` ya las reconstruía
+    en memoria desde la tabla lateral; lo único que faltaba era que
+    ``snapshot restore`` las re-sembrara en el store DESTINO (fresco, sin la
+    tabla lateral poblada).
+    """
+    import httpx
+
+    from bib2graph.cli.commands.seed import run_seed
+    from bib2graph.service.snapshot import run_restore, run_snapshot
+    from bib2graph.stores.duckdb import DuckDBStore
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={"results": [], "meta": {"count": 0, "next_cursor": None}},
+            headers={"x-openalex-api-version": "2026-06-17"},
+        )
+
+    transport = httpx.MockTransport(handler)
+
+    # --- 1. Sembrar 2 ecuaciones en el store ORIGEN ---
+    origin_store_path = tmp_path / "origin.duckdb"
+    run_seed(origin_store_path, "ecology", transport=transport)
+    run_seed(origin_store_path, "environmental justice", transport=transport)
+
+    origin_store = DuckDBStore(origin_store_path)
+    try:
+        origin_equations = origin_store.backend.load_equations()
+    finally:
+        origin_store.close()
+    assert len(origin_equations) >= 1  # puede colapsar a 1 si cae en el mismo segundo
+
+    # --- 2. snapshot create: exporta parquet + manifest.json sellando equations ---
+    snap_dir = tmp_path / "snap"
+    run_snapshot(origin_store_path, out_dir=snap_dir)
+    manifest_path = snap_dir / "manifest.json"
+    assert manifest_path.exists()
+    manifest_data = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert manifest_data["equations"], "el manifest debe sellar ecuaciones no vacías"
+
+    # --- 3. snapshot restore en un store FRESCO (nunca vio estas ecuaciones) ---
+    fresh_store_path = tmp_path / "fresh.duckdb"
+    run_restore(fresh_store_path, snap_dir / "corpus.parquet")
+
+    fresh_store = DuckDBStore(fresh_store_path)
+    try:
+        restored_equations = fresh_store.backend.load_equations()
+        restored_corpus = fresh_store.load()
+    finally:
+        fresh_store.close()
+
+    # equation_id/raw_query coinciden con los sembrados en origen.
+    origin_ids = {eq["equation_id"] for eq in origin_equations}
+    restored_ids = {eq["equation_id"] for eq in restored_equations}
+    assert restored_ids == origin_ids
+
+    origin_raw_queries = {eq["raw_query"] for eq in origin_equations}
+    restored_raw_queries = {eq["raw_query"] for eq in restored_equations}
+    assert restored_raw_queries == origin_raw_queries
+
+    # manifest.equations (reconstruido por DuckDBStore.load()) no está vacío.
+    assert len(restored_corpus.manifest.equations) == len(restored_equations)
+
+
+@pytest.mark.unit
+def test_snapshot_restore_reconstruye_equations_via_cli(tmp_path: Path) -> None:
+    """``b2g snapshot restore --from-corpus`` (CliRunner) reconstruye equations.
+
+    Cubre el camino end-to-end real: ``b2g snapshot create`` seguido de
+    ``b2g snapshot restore`` en un workspace fresco.
+    """
+    import httpx
+    from click.testing import CliRunner
+
+    from bib2graph.cli import b2g
+    from bib2graph.cli.commands.seed import run_seed
+    from bib2graph.service.snapshot import run_snapshot
+    from bib2graph.stores.duckdb import DuckDBStore
+    from bib2graph.workspace import Workspace
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={"results": [], "meta": {"count": 0, "next_cursor": None}},
+            headers={"x-openalex-api-version": "2026-06-17"},
+        )
+
+    transport = httpx.MockTransport(handler)
+
+    origin_ws_dir = tmp_path / "origin_ws"
+    origin_ws = Workspace.init(origin_ws_dir, "origin")
+    run_seed(origin_ws.library_path, "unequal exchange", transport=transport)
+
+    snap_dir = tmp_path / "snap_cli"
+    run_snapshot(origin_ws.library_path, out_dir=snap_dir)
+
+    fresh_ws_dir = tmp_path / "fresh_ws"
+    Workspace.init(fresh_ws_dir, "fresh")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        b2g,
+        [
+            "--workspace",
+            str(fresh_ws_dir),
+            "snapshot",
+            "restore",
+            "--from-corpus",
+            str(snap_dir / "corpus.parquet"),
+            "--json",
+        ],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, f"Salida inesperada: {result.output}"
+
+    # Resolver la ruta canónica del store vía el Workspace (evita asumir nombre de archivo).
+    ws2 = Workspace.open(fresh_ws_dir)
+    fresh_store = DuckDBStore(ws2.library_path)
+    try:
+        restored_equations = fresh_store.backend.load_equations()
+    finally:
+        fresh_store.close()
+
+    assert len(restored_equations) == 1
+    assert restored_equations[0]["raw_query"] == "unequal exchange"
+
+
+@pytest.mark.unit
+def test_snapshot_restore_sin_manifest_hermano_es_graceful(tmp_path: Path) -> None:
+    """Restore desde un parquet SIN manifest.json hermano no crashea.
+
+    Simula un parquet curado externo suelto (p.ej. exportado a mano, sin el
+    ``manifest.json`` que produce ``snapshot create``): 0 ecuaciones
+    reconstruidas, sin excepción, y las filas del corpus se importan igual
+    que siempre (no regresión).
+    """
+    from bib2graph.service.snapshot import run_restore
+    from bib2graph.stores.duckdb import DuckDBStore
+
+    rows = [
+        _make_corpus_row(id="P1"),
+        _make_corpus_row(id="P2", curation_status="accepted"),
+    ]
+    parquet_path = tmp_path / "external_corpus.parquet"
+    _make_parquet(parquet_path, rows)
+    # Sin manifest.json hermano en tmp_path.
+    assert not (tmp_path / "manifest.json").exists()
+
+    store_path = tmp_path / "test.duckdb"
+    data = run_restore(store_path, parquet_path)
+
+    assert data["papers_loaded"] == 2
+    assert data["total_papers"] == 2
+
+    store = DuckDBStore(store_path)
+    try:
+        equations = store.backend.load_equations()
+        corpus = store.load()
+        corpus_len = len(corpus)
+        manifest_equations = corpus.manifest.equations
+    finally:
+        store.close()
+
+    assert equations == []
+    assert manifest_equations == []
+    assert corpus_len == 2

--- a/tests/unit/test_status_10.py
+++ b/tests/unit/test_status_10.py
@@ -864,3 +864,138 @@ class TestContratoEnvelope:
         assert envelope["data"]["next_best_action"] == "build"
         assert envelope["data"]["readiness"]["ready"] is True
         assert len(envelope["data"]["build_preview"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# QA 0.14.0 hallazgo #2: b2g status expone las ecuaciones registradas
+# (tabla lateral ``equations``, ADR 0050 D1) — antes invisibles.
+# ---------------------------------------------------------------------------
+
+
+class TestStatusExponeEquations:
+    """``run_status`` incluye ``equations`` leído de ``backend.load_equations()``."""
+
+    def test_status_sin_ecuaciones_da_lista_vacia(self, tmp_path: Path) -> None:
+        """Store sin ecuaciones registradas → equations=[] sin romper."""
+        from bib2graph.cli.commands.status import run_status
+
+        store_path = tmp_path / "test.duckdb"
+        _seed_store(store_path, [_row("P1")])
+
+        data = run_status(store_path)
+
+        assert data["equations"] == []
+
+    def test_status_con_ecuaciones_las_expone_en_data(self, tmp_path: Path) -> None:
+        """Ecuaciones persistidas aparecen en data['equations'] con sus campos."""
+        from bib2graph.cli.commands.status import run_status
+        from bib2graph.stores.duckdb import DuckDBStore
+
+        store_path = tmp_path / "test.duckdb"
+        _seed_store(store_path, [_row("P1")])
+
+        store = DuckDBStore(store_path)
+        try:
+            store.backend.persist_equation(
+                "eq-20260101T000000",
+                engine="openalex",
+                raw_query="unequal exchange",
+                params_json='{"raw_query": "unequal exchange"}',
+                created_at="2026-01-01T00:00:00+00:00",
+            )
+            store.backend.persist_equation(
+                "eq-20260102T000000",
+                engine="openalex",
+                raw_query="ecological debt",
+                params_json='{"raw_query": "ecological debt"}',
+                created_at="2026-01-02T00:00:00+00:00",
+            )
+        finally:
+            store.close()
+
+        data = run_status(store_path)
+
+        assert len(data["equations"]) == 2
+        equation_ids = {eq["equation_id"] for eq in data["equations"]}
+        assert equation_ids == {"eq-20260101T000000", "eq-20260102T000000"}
+        first = next(
+            eq for eq in data["equations"] if eq["equation_id"] == "eq-20260101T000000"
+        )
+        assert first["raw_query"] == "unequal exchange"
+        assert first["engine"] == "openalex"
+        assert first["created_at"] == "2026-01-01T00:00:00+00:00"
+
+    def _init_workspace_with_equation(self, tmp_path: Path, *, seeded: bool) -> Path:
+        """Crea un workspace (ADR 0029), sembra una fila y opcionalmente 1 ecuación."""
+        from bib2graph.stores.duckdb import DuckDBStore
+        from bib2graph.workspace import Workspace
+
+        ws_root = tmp_path / "ws"
+        ws = Workspace.init(ws_root, name="test")
+
+        _seed_store(ws.library_path, [_row("P1")])
+
+        if seeded:
+            store = DuckDBStore(ws.library_path)
+            try:
+                store.backend.persist_equation(
+                    "eq-20260101T000000",
+                    engine="openalex",
+                    raw_query="unequal exchange",
+                    params_json="{}",
+                    created_at="2026-01-01T00:00:00+00:00",
+                )
+            finally:
+                store.close()
+
+        return ws_root
+
+    def test_status_json_envelope_incluye_equations(self, tmp_path: Path) -> None:
+        """``status --json`` expone ``data.equations`` vía el CLI runner."""
+        import json as _json
+
+        from click.testing import CliRunner
+
+        from bib2graph.cli import b2g
+
+        ws_root = self._init_workspace_with_equation(tmp_path, seeded=True)
+
+        runner = CliRunner()
+        result = runner.invoke(b2g, ["--workspace", str(ws_root), "status", "--json"])
+
+        assert result.exit_code == 0, result.output
+        envelope = _json.loads(result.output)
+        assert "equations" in envelope["data"]
+        assert len(envelope["data"]["equations"]) == 1
+        assert envelope["data"]["equations"][0]["raw_query"] == "unequal exchange"
+
+    def test_status_humano_lista_ecuaciones_registradas(self, tmp_path: Path) -> None:
+        """Modo humano imprime la sección 'Ecuaciones registradas (N):'."""
+        from click.testing import CliRunner
+
+        from bib2graph.cli import b2g
+
+        ws_root = self._init_workspace_with_equation(tmp_path, seeded=True)
+
+        runner = CliRunner()
+        result = runner.invoke(b2g, ["--workspace", str(ws_root), "status"])
+
+        assert result.exit_code == 0, result.output
+        assert "Ecuaciones registradas (1):" in result.output
+        assert "eq-20260101T000000" in result.output
+        assert "unequal exchange" in result.output
+        assert "openalex" in result.output
+
+    def test_status_humano_sin_ecuaciones_muestra_cero(self, tmp_path: Path) -> None:
+        """Store sin ecuaciones → sección igual aparece con conteo 0, sin romper."""
+        from click.testing import CliRunner
+
+        from bib2graph.cli import b2g
+
+        ws_root = self._init_workspace_with_equation(tmp_path, seeded=False)
+
+        runner = CliRunner()
+        result = runner.invoke(b2g, ["--workspace", str(ws_root), "status"])
+
+        assert result.exit_code == 0, result.output
+        assert "Ecuaciones registradas (0):" in result.output


### PR DESCRIPTION
Consolida sobre `dev` los fixes de QA y de revisión arquitectónica del corte 0.14.0. Los 4 PRs base (#299 export, #300 equations, #301 API.md, #302 despersonalización) ya están en `dev`; este PR aterriza **solo el delta de fixes** (7 commits, 14 archivos), validado con el capstone real (alfabetización digital crítica, 398 papers).

> **Mergear con MERGE COMMIT (no squash)** para preservar la granularidad de los 7 commits en el CHANGELOG que release-please generará al cortar `dev → main`.

## Hallazgos de la revisión arquitectónica
- **`af847c5`** — propaga el warning de `equation_hash` omitido (0/N ecuaciones) al envelope de `export --format arrow` (antes se omitía en silencio); DRY de `_map_scope` a `cli/_scope.py` (compartido build/export).

## Hallazgos de QA (con datos reales)
- **`87ea10f`** — **bug**: `DuckDBStore.load()` no reconstruía `manifest.equations` desde la tabla lateral → el snapshot sellaba `equations:[]` y perdía la procedencia. Ahora la reconstruye. Además: `status` expone las ecuaciones (`data.equations` + humano), y se desduplica el warning del envelope de export.
- **`4f37e76`** — mismo patrón de warning duplicado en `build.py` → canal único (top-level); + test que lo caza (el previo solo veía presencia, no duplicación).
- **`e64fbff`** — **bug**: `snapshot restore` no reconstruía las equations desde el `manifest.json` hermano → cierra el **round-trip de D1 de punta a punta** (seed→load→status→create→**restore**). Graceful sin manifest.

## Cobertura y docs
- **`6b8031c`** — tests: clone/persist_replace preservan equations; export de corpus-vacío (arrow/bibtex 0 filas) y scope sin filas.
- **`ef0fed3`** + **`aa061df`** — docs: `API.md` (status.equations, D1 completo, restore) + **ADR 0021** enmienda que fija la norma del **canal único de warnings**.

## Verificación (round-trip D1 real)
`seed` persiste → `load()` reconstruye (0→2) → `status` muestra "Ecuaciones (2)" → `snapshot create` sella (2) → `snapshot restore` recupera (0→2). Todo con el `equation_hash` bit-exacto para 1 ecuación / omitido+warning para >1.

## Gate
ruff/format/mypy limpios; 131 tests tocados verdes (CI corre el completo).