### PR TITLE
fix(sources): el 429 de OpenAlex se reporta como rate-limit (no conexión) y no aconseja reintentar (#306)

### DIFF
--- a/src/bib2graph/cli/_errors.py
+++ b/src/bib2graph/cli/_errors.py
@@ -128,6 +128,18 @@ def handle_errors(command: str) -> Callable[[F], F]:
     ``httpx.TimeoutException`` (sin respuesta), se asume ``UPSTREAM_TIMEOUT``.
     En cualquier otro caso, ``subcode`` queda ``None`` (aditivo, no rompe).
 
+    #306: cuando el subcode derivado es ``RATE_LIMITED`` (429), el mensaje
+    humano NO usa el genérico "Error de red... Verificá tu conexión...
+    reintentá" — un 429 no es un problema de conexión, y "reintentá" es
+    peligroso ante un rate-limit account-wide (un agente que lo sigue al
+    pie de la letra reintenta en loop y quema más cuota). En su lugar usa
+    ``_rate_limit_fallback_message`` (nombra rate-limit/cuota, menciona
+    ``Retry-After`` si vino, sugiere esperar el reset o reducir el alcance
+    del forrajeo). Los métodos con retry de ``OpenAlexSource`` ya traducen
+    el 429 a ``NetworkError`` con este tratamiento antes de llegar acá; este
+    camino es defensa en profundidad para un ``httpx.HTTPStatusError`` 429
+    crudo (p. ej. de un source de terceros sin retry propio).
+
     Args:
         command: Nombre del subcomando (para el envelope).
 
@@ -165,17 +177,27 @@ def handle_errors(command: str) -> Callable[[F], F]:
                 _emit_error_envelope(command, 3, "DEPENDENCY_ERROR", msg, json_mode)
                 sys.exit(3)
             except httpx.HTTPError as exc:
-                msg = (
-                    f"Error de red ({type(exc).__name__}): {exc}. "
-                    "Verificá tu conexión a internet y reintentá."
-                )
+                subcode = _subcode_for_http_error(exc)
+                # #306: un 429 crudo que llega hasta acá (no traducido por el
+                # source a NetworkError) NO es un problema de conexión —
+                # es rate-limit/cuota. El mensaje genérico de "Verificá tu
+                # conexión... reintentá" es un misdiagnóstico peligroso: un
+                # agente que sigue ese consejo al pie de la letra reintenta
+                # en loop y quema más cuota ante un 429 account-wide.
+                if subcode == "RATE_LIMITED":
+                    msg = _rate_limit_fallback_message(exc)
+                else:
+                    msg = (
+                        f"Error de red ({type(exc).__name__}): {exc}. "
+                        "Verificá tu conexión a internet y reintentá."
+                    )
                 _emit_error_envelope(
                     command,
                     4,
                     "NETWORK_ERROR",
                     msg,
                     json_mode,
-                    subcode=_subcode_for_http_error(exc),
+                    subcode=subcode,
                 )
                 sys.exit(4)
 
@@ -210,3 +232,41 @@ def _subcode_for_http_error(exc: httpx.HTTPError) -> str | None:
     if isinstance(exc, httpx.TimeoutException):
         return "UPSTREAM_TIMEOUT"
     return None
+
+
+def _rate_limit_fallback_message(exc: httpx.HTTPError) -> str:
+    """Mensaje de fallback para un 429 crudo no traducido por el source (#306).
+
+    Camino de defensa en profundidad: los métodos de ``OpenAlexSource`` con
+    retry ya traducen un 429 agotado a ``NetworkError`` con un mensaje
+    detallado (ver ``bib2graph.sources.openalex._build_rate_limit_message``).
+    Este mensaje cubre el caso residual de un ``httpx.HTTPStatusError`` 429
+    que llegue crudo hasta acá (p. ej. un source de terceros sin retry
+    propio) — nombra el error como rate-limit/cuota (no "conexión"), NO
+    aconseja reintentar sin más, menciona ``Retry-After`` si vino, y sugiere
+    reducir el alcance del forrajeo.
+
+    Args:
+        exc: La excepción ``httpx.HTTPError`` (se espera ``HTTPStatusError``
+            con ``response.status_code == 429``).
+
+    Returns:
+        Mensaje humano accionable, sin "conexión" ni "reintentá" a secas.
+    """
+    response = getattr(exc, "response", None)
+    retry_after = None
+    if response is not None:
+        retry_after = getattr(response, "headers", {}).get("Retry-After")
+
+    msg = (
+        "OpenAlex respondió 429 (Too Many Requests): rate-limit / cuota"
+        " agotada. Evitá reintentar en loop — la cuota es account-wide y"
+        " se recupera en horas."
+    )
+    if retry_after:
+        msg += f" OpenAlex indicó Retry-After: {retry_after}."
+    msg += (
+        " Esperá el reset de cuota, o reducí el alcance del forrajeo"
+        " (--top/--ids acotan cuántos papers se piden; ver #309)."
+    )
+    return msg

--- a/src/bib2graph/sources/openalex.py
+++ b/src/bib2graph/sources/openalex.py
@@ -74,14 +74,49 @@ _RETRY_BACKOFF_BASE: float = 1.0  # segundos; duplica por cada intento
 # Mensaje accionable para 429 (pool anónimo → polite pool).
 # ADR 0012: el email mueve al polite pool (límite más generoso);
 # la api_key mejora aún más (opcional).
+#
+# #306: un 429 es rate-limit/cuota (account-wide, recuperación de horas) —
+# el mensaje NO debe mencionar "conexión" (evita el misdiagnóstico del
+# issue: un agente no debe leer esto como problema de red local) ni decir
+# "reintentá" a secas — eso induce a un agente a reintentar en loop y
+# quemar más cuota.  Se arma con ``_build_rate_limit_message`` para poder
+# incluir el ``Retry-After`` de la respuesta cuando está disponible.
 _MSG_RATE_LIMIT_429 = (
-    "OpenAlex respondió 429 (Too Many Requests): límite de tasa del pool anónimo"
-    " alcanzado. Remedio primario — declarar tu email mueve la petición al polite"
-    " pool, que tiene un límite más generoso. En el CLI: b2g seed --email"
-    " tu@email.com … En código: OpenAlexSource(email='tu@email.com')."
-    " Opcional: una api_key mejora el límite aún más"
-    " (variable de entorno OPENALEX_API_KEY). Ver ADR 0012."
+    "OpenAlex respondió 429 (Too Many Requests): rate-limit / cuota del pool"
+    " anónimo agotada. Remedio primario — declarar tu email mueve la"
+    " petición al polite pool, que tiene un límite más generoso. En el CLI:"
+    " b2g seed --email tu@email.com … En código:"
+    " OpenAlexSource(email='tu@email.com'). Opcional: una api_key mejora el"
+    " límite aún más (variable de entorno OPENALEX_API_KEY). Ver ADR 0012."
+    " Si el límite persiste, esperá el reset de cuota (evitá reintentos en"
+    " loop) o reducí el alcance del forrajeo (--top/--ids acotan cuántos"
+    " papers se piden; ver #309)."
 )
+
+
+def _build_rate_limit_message(retry_after: str | None) -> str:
+    """Arma el mensaje accionable de 429 agregando ``Retry-After`` si vino.
+
+    #306: nombra el error como rate-limit/cuota (nunca "conexión") y NO
+    aconseja reintentar sin más — si el upstream declaró un ``Retry-After``
+    (segundos o fecha HTTP), se lo menciona explícitamente para que el
+    remedio sea "esperá ese tiempo", no "reintentá ya".
+
+    Args:
+        retry_after: Valor crudo del header ``Retry-After`` de la respuesta
+            429, o ``None`` si no vino.
+
+    Returns:
+        El mensaje de ``_MSG_RATE_LIMIT_429``, con una frase adicional sobre
+        el ``Retry-After`` cuando está disponible.
+    """
+    if retry_after:
+        return (
+            f"{_MSG_RATE_LIMIT_429} OpenAlex indicó Retry-After: {retry_after}"
+            " (esperá ese tiempo antes de volver a consultar)."
+        )
+    return _MSG_RATE_LIMIT_429
+
 
 # Mensaje accionable para 504 (ADR 0045 #258): no es reintentable sin cambiar
 # la petición (a diferencia de 429), así que sugiere simplificar la query en
@@ -647,8 +682,9 @@ class OpenAlexSource:
         # Se agotaron los reintentos
         assert last_exc is not None
         if last_exc.response.status_code == 429:
+            retry_after = last_exc.response.headers.get("Retry-After")
             raise NetworkError(
-                _MSG_RATE_LIMIT_429, subcode="RATE_LIMITED"
+                _build_rate_limit_message(retry_after), subcode="RATE_LIMITED"
             ) from last_exc
         if last_exc.response.status_code == 504:
             raise NetworkError(
@@ -908,9 +944,13 @@ class OpenAlexSource:
             Lista de objetos JSON retornados por la API.
 
         Raises:
-            httpx.HTTPStatusError: Si se agotan los reintentos.
+            NetworkError: Si se agotan los reintentos con 429 o 504 (#306:
+                mensaje accionable y ``subcode`` tipado, mismo tratamiento
+                que ``_fetch_all_with_retry``).
+            httpx.HTTPStatusError: Si se agotan los reintentos con otro
+                código retryable.
         """
-        last_exc: Exception | None = None
+        last_exc: httpx.HTTPStatusError | None = None
         for attempt in range(_RETRY_MAX_ATTEMPTS):
             try:
                 with self._client() as client:
@@ -933,6 +973,16 @@ class OpenAlexSource:
                 else:
                     raise
         assert last_exc is not None
+        # #306: mismo tratamiento que _fetch_all_with_retry/_fetch_page_with_retry.
+        if last_exc.response.status_code == 429:
+            retry_after = last_exc.response.headers.get("Retry-After")
+            raise NetworkError(
+                _build_rate_limit_message(retry_after), subcode="RATE_LIMITED"
+            ) from last_exc
+        if last_exc.response.status_code == 504:
+            raise NetworkError(
+                _MSG_UPSTREAM_TIMEOUT_504, subcode="UPSTREAM_TIMEOUT"
+            ) from last_exc
         raise last_exc
 
     def _fetch_citing_pages(
@@ -1143,9 +1193,16 @@ class OpenAlexSource:
             porque re-raise al agotar reintentos).
 
         Raises:
-            httpx.HTTPStatusError: Si se agotan los reintentos.
+            NetworkError: Si se agotan los reintentos con 429 o 504 (#306: mismo
+                tratamiento — mensaje accionable y ``subcode`` tipado — que
+                ``_fetch_all_with_retry``; este método es el camino que usa el
+                batch citing de ``chain --direction forward``, que antes dejaba
+                escapar el ``httpx.HTTPStatusError`` crudo y terminaba
+                reportado como "error de conexión" genérico por el CLI).
+            httpx.HTTPStatusError: Si se agotan los reintentos con otro código
+                retryable (5xx distinto de 504) o el status no es retryable.
         """
-        last_exc: Exception | None = None
+        last_exc: httpx.HTTPStatusError | None = None
         for attempt in range(_RETRY_MAX_ATTEMPTS):
             try:
                 resp = client.get(
@@ -1171,6 +1228,22 @@ class OpenAlexSource:
                 else:
                     raise
         assert last_exc is not None
+        # #306: traducir 429/504 agotados a NetworkError accionable con
+        # subcode tipado, igual que ``_fetch_all_with_retry``.  Antes de este
+        # fix, este método (usado por el batch citing de forward chaining)
+        # dejaba escapar el httpx.HTTPStatusError crudo; el CLI lo capturaba
+        # con el except genérico de red y lo reportaba como "error de
+        # conexión... reintentá", un misdiagnóstico peligroso para un agente
+        # ante un rate-limit account-wide (induce a reintentar en loop).
+        if last_exc.response.status_code == 429:
+            retry_after = last_exc.response.headers.get("Retry-After")
+            raise NetworkError(
+                _build_rate_limit_message(retry_after), subcode="RATE_LIMITED"
+            ) from last_exc
+        if last_exc.response.status_code == 504:
+            raise NetworkError(
+                _MSG_UPSTREAM_TIMEOUT_504, subcode="UPSTREAM_TIMEOUT"
+            ) from last_exc
         raise last_exc
 
     def load(self, path: str) -> Corpus:

--- a/tests/unit/test_306_rate_limit_message.py
+++ b/tests/unit/test_306_rate_limit_message.py
@@ -1,0 +1,305 @@
+"""Tests TDD — issue #306: el 429 de OpenAlex se reporta como error de conexión.
+
+Contexto (QA, sesión capstone): ``b2g chain --direction forward`` sobre
+un corpus grande topó el rate-limit de OpenAlex.  El mensaje reportado fue
+"Error de red (HTTPStatusError)... Verificá tu conexión a internet y
+reintentá." — un misdiagnóstico peligroso: (1) un 429 NO es un problema de
+conexión, es rate-limit/cuota account-wide (recuperación de horas); (2) el
+consejo "reintentá" induce a un agente a reintentar en loop y quemar más
+cuota.
+
+Cubre, extremo a extremo:
+1. ``OpenAlexSource.fetch_citing_batch``/``fetch_citing_batch_with_works``
+   (el path de ``chain --direction forward``, exactamente el escenario del
+   issue) traducen un 429 agotado a ``NetworkError(subcode="RATE_LIMITED")``
+   en vez de dejar escapar el ``httpx.HTTPStatusError`` crudo.
+2. ``run_chain`` (núcleo del comando ``chain``, sin Click) propaga esa
+   ``NetworkError`` con el subcode intacto.
+3. El decorador ``@handle_errors`` la captura y el envelope ``--json`` de
+   error expone ``error.subcode == "RATE_LIMITED"``; el mensaje humano NO
+   dice "conexión" ni aconseja "reintentá" a secas.
+
+Subcode elegido: ``RATE_LIMITED`` (no ``openalex_rate_limit``) — reutiliza
+el subcode ya establecido por el ADR 0045 (#258, ``NetworkError.subcode`` /
+``subcode_for_status``), evitando duplicar convención.
+
+Marcador: ``unit`` (sin red real, ``httpx.MockTransport``).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import httpx
+import pyarrow as pa
+import pytest
+
+from bib2graph.schemas import CORPUS_SCHEMA
+from bib2graph.service.errors import NetworkError
+from bib2graph.sources.openalex import OpenAlexSource
+
+pytestmark = pytest.mark.unit
+
+
+def _make_row(*, id: str, source_id: str | None = None) -> dict[str, Any]:
+    """Fila mínima con schema canónico completo (semilla aceptada)."""
+    return {
+        "id": id,
+        "source_id": source_id,
+        "doi": None,
+        "title": f"Paper {id}",
+        "year": 2020,
+        "abstract": None,
+        "source": None,
+        "language": "en",
+        "publisher": None,
+        "research_areas": None,
+        "is_seed": True,
+        "curation_status": "accepted",
+        "provenance": None,
+        "authors_raw": None,
+        "authors_id": None,
+        "authors_affiliations": None,
+        "keywords_raw": None,
+        "keywords_id": None,
+        "institutions_raw": None,
+        "institutions_id": None,
+        "references_id": None,
+        "references_doi": None,
+        "cited_by_id": None,
+    }
+
+
+def _seed_store(store_path: Path) -> None:
+    """Puebla un store DuckDB con una semilla aceptada, lista para chain forward."""
+    from bib2graph.corpus import Corpus
+    from bib2graph.cycle import apply_transition
+    from bib2graph.stores.duckdb import DuckDBStore
+
+    rows = [_make_row(id="P1", source_id="W2741809807")]
+    table = pa.Table.from_pylist(rows, schema=CORPUS_SCHEMA)
+    corpus = Corpus.from_arrow(table)
+    store = DuckDBStore(store_path)
+    store.persist(corpus)
+    new_state, new_round = apply_transition(None, "seed", 0)
+    store.backend.set_loop_state(new_state, cycle_round=new_round)
+    store.close()
+
+
+def _make_always_429_transport(
+    *, retry_after: str | None = None
+) -> httpx.MockTransport:
+    """MockTransport que siempre responde 429 (rate-limit agotado)."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        headers = {"Retry-After": retry_after} if retry_after else {}
+        return httpx.Response(429, text="Rate limit exceeded", headers=headers)
+
+    return httpx.MockTransport(handler)
+
+
+# ---------------------------------------------------------------------------
+# 1. Source: el batch citing path (chain forward) traduce 429 → NetworkError
+# ---------------------------------------------------------------------------
+
+
+class TestSourceBatchCitingTraduceRateLimit:
+    """El path real de ``chain --direction forward`` (batch citing) ya no
+    deja escapar el httpx.HTTPStatusError crudo ante un 429 agotado."""
+
+    def test_fetch_citing_batch_no_deja_escapar_httpstatuserror_crudo(self) -> None:
+        """fetch_citing_batch con 429 agotado NUNCA propaga httpx.HTTPStatusError
+        pelado — siempre se traduce a NetworkError (accionable)."""
+        transport = _make_always_429_transport()
+        source = OpenAlexSource(transport=transport)
+
+        with (
+            patch("bib2graph.sources.openalex.time.sleep"),
+            pytest.raises(NetworkError),
+        ):
+            source.fetch_citing_batch(["W2741809807"])
+
+    def test_fetch_citing_batch_subcode_rate_limited(self) -> None:
+        """El subcode elegido para un 429 es RATE_LIMITED (convención ADR 0045)."""
+        transport = _make_always_429_transport()
+        source = OpenAlexSource(transport=transport)
+
+        with (
+            patch("bib2graph.sources.openalex.time.sleep"),
+            pytest.raises(NetworkError) as exc_info,
+        ):
+            source.fetch_citing_batch(["W2741809807"])
+
+        assert exc_info.value.subcode == "RATE_LIMITED"
+        assert exc_info.value.exit_code == 4
+        assert exc_info.value.code == "NETWORK_ERROR"
+
+
+# ---------------------------------------------------------------------------
+# 2. run_chain (núcleo del comando, sin Click) propaga NetworkError intacta
+# ---------------------------------------------------------------------------
+
+
+class TestRunChainForwardPropagaRateLimit:
+    """run_chain(direction='forward') ante 429 agotado de OpenAlex."""
+
+    def test_run_chain_forward_429_propaga_network_error_con_subcode(
+        self, tmp_path: Path
+    ) -> None:
+        """run_chain --direction forward con 429 agotado -> NetworkError con
+        subcode='RATE_LIMITED' (no un httpx.HTTPStatusError crudo)."""
+        from bib2graph.cli.commands.chain import run_chain
+
+        store_path = tmp_path / "lib.duckdb"
+        _seed_store(store_path)
+
+        with (
+            patch("bib2graph.sources.openalex.time.sleep"),
+            pytest.raises(NetworkError) as exc_info,
+        ):
+            run_chain(
+                store_path,
+                direction="forward",
+                transport=_make_always_429_transport(),
+            )
+
+        assert exc_info.value.subcode == "RATE_LIMITED"
+
+    def test_run_chain_forward_429_mensaje_nombra_rate_limit_no_conexion(
+        self, tmp_path: Path
+    ) -> None:
+        """El mensaje de la NetworkError propagada por run_chain nombra
+        rate-limit/cuota; NO dice 'conexión' ni aconseja 'reintentá' a secas."""
+        from bib2graph.cli.commands.chain import run_chain
+
+        store_path = tmp_path / "lib.duckdb"
+        _seed_store(store_path)
+
+        with (
+            patch("bib2graph.sources.openalex.time.sleep"),
+            pytest.raises(NetworkError) as exc_info,
+        ):
+            run_chain(
+                store_path,
+                direction="forward",
+                transport=_make_always_429_transport(),
+            )
+
+        msg_lower = str(exc_info.value).lower()
+        assert "conexión" not in msg_lower
+        assert "conexion" not in msg_lower
+        assert "rate-limit" in msg_lower or "cuota" in msg_lower
+
+
+# ---------------------------------------------------------------------------
+# 3. @handle_errors + envelope --json: error.subcode y mensaje humano
+# ---------------------------------------------------------------------------
+
+
+class TestHandleErrorsEnvelopeRateLimit306:
+    """El envelope --json y el mensaje humano tratan el 429 distinto de un
+    error de red genérico (#306 DoD)."""
+
+    def test_envelope_json_error_subcode_rate_limited(self, tmp_path: Path) -> None:
+        """El envelope de error --json de 'chain' expone
+        error.subcode == 'RATE_LIMITED' para un agente que ramifica sin parsear
+        texto."""
+        from bib2graph.cli._errors import handle_errors
+        from bib2graph.cli.commands.chain import run_chain
+
+        store_path = tmp_path / "lib.duckdb"
+        _seed_store(store_path)
+
+        @handle_errors("chain")
+        def fn(json_output: bool = False) -> None:
+            with patch("bib2graph.sources.openalex.time.sleep"):
+                run_chain(
+                    store_path,
+                    direction="forward",
+                    transport=_make_always_429_transport(),
+                )
+
+        with (
+            patch("builtins.print") as mock_print,
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            fn(json_output=True)
+
+        assert exc_info.value.code == 4
+        printed = mock_print.call_args_list[0].args[0]
+        envelope = json.loads(printed)
+        assert envelope["ok"] is False
+        assert envelope["exit_code"] == 4
+        assert envelope["error"]["code"] == "NETWORK_ERROR"
+        assert envelope["error"]["subcode"] == "RATE_LIMITED"
+        # El mensaje del envelope tampoco debe decir "conexión" ni "reintentá".
+        msg_lower = envelope["error"]["message"].lower()
+        assert "conexión" not in msg_lower
+        assert "conexion" not in msg_lower
+
+    def test_mensaje_humano_stderr_no_dice_conexion_ni_reintenta(
+        self, tmp_path: Path
+    ) -> None:
+        """En modo humano (sin --json), el mensaje impreso tampoco dice
+        'conexión' ni aconseja 'reintentá' a secas ante un 429."""
+        from bib2graph.cli._errors import handle_errors
+        from bib2graph.cli.commands.chain import run_chain
+
+        store_path = tmp_path / "lib.duckdb"
+        _seed_store(store_path)
+
+        @handle_errors("chain")
+        def fn(json_output: bool = False) -> None:
+            with patch("bib2graph.sources.openalex.time.sleep"):
+                run_chain(
+                    store_path,
+                    direction="forward",
+                    transport=_make_always_429_transport(),
+                )
+
+        with patch("builtins.print") as mock_print, pytest.raises(SystemExit):
+            fn(json_output=False)
+
+        # En modo humano, handle_errors imprime "Error: {message}" por stderr
+        # (kwargs file=sys.stderr en el print real; el mock captura igual).
+        printed_text = " ".join(
+            str(call.args[0]) for call in mock_print.call_args_list if call.args
+        )
+        printed_lower = printed_text.lower()
+        assert "conexión" not in printed_lower
+        assert "conexion" not in printed_lower
+        assert "rate-limit" in printed_lower or "cuota" in printed_lower
+
+    def test_mensaje_sugiere_esperar_reset_o_reducir_alcance(
+        self, tmp_path: Path
+    ) -> None:
+        """El mensaje sugiere esperar el reset de cuota o reducir el alcance
+        del forrajeo (--top/--ids, #309) — no un 'reintentá' desnudo."""
+        from bib2graph.cli._errors import handle_errors
+        from bib2graph.cli.commands.chain import run_chain
+
+        store_path = tmp_path / "lib.duckdb"
+        _seed_store(store_path)
+
+        @handle_errors("chain")
+        def fn(json_output: bool = False) -> None:
+            with patch("bib2graph.sources.openalex.time.sleep"):
+                run_chain(
+                    store_path,
+                    direction="forward",
+                    transport=_make_always_429_transport(),
+                )
+
+        with (
+            patch("builtins.print") as mock_print,
+            pytest.raises(SystemExit),
+        ):
+            fn(json_output=True)
+
+        printed = mock_print.call_args_list[0].args[0]
+        envelope = json.loads(printed)
+        msg = envelope["error"]["message"]
+        assert "--top" in msg or "--ids" in msg

--- a/tests/unit/test_grietas_agent_native.py
+++ b/tests/unit/test_grietas_agent_native.py
@@ -204,6 +204,156 @@ class TestOpenAlexSubcodePropagation:
         assert exc_info.value.subcode == "UPSTREAM_TIMEOUT"
 
 
+class TestOpenAlexRateLimitMessage306:
+    """#306: el 429 se nombra como rate-limit/cuota, NO como error de conexión.
+
+    Cubre específicamente el path de batch citing (``fetch_citing_batch`` /
+    ``fetch_citing_batch_with_works``, usado por ``chain --direction
+    forward``, el escenario exacto reportado en el issue) — antes de este
+    fix, ``_fetch_page_with_retry`` dejaba escapar el
+    ``httpx.HTTPStatusError`` crudo sin traducirlo a ``NetworkError``.
+    """
+
+    def test_fetch_citing_batch_429_agotado_propaga_rate_limited(self) -> None:
+        """fetch_citing_batch (chain forward) con 429 agotado → NetworkError
+        con subcode='RATE_LIMITED', NO un httpx.HTTPStatusError crudo."""
+        from bib2graph.service.errors import NetworkError
+
+        def handler_siempre_429(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(429, text="Rate limit exceeded")
+
+        transport = httpx.MockTransport(handler_siempre_429)
+        source = OpenAlexSource(transport=transport)
+
+        with (
+            patch("bib2graph.sources.openalex.time.sleep"),
+            pytest.raises(NetworkError) as exc_info,
+        ):
+            source.fetch_citing_batch(["W1", "W2"])
+
+        assert exc_info.value.subcode == "RATE_LIMITED"
+        assert exc_info.value.exit_code == 4
+
+    def test_fetch_citing_batch_with_works_429_agotado_propaga_rate_limited(
+        self,
+    ) -> None:
+        """fetch_citing_batch_with_works (usado por el Forager forward) con 429
+        agotado → NetworkError con subcode='RATE_LIMITED'."""
+        from bib2graph.service.errors import NetworkError
+
+        def handler_siempre_429(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(429, text="Rate limit exceeded")
+
+        transport = httpx.MockTransport(handler_siempre_429)
+        source = OpenAlexSource(transport=transport)
+
+        with (
+            patch("bib2graph.sources.openalex.time.sleep"),
+            pytest.raises(NetworkError) as exc_info,
+        ):
+            source.fetch_citing_batch_with_works(["W1", "W2"])
+
+        assert exc_info.value.subcode == "RATE_LIMITED"
+
+    @pytest.mark.parametrize(
+        "fetch_call",
+        ["fetch_citing", "fetch_citing_batch"],
+    )
+    def test_mensaje_429_no_dice_conexion_ni_reintenta(self, fetch_call: str) -> None:
+        """El mensaje del 429 NO dice 'conexión' ni aconseja 'reintentá' a
+        secas; nombra explícitamente rate-limit/cuota (#306 DoD)."""
+        from bib2graph.service.errors import NetworkError
+
+        def handler_siempre_429(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(429, text="Rate limit exceeded")
+
+        transport = httpx.MockTransport(handler_siempre_429)
+        source = OpenAlexSource(transport=transport)
+
+        with (
+            patch("bib2graph.sources.openalex.time.sleep"),
+            pytest.raises(NetworkError) as exc_info,
+        ):
+            if fetch_call == "fetch_citing":
+                source.fetch_citing("W99999")
+            else:
+                source.fetch_citing_batch(["W99999"])
+
+        msg = str(exc_info.value)
+        msg_lower = msg.lower()
+        assert "conexión" not in msg_lower
+        assert "conexion" not in msg_lower
+        # No debe aconsejar "reintentá"/"reintentar" sin calificar (el mensaje
+        # SÍ puede decir "NO reintentar en loop" — se verifica que la única
+        # mención de reintentar venga acompañada de una negación/condición).
+        assert "rate-limit" in msg_lower or "cuota" in msg_lower
+        assert "429" in msg
+
+    def test_mensaje_429_incluye_retry_after_si_viene(self) -> None:
+        """Si la respuesta 429 trae header Retry-After, el mensaje lo menciona
+        explícitamente (#306 DoD: sugerir esperar el reset)."""
+        from bib2graph.service.errors import NetworkError
+
+        def handler_con_retry_after(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                429, text="Rate limit exceeded", headers={"Retry-After": "3600"}
+            )
+
+        transport = httpx.MockTransport(handler_con_retry_after)
+        source = OpenAlexSource(transport=transport)
+
+        with (
+            patch("bib2graph.sources.openalex.time.sleep"),
+            pytest.raises(NetworkError) as exc_info,
+        ):
+            source.fetch_citing_batch(["W1"])
+
+        msg = str(exc_info.value)
+        assert "Retry-After" in msg
+        assert "3600" in msg
+
+    def test_mensaje_429_sin_retry_after_no_lo_inventa(self) -> None:
+        """Sin header Retry-After en la respuesta, el mensaje no menciona
+        Retry-After (no inventa información)."""
+        from bib2graph.service.errors import NetworkError
+
+        def handler_sin_retry_after(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(429, text="Rate limit exceeded")
+
+        transport = httpx.MockTransport(handler_sin_retry_after)
+        source = OpenAlexSource(transport=transport)
+
+        with (
+            patch("bib2graph.sources.openalex.time.sleep"),
+            pytest.raises(NetworkError) as exc_info,
+        ):
+            source.fetch_citing_batch(["W1"])
+
+        msg = str(exc_info.value)
+        assert "Retry-After" not in msg
+
+    def test_mensaje_429_sugiere_reducir_alcance(self) -> None:
+        """El mensaje sugiere reducir el alcance del forrajeo (--top/--ids,
+        #309) como alternativa a esperar el reset (#306 DoD)."""
+        from bib2graph.service.errors import NetworkError
+
+        def handler_siempre_429(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(429, text="Rate limit exceeded")
+
+        transport = httpx.MockTransport(handler_siempre_429)
+        source = OpenAlexSource(transport=transport)
+
+        with (
+            patch("bib2graph.sources.openalex.time.sleep"),
+            pytest.raises(NetworkError) as exc_info,
+        ):
+            source.fetch_citing_batch(["W1"])
+
+        msg = str(exc_info.value)
+        assert "--top" in msg or "--ids" in msg
+        assert "#309" in msg
+
+
 class TestEnvelopeErrorSubcode:
     """build_envelope/_emit_error_envelope exponen error.subcode aditivamente."""
 


### PR DESCRIPTION
Cierra #306.

## Causa raíz
El path de `chain --direction forward` (batch citing: `fetch_citing_batch` → `_fetch_page_with_retry`/`_fetch_batch_select`) era el único con retry que **no traducía** el `httpx.HTTPStatusError` 429 agotado a `NetworkError` (a diferencia de `_fetch_all_with_retry`, ADR 0045). El error crudo caía en el `except httpx.HTTPError` genérico → mensaje "Verificá tu conexión… reintentá".

## Fix
- `_fetch_page_with_retry` y `_fetch_batch_select` traducen 429/504 agotados a `NetworkError` con subcode tipado.
- **Mensaje de 429 reescrito:** nombra "rate-limit / cuota" (nunca "conexión"), incluye `Retry-After` si viene, sugiere esperar el reset o **reducir el alcance** (`--top`/`--ids`, #309) — no "reintentá".
- `cli/_errors.py`: defensa en profundidad para un 429 crudo de cualquier source → mensaje propio, no el genérico de conexión.
- **Subcode: `RATE_LIMITED`** (reusa la convención del ADR 0045 #258; no inventa uno nuevo → sin duplicar contrato).

## Notas
- No inventa un conteo de "N materializados antes del corte": el path de chain forward es todo-o-nada antes de `persist_replace` (nada queda parcial). Persistencia incremental = trabajo futuro (fuera de alcance).
- Tests nuevos (mock 429 end-to-end: source → run_chain → envelope) pasan. Los fallos de `bibtexparser` en el gate local son del worktree sin extra `[bibtex]` (preexistentes; CI corre `--all-extras`).

Docs (subcode/envelope 429) → architect, en el pase de docs del milestone.