### PR TITLE
feat(chain): forrajeo acotado — scoping (--ids/--top/--scope) + --preview + --budget (#309)

### DIFF
--- a/src/bib2graph/cli/commands/chain.py
+++ b/src/bib2graph/cli/commands/chain.py
@@ -2,13 +2,27 @@
 
 Expande el corpus con candidatos rankeados por information scent.
 Transiciona el CycleState a FORAGED tras persistir con éxito.
+
+**Guardarraíles anti-footgun (#309):** el forrajeo forward es multiplicativo
+(cada semilla dispara sus propias llamadas HTTP) y su costo es invisible hasta
+que ya se gastó — un ``chain`` sin acotar sobre cientos de semillas puede
+agotar la cuota de OpenAlex (429 account-wide, recuperación de horas).  Este
+módulo agrega, TODOS aditivos (no cambian el default sin acotar, ver
+Discussion #310):
+
+- ``--ids``/``--top``/``--scope``: acotan la **unidad escopada** — de qué
+  papers-origen se forrajea (ver ``_resolve_origin_ids``).
+- ``--preview``: dry-run que estima el fanout sin fetchear (ya existía,
+  ahora también refleja el scoping).
+- ``--budget``: tope de llamadas HTTP; al alcanzarlo, para y reporta parcial
+  SIN reintentar (ver ``foraging.base.CallBudget``).
 """
 
 from __future__ import annotations
 
 from datetime import UTC, date, datetime
 from pathlib import Path
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 import click
 
@@ -23,6 +37,129 @@ from bib2graph.cli._store import (
     workspace_echo,
     workspace_walkup_warning,
 )
+from bib2graph.constants import Col
+
+if TYPE_CHECKING:
+    from bib2graph.corpus import Corpus
+
+# Mapea el vocab de --scope (CLI) al vocab interno de corpus.scoped() —
+# mismo patrón que build.py._map_scope (#309, reusa Corpus.scoped, ADR
+# consistente con el resto del CLI: --scope usa 'seeds', scoped() 'seeds_only').
+_SCOPE_TO_INTERNAL = {"all": "all", "accepted": "accepted", "seeds": "seeds_only"}
+
+
+def _resolve_origin_ids(
+    corpus: Corpus,
+    *,
+    ids: tuple[str, ...],
+    top: int | None,
+    scope: str | None,
+) -> set[str] | None:
+    """Resuelve la unidad escopada del forrajeo (#309) a un set de ids.
+
+    Los tres flags (``--ids``, ``--top``, ``--scope``) son mutuamente
+    excluyentes en este MVP: combinar dos criterios de acotamiento distintos
+    (p. ej. "estos 3 IDs" + "los 10 más centrales") no tiene una semántica
+    obvia sin más contexto de producto — se deja para una iteración futura si
+    hay necesidad real (ver Discussion #310).
+
+    Args:
+        corpus: Corpus cargado del store.
+        ids: IDs explícitos de ``--ids`` (tupla vacía = no se usó el flag).
+        top: Valor de ``--top`` (``None`` = no se usó el flag).
+        scope: Valor de ``--scope`` (``None`` = no se usó el flag).
+
+    Returns:
+        Set de ``id``/``source_id`` a los que acotar el chaining, o ``None``
+        si no se pasó ningún flag de scoping — comportamiento ACTUAL sin
+        cambios: todas las semillas (#309, DoD "no cambiar los defaults").
+
+    Raises:
+        UsageError: Si se combina más de un flag de scoping, si ``--ids``
+            referencia IDs que no existen en el corpus, o si ``--top`` es
+            <= 0.
+    """
+    flags_used = sum([bool(ids), top is not None, scope is not None])
+    if flags_used > 1:
+        raise UsageError(
+            "--ids, --top y --scope son mutuamente excluyentes: elegí UN "
+            "criterio para acotar la unidad escopada del forrajeo."
+        )
+    if flags_used == 0:
+        return None
+
+    if ids:
+        corpus_ids: set[str] = set()
+        rows = corpus.to_arrow().to_pylist()
+        for row in rows:
+            if row.get(Col.ID):
+                corpus_ids.add(str(row[Col.ID]))
+            if row.get(Col.SOURCE_ID):
+                corpus_ids.add(str(row[Col.SOURCE_ID]))
+        missing = [id_ for id_ in ids if id_ not in corpus_ids]
+        if missing:
+            raise UsageError(
+                f"--ids referencia {len(missing)} id(s) que no están en el "
+                f"corpus: {missing}. Verificá los IDs con 'b2g read' o quitalos."
+            )
+        return set(ids)
+
+    if top is not None:
+        if top <= 0:
+            raise UsageError(f"--top debe ser un entero positivo (recibido {top}).")
+        return _top_n_seed_ids(corpus, top)
+
+    assert scope is not None  # flags_used == 1 y ni ids ni top: debe ser scope
+    internal_scope = _SCOPE_TO_INTERNAL.get(scope)
+    if internal_scope is None:
+        raise UsageError(f"--scope '{scope}' no reconocido. Usá: all, accepted, seeds.")
+    scoped_corpus = corpus.scoped(internal_scope)
+    scoped_rows = scoped_corpus.to_arrow().to_pylist()
+    result: set[str] = set()
+    for row in scoped_rows:
+        if row.get(Col.ID):
+            result.add(str(row[Col.ID]))
+        if row.get(Col.SOURCE_ID):
+            result.add(str(row[Col.SOURCE_ID]))
+    return result
+
+
+def _top_n_seed_ids(corpus: Corpus, top: int) -> set[str]:
+    """Resuelve ``--top N``: las N semillas más "centrales" del corpus.
+
+    **Criterio (#309):** nº de referencias (``len(references_id)``) como
+    proxy simple de centralidad — una semilla con más referencias listadas
+    tiene más superficie de acoplamiento bibliográfico potencial (backward) y
+    tiende a ser un hub más citado en su propio campo.  Es una **degradación
+    documentada** del criterio ideal (centralidad de acople sobre el grafo
+    construido por ``b2g build``): no requiere un build previo ni artefactos
+    en disco, es puro y determinista.  Si se necesita la centralidad real del
+    acoplamiento bibliográfico, correr ``b2g build`` y usar ``--scope``/
+    ``--ids`` con los IDs más centrales del ``metrics.json`` resultante.
+
+    Desempate: ``id`` ascendente (mismo criterio de estabilidad que
+    ``foraging.scent.rank_candidates``).
+
+    Args:
+        corpus: Corpus cargado del store.
+        top: Cuántas semillas devolver (ya validado > 0 por el llamador).
+
+    Returns:
+        Set de ``id`` (no ``source_id``: alcanza para acotar, ``_resolve_origin_ids``
+        ya matchea contra ambos en el llamador de ``Forager``) de las ``top``
+        semillas con más referencias.  Si hay menos de ``top`` semillas, se
+        devuelven todas.
+    """
+    rows = corpus.to_arrow().to_pylist()
+    seed_rows = [row for row in rows if row.get(Col.IS_SEED)]
+    ranked = sorted(
+        seed_rows,
+        key=lambda row: (
+            -len(row.get(Col.REFERENCES_ID) or []),
+            str(row.get(Col.ID)),
+        ),
+    )
+    return {str(row[Col.ID]) for row in ranked[:top] if row.get(Col.ID)}
 
 
 # Función núcleo (testeable, sin Click)
@@ -37,6 +174,10 @@ def run_chain(
     transport: Any = None,
     preview: bool = False,
     since: date | None = None,
+    ids: tuple[str, ...] = (),
+    top: int | None = None,
+    scope: str | None = None,
+    budget: int | None = None,
     _fsm_action: str | None = None,
 ) -> dict[str, Any]:
     """Expande el corpus con candidatos rankeados por information scent.
@@ -47,6 +188,15 @@ def run_chain(
     ``cited_by_id`` poblado (por un ``chain forward`` previo o la pasada
     cited_by de ``build``, ADR 0048), o indica que se requiere fetch si
     ``cited_by_id`` está vacío.
+
+    **Unidad escopada (#309):** ``ids``/``top``/``scope`` acotan de qué
+    papers-origen se forrajea (mutuamente excluyentes, ver
+    ``_resolve_origin_ids``).  Si no se pasa ninguno, comportamiento ACTUAL
+    sin cambios: todas las semillas.
+
+    **Budget (#309):** ``budget`` topa las llamadas HTTP del forward
+    chaining.  Al alcanzarlo, el forrajeo **para limpio (sin reintentar)** y
+    el resultado queda marcado como parcial (``result["budget_stopped"]``).
 
     Args:
         store_path: Ruta al archivo ``.duckdb``.
@@ -59,17 +209,29 @@ def run_chain(
         transport: Transport inyectable para tests.
         preview: Si ``True``, solo estima el crecimiento sin fetchear ni
             transicionar estado (dry-run).
+        ids: IDs explícitos de papers-origen (``--ids``, repetible).  Tupla
+            vacía (default) = no acota.
+        top: Acota a las ``top`` semillas más "centrales" (``--top``, ver
+            ``_top_n_seed_ids``).  ``None`` (default) = no acota.
+        scope: Acota al subconjunto ``all``/``accepted``/``seeds`` del
+            corpus (``--scope``, reusa ``Corpus.scoped``).  ``None``
+            (default) = no acota.
+        budget: Tope de llamadas HTTP a OpenAlex (``--budget``).  ``None``
+            (default) = sin tope (comportamiento actual).
 
     Returns:
-        Dict con ``candidates_found``, ``total_papers``, ``ranking_preview``
-        (modo normal); o con ``preview``, ``estimated_candidates``,
-        ``by_direction``, ``capped_by_max``, ``forward_requires_fetch``,
-        ``forward_from_cited_by`` (modo preview).  ``candidates_found`` es el
-        total de candidatos rankeados (backward observados + forward
-        materializados, #269); NO cuenta solo lo materializado en el corpus,
-        que en chaining puramente backward siempre da 0 (opción B, #54).
+        Dict con ``candidates_found``, ``total_papers``, ``ranking_preview``,
+        ``budget_used``, ``budget_stopped`` (modo normal); o con ``preview``,
+        ``estimated_candidates``, ``by_direction``, ``capped_by_max``,
+        ``forward_requires_fetch``, ``forward_from_cited_by``, ``origin_count``
+        (modo preview).  ``candidates_found`` es el total de candidatos
+        rankeados (backward observados + forward materializados, #269); NO
+        cuenta solo lo materializado en el corpus, que en chaining puramente
+        backward siempre da 0 (opción B, #54).
 
     Raises:
+        UsageError: Si se combina más de un flag de scoping, o si
+            ``--ids``/``--top`` son inválidos.
         DependencyError: Si el source no soporta forward chaining.
         NetworkError: Si falla la conexión a OpenAlex.
         StoreError: Si el store está bloqueado.
@@ -80,6 +242,9 @@ def run_chain(
             direction=direction,
             depth=depth,
             max_candidates=max_candidates,
+            ids=ids,
+            top=top,
+            scope=scope,
         )
 
     if since is not None and direction == "backward":
@@ -95,7 +260,7 @@ def run_chain(
         effective_direction = "forward"
 
     from bib2graph.cycle import apply_transition
-    from bib2graph.foraging import Forager
+    from bib2graph.foraging import CallBudget, Forager
     from bib2graph.sources.openalex import OpenAlexSource
 
     # Selección de acción FSM: "monitor" si --since activo O si se fuerza
@@ -133,6 +298,12 @@ def run_chain(
             current_state, fsm_action, current_round
         )
 
+        # Unidad escopada (#309): resuelve --ids/--top/--scope contra el
+        # corpus ANTES de tocar la red. None = comportamiento actual (todas
+        # las semillas), sin cambios.
+        origin_ids = _resolve_origin_ids(corpus, ids=ids, top=top, scope=scope)
+        call_budget = CallBudget(budget) if budget is not None else None
+
         source = OpenAlexSource(email=email, transport=transport)
 
         # Pre-check explícito: si la dirección requiere forward y el source no
@@ -156,6 +327,8 @@ def run_chain(
                 depth=depth,
                 max_candidates=max_candidates,
                 max_citing_per_paper=max_citing_per_paper,
+                origin_ids=origin_ids,
+                call_budget=call_budget,
             )
             ranked = forager.chain(corpus, direction=effective_direction, since=since)
         except NotImplementedError as exc:
@@ -232,6 +405,11 @@ def run_chain(
         "loop_state": new_state.value,
         "round": new_round,
         "enrichment": enrich_metrics,
+        # #309: budget del forward chaining (llamadas HTTP a /works para
+        # traer citantes).  NO incluye las llamadas de la pasada refs_doi
+        # posterior (acotada, bajo impacto — fuera de alcance del budget).
+        "budget_used": ranked.budget_used,
+        "budget_stopped": ranked.budget_stopped,
     }
 
 
@@ -241,22 +419,33 @@ def _run_chain_preview(
     direction: Literal["backward", "forward", "both"],
     depth: int,
     max_candidates: int | None,
+    ids: tuple[str, ...] = (),
+    top: int | None = None,
+    scope: str | None = None,
 ) -> dict[str, Any]:
     """Implementación del modo preview (dry-run) de ``run_chain``.
 
     Estima el crecimiento potencial del corpus **sin hacer fetch ni transicionar
     estado**.  Abre el store, lee el corpus y llama a ``Forager.preview()``.
 
+    Con ``--ids``/``--top``/``--scope`` (#309), la estimación de fanout se
+    acota al subconjunto de papers-origen resuelto — el preview refleja
+    fielmente lo que haría el ``chain`` real subsecuente sin ``--preview``.
+
     Args:
         store_path: Ruta al archivo ``.duckdb``.
         direction: Dirección pedida.
         depth: Profundidad (solo 1 implementado; >1 → DependencyError).
         max_candidates: Tope de candidatos.
+        ids: IDs explícitos de papers-origen (``--ids``).
+        top: Acota a las ``top`` semillas más "centrales" (``--top``).
+        scope: Acota al scope ``all``/``accepted``/``seeds`` (``--scope``).
 
     Returns:
         Dict con las claves del envelope de preview (``preview=True``,
         ``estimated_candidates``, ``by_direction``, ``direction``,
-        ``capped_by_max``, ``forward_requires_fetch``, ``forward_from_cited_by``).
+        ``capped_by_max``, ``forward_requires_fetch``, ``forward_from_cited_by``,
+        ``origin_count``: cuántos papers-origen participan del fanout estimado).
     """
     from bib2graph.foraging import Forager
 
@@ -264,11 +453,27 @@ def _run_chain_preview(
     try:
         corpus = store.load()
 
+        origin_ids = _resolve_origin_ids(corpus, ids=ids, top=top, scope=scope)
+        rows = corpus.to_arrow().to_pylist()
+        if origin_ids is not None:
+            # Contar PAPERS (filas), no entradas del set (que incluye tanto
+            # id como source_id por paper — contar el set duplicaría).
+            origin_count = sum(
+                1
+                for row in rows
+                if str(row.get(Col.ID)) in origin_ids
+                or str(row.get(Col.SOURCE_ID)) in origin_ids
+            )
+        else:
+            # Comportamiento actual sin scoping: origen = todas las semillas.
+            origin_count = sum(1 for row in rows if row.get(Col.IS_SEED))
+
         try:
             forager = Forager(
                 None,  # source no se usa en preview()
                 depth=depth,
                 max_candidates=max_candidates,
+                origin_ids=origin_ids,
             )
         except NotImplementedError as exc:
             raise DependencyError(
@@ -298,6 +503,9 @@ def _run_chain_preview(
         "capped_by_max": growth.capped_by_max,
         "forward_requires_fetch": growth.forward_requires_fetch,
         "forward_from_cited_by": growth.forward_from_cited_by,
+        # #309: cuántos papers-origen participan del fanout estimado (todas
+        # las semillas si no se pasó --ids/--top/--scope).
+        "origin_count": origin_count,
         "warnings": warnings,
     }
 
@@ -360,6 +568,48 @@ def _run_chain_preview(
         "Incompatible con --direction backward."
     ),
 )
+@click.option(
+    "--ids",
+    "ids",
+    multiple=True,
+    help=(
+        "Forrajea SOLO desde estos papers-origen (repetible: --ids ID1 --ids ID2). "
+        "Mutuamente excluyente con --top/--scope.  Sin este flag (default): "
+        "todas las semillas (comportamiento actual, sin cambios)."
+    ),
+)
+@click.option(
+    "--top",
+    "top",
+    type=int,
+    default=None,
+    help=(
+        "Forrajea desde las N semillas más 'centrales' (criterio: nº de "
+        "referencias, ver docstring de _top_n_seed_ids). "
+        "Mutuamente excluyente con --ids/--scope."
+    ),
+)
+@click.option(
+    "--scope",
+    "scope",
+    type=click.Choice(["all", "accepted", "seeds"]),
+    default=None,
+    help=(
+        "Forrajea desde este subconjunto del corpus (reusa Corpus.scoped). "
+        "Mutuamente excluyente con --ids/--top."
+    ),
+)
+@click.option(
+    "--budget",
+    "budget",
+    type=int,
+    default=None,
+    help=(
+        "Tope de llamadas HTTP a OpenAlex para el forward chaining.  Al "
+        "alcanzarlo, PARA y reporta el estado parcial (papers materializados, "
+        "budget usado) — nunca reintenta.  Sin límite por defecto."
+    ),
+)
 @json_option
 @click.pass_context
 @handle_errors("chain")
@@ -372,12 +622,20 @@ def chain_cmd(
     email: str | None,
     preview: bool,
     since_str: str | None,
+    ids: tuple[str, ...],
+    top: int | None,
+    scope: str | None,
+    budget: int | None,
     json_output: bool,
 ) -> None:
     """Expande el corpus con candidatos rankeados por information scent.
 
     Con --preview (dry-run), solo muestra la estimación de crecimiento sin
     tocar la red ni el corpus.  Sin --preview, transiciona el estado a FORAGED.
+
+    Guardarraíles anti-footgun (#309): --ids/--top/--scope acotan de qué
+    papers-origen se forrajea (sin ninguno: todas las semillas, igual que
+    siempre); --budget topa las llamadas HTTP y para limpio al agotarse.
     """
     from bib2graph.cli._options import parse_since
 
@@ -398,6 +656,10 @@ def chain_cmd(
         email=email,
         preview=preview,
         since=since,
+        ids=ids,
+        top=top,
+        scope=scope,
+        budget=budget,
     )
 
     # ADR 0045 (#259): eco de workspace + warning accionable en walk-up.
@@ -414,6 +676,7 @@ def chain_cmd(
         emit(envelope)
     elif preview:
         emit_human(f"[preview] Dirección: {data['direction']}")
+        emit_human(f"[preview] Papers-origen: {data['origin_count']}")
         emit_human(f"[preview] Candidatos potenciales: {data['estimated_candidates']}")
         for dir_name, count in data["by_direction"].items():
             emit_human(f"  {dir_name}: {count}")
@@ -428,3 +691,9 @@ def chain_cmd(
             emit_human("Top candidatos por scent:")
             for item in data["ranking_preview"][:5]:
                 emit_human(f"  {item['id']}: {item['scent']:.3f}")
+        if data.get("budget_stopped"):
+            emit_human(
+                f"Aviso: se alcanzó --budget ({data['budget_used']} llamadas). "
+                "El resultado es PARCIAL — corré 'b2g chain' de nuevo (o con "
+                "--ids/--top/--scope más acotado) para completar el forrajeo."
+            )

--- a/src/bib2graph/foraging/__init__.py
+++ b/src/bib2graph/foraging/__init__.py
@@ -12,10 +12,16 @@ Ver docs/API.md §5 y ADR 0020/0022.
 
 from __future__ import annotations
 
-from bib2graph.foraging.base import Direction, GrowthPreview, RankedCandidates
+from bib2graph.foraging.base import (
+    CallBudget,
+    Direction,
+    GrowthPreview,
+    RankedCandidates,
+)
 from bib2graph.foraging.forager import Forager
 
 __all__ = [
+    "CallBudget",
     "Direction",
     "Forager",
     "GrowthPreview",

--- a/src/bib2graph/foraging/base.py
+++ b/src/bib2graph/foraging/base.py
@@ -1,6 +1,6 @@
 """foraging.base — tipos de datos del forrajeo.
 
-Define ``Direction``, ``GrowthPreview`` y ``RankedCandidates``.
+Define ``Direction``, ``GrowthPreview``, ``RankedCandidates`` y ``CallBudget``.
 
 ``RankedCandidates`` necesita ``arbitrary_types_allowed`` porque ``Corpus``
 no es un ``BaseModel`` de Pydantic.
@@ -17,6 +17,39 @@ from pydantic import BaseModel, ConfigDict
 from bib2graph.corpus import Corpus
 
 Direction = Literal["backward", "forward", "both"]
+
+
+class CallBudget:
+    """Tope mutable de llamadas HTTP a OpenAlex, compartido por referencia (#309).
+
+    Guardarraíl anti-footgun: ``chain --budget N`` limita cuántas llamadas a
+    la API se hacen durante un forward chaining.  Al llegar al tope, quien
+    consulta ``exhausted`` **debe parar limpio, sin reintentar** — ni el
+    retry/backoff ante 429/5xx (``OpenAlexSource._fetch_page_with_retry``) ni
+    una página adicional de paginación por cursor.
+
+    Se pasa por referencia (mismo objeto) entre ``Forager`` y ``OpenAlexSource``
+    para que ambos vean el mismo contador sin acoplarlos por herencia ni
+    parámetros posicionales adicionales en cada método de fetch.
+
+    Attributes:
+        limit: Tope de llamadas HTTP permitidas.  ``None`` = sin tope (default,
+            comportamiento actual sin cambios).
+        used: Llamadas HTTP realizadas hasta el momento.
+    """
+
+    def __init__(self, limit: int | None) -> None:
+        self.limit = limit
+        self.used = 0
+
+    @property
+    def exhausted(self) -> bool:
+        """``True`` si se alcanzó (o superó) el tope de llamadas."""
+        return self.limit is not None and self.used >= self.limit
+
+    def record_call(self) -> None:
+        """Registra una llamada HTTP realizada (incrementa ``used``)."""
+        self.used += 1
 
 
 class GrowthPreview(BaseModel):
@@ -96,6 +129,12 @@ class RankedCandidates(BaseModel):
             los candidatos backward que se persisten en la tabla auxiliar
             ``referenced_but_not_fetched`` por el comando CLI, no en el corpus.
             Vacío en chaining puramente forward.
+        budget_used: Llamadas HTTP realizadas cuando ``chain --budget N`` está
+            activo (#309).  ``0`` si no se pasó ``call_budget`` al ``Forager``.
+        budget_stopped: ``True`` si el chaining se detuvo tempranamente por
+            agotar ``call_budget`` (parada limpia, sin reintentar) — el
+            resultado es parcial pero consistente.  ``False`` en el
+            comportamiento normal (sin budget o budget no alcanzado).
     """
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
@@ -103,3 +142,5 @@ class RankedCandidates(BaseModel):
     corpus: Corpus
     ranking: list[tuple[str, float]]
     observed_refs: list[str] = []
+    budget_used: int = 0
+    budget_stopped: bool = False

--- a/src/bib2graph/foraging/forager.py
+++ b/src/bib2graph/foraging/forager.py
@@ -53,11 +53,13 @@ import pyarrow as pa
 
 from bib2graph.constants import Col
 from bib2graph.corpus import Corpus, _rows_with_ids
-from bib2graph.foraging.base import Direction, GrowthPreview, RankedCandidates
-from bib2graph.foraging.scent import (
-    compute_backward_scent,
-    rank_candidates,
+from bib2graph.foraging.base import (
+    CallBudget,
+    Direction,
+    GrowthPreview,
+    RankedCandidates,
 )
+from bib2graph.foraging.scent import rank_candidates
 from bib2graph.schemas import CORPUS_SCHEMA
 from bib2graph.sources.openalex import _work_to_row
 
@@ -72,8 +74,12 @@ def _make_empty_corpus() -> Corpus:
     )
 
 
-def _extract_seed_ids(corpus_rows: list[dict[str, Any]]) -> list[str]:
-    """Extrae los source_id de todas las semillas del corpus.
+def _extract_seed_ids(
+    corpus_rows: list[dict[str, Any]],
+    *,
+    origin_ids: set[str] | None = None,
+) -> list[str]:
+    """Extrae los source_id de las semillas del corpus (opcionalmente acotadas).
 
     El forward chaining corre antes de la curación (ciclo: SEEDED → FORAGED
     → curación); las semillas nacen con ``curation_status="candidate"`` y el
@@ -86,25 +92,44 @@ def _extract_seed_ids(corpus_rows: list[dict[str, Any]]) -> list[str]:
 
     Args:
         corpus_rows: Filas del corpus como dicts.
+        origin_ids: Si se pasa (#309, ``chain --ids``/``--top``/``--scope``),
+            acota el resultado a las semillas cuyo ``id`` o ``source_id`` esté
+            en este set — la unidad escopada del forrajeo.  ``None`` (default)
+            preserva el comportamiento actual: todas las semillas.
 
     Returns:
-        Lista de source_ids (IDs del motor de extracción) de las semillas,
-        en orden de aparición (determinista).
+        Lista de source_ids (IDs del motor de extracción) de las semillas
+        (acotadas por ``origin_ids`` si se pasó), en orden de aparición
+        (determinista).
     """
     result: list[str] = []
     for row in corpus_rows:
-        if row.get(Col.IS_SEED) and row.get(Col.SOURCE_ID):
-            result.append(str(row[Col.SOURCE_ID]))
+        if not (row.get(Col.IS_SEED) and row.get(Col.SOURCE_ID)):
+            continue
+        if origin_ids is not None:
+            row_id = row.get(Col.ID)
+            row_source_id = row.get(Col.SOURCE_ID)
+            if str(row_id) not in origin_ids and str(row_source_id) not in origin_ids:
+                continue
+        result.append(str(row[Col.SOURCE_ID]))
     return result
 
 
 def _estimate_forward_from_cited_by_detail(
     corpus_rows: list[dict[str, Any]],
+    origin_rows: list[dict[str, Any]] | None = None,
 ) -> tuple[int, bool, int]:
     """Versión de diagnóstico que devuelve también el total sin cap.
 
     Args:
-        corpus_rows: Filas del corpus como dicts (``to_pylist()``).
+        corpus_rows: Filas del corpus completo como dicts (``to_pylist()``).
+            Se usa para construir ``corpus_ids`` (exclusión de candidatos ya
+            presentes) — SIEMPRE el corpus completo, sin importar el scoping,
+            para no re-proponer papers que ya están en cualquier parte del
+            corpus.
+        origin_rows: Filas de origen (#309, unidad escopada): solo se cuenta
+            el ``cited_by_id`` de estas filas.  ``None`` (default) = usa
+            ``corpus_rows`` completo (comportamiento actual sin cambios).
 
     Returns:
         Tupla ``(count_capped_placeholder, available, total_uncapped)``
@@ -120,9 +145,10 @@ def _estimate_forward_from_cited_by_detail(
         if source_id_val:
             corpus_ids.add(str(source_id_val))
 
+    rows_for_cited_by = origin_rows if origin_rows is not None else corpus_rows
     candidate_ids: set[str] = set()
     has_cited_by_data = False
-    for row in corpus_rows:
+    for row in rows_for_cited_by:
         cited_by = row.get(Col.CITED_BY_ID)
         if not cited_by or not isinstance(cited_by, list):
             continue
@@ -136,6 +162,78 @@ def _estimate_forward_from_cited_by_detail(
 
     total = len(candidate_ids)
     return total, True, total
+
+
+def _filter_rows_to_origin(
+    corpus_rows: list[dict[str, Any]],
+    origin_ids: set[str] | None,
+) -> list[dict[str, Any]]:
+    """Filtra filas del corpus a las que son "origen" del chaining (#309).
+
+    Una fila es origen si su ``id`` o ``source_id`` está en ``origin_ids``.
+    Vista pura, no muta ``corpus_rows``.
+
+    Args:
+        corpus_rows: Filas del corpus completo.
+        origin_ids: Set de ids/source_ids a los que acotar.  ``None`` =
+            sin acotar (devuelve ``corpus_rows`` tal cual — comportamiento
+            actual, todas las filas son origen).
+
+    Returns:
+        Subconjunto de ``corpus_rows`` cuyo id o source_id está en
+        ``origin_ids``, o ``corpus_rows`` completo si ``origin_ids`` es
+        ``None``.
+    """
+    if origin_ids is None:
+        return corpus_rows
+    result = []
+    for row in corpus_rows:
+        row_id = row.get(Col.ID)
+        row_source_id = row.get(Col.SOURCE_ID)
+        if str(row_id) in origin_ids or str(row_source_id) in origin_ids:
+            result.append(row)
+    return result
+
+
+def _compute_backward_scent_scoped(
+    corpus_rows: list[dict[str, Any]],
+    origin_rows: list[dict[str, Any]],
+) -> dict[str, float]:
+    """Como ``compute_backward_scent`` pero solo cuenta referencias de ``origin_rows``.
+
+    Reimplementa el cuerpo de ``compute_backward_scent`` (en vez de acotar su
+    entrada directamente) porque la exclusión de candidatos ya presentes debe
+    hacerse contra el **corpus completo** (``corpus_rows``), no solo contra las
+    filas origen — de lo contrario un candidato que ya está en el corpus, pero
+    fuera del subconjunto escopeado, se re-propondría como si fuera nuevo.
+
+    Args:
+        corpus_rows: Filas del corpus completo (para la exclusión).
+        origin_rows: Filas origen (#309): solo estas cuentan como fuente de
+            ``references_id`` para el scent backward.
+
+    Returns:
+        Dict ``{candidate_id: score}`` igual que ``compute_backward_scent``,
+        pero el score solo cuenta papers-origen que referencian al candidato.
+    """
+    from bib2graph.networks.projectors import collect_item_to_papers
+
+    corpus_ids: set[str] = set()
+    for row in corpus_rows:
+        id_val = row.get(Col.ID)
+        source_id_val = row.get(Col.SOURCE_ID)
+        if id_val:
+            corpus_ids.add(str(id_val))
+        if source_id_val:
+            corpus_ids.add(str(source_id_val))
+
+    ref_to_papers = collect_item_to_papers(origin_rows, Col.ID, Col.REFERENCES_ID)
+
+    return {
+        ref_id: float(len(set(papers)))
+        for ref_id, papers in ref_to_papers.items()
+        if ref_id not in corpus_ids
+    }
 
 
 class Forager:
@@ -163,6 +261,12 @@ class Forager:
         max_candidates: Tope de candidatos en el ranking; ``None`` = sin límite.
         max_citing_per_paper: Presupuesto de citantes por semilla en el forward
             chaining; ``None`` = sin tope.
+        origin_ids: Unidad escopada (#309): si no es ``None``, acota los
+            "papers origen" del chaining (semillas forward, base backward) a
+            este set de ids/source_ids.  ``None`` = comportamiento actual sin
+            cambios (todas las semillas/todo el corpus).
+        call_budget: Tope de llamadas HTTP compartido con el ``source`` (#309,
+            ``chain --budget N``).  ``None`` = sin tope (default).
     """
 
     def __init__(
@@ -172,6 +276,8 @@ class Forager:
         depth: int = 1,
         max_candidates: int | None = None,
         max_citing_per_paper: int | None = 50,
+        origin_ids: set[str] | None = None,
+        call_budget: CallBudget | None = None,
     ) -> None:
         """Inicializa el Forager.
 
@@ -184,6 +290,14 @@ class Forager:
             max_citing_per_paper: Presupuesto de citantes por semilla para el
                 forward chaining.  Default 50 (acota el fetch por semilla, no
                 solo trunca el resultado).  Pasar ``None`` para sin tope.
+            origin_ids: Unidad escopada del forrajeo (#309): acota qué
+                papers cuentan como origen (semillas forward / base backward)
+                a este set de ``id``/``source_id``.  ``None`` (default) =
+                comportamiento actual: todas las semillas.
+            call_budget: ``CallBudget`` compartido para topar llamadas HTTP
+                (#309, ``chain --budget N``).  Al agotarse, el forward
+                chaining para limpio SIN reintentar y devuelve lo
+                materializado hasta ese punto.  ``None`` (default) = sin tope.
 
         Raises:
             NotImplementedError: Si ``depth > 1``.
@@ -197,6 +311,8 @@ class Forager:
         self._depth = depth
         self._max_candidates = max_candidates
         self._max_citing_per_paper = max_citing_per_paper
+        self._origin_ids = origin_ids
+        self._call_budget = call_budget
 
     def preview(
         self,
@@ -218,6 +334,12 @@ class Forager:
             forward no es estimable sin red; ``forward_requires_fetch=True``
             y ``by_direction["forward"]`` vale ``0``.
 
+        Si el ``Forager`` se construyó con ``origin_ids`` (#309, unidad
+        escopada de ``chain --ids``/``--top``/``--scope``), la estimación se
+        acota a los papers origen indicados: backward cuenta solo las
+        ``references_id`` de esos papers; forward cuenta solo el
+        ``cited_by_id`` de esas semillas.
+
         NO muta el corpus de entrada.
 
         Args:
@@ -230,13 +352,14 @@ class Forager:
             refleja solo el crecimiento estimable localmente (backward).
         """
         rows = corpus.to_arrow().to_pylist()
+        origin_rows = _filter_rows_to_origin(rows, self._origin_ids)
         by_direction: dict[str, int] = {}
         forward_requires_fetch = False
         forward_from_cited_by = False
         capped_by_max = False
 
         if direction in ("backward", "both"):
-            bwd_uncapped = compute_backward_scent(rows)
+            bwd_uncapped = _compute_backward_scent_scoped(rows, origin_rows)
             bwd_total = len(bwd_uncapped)
             if self._max_candidates is not None and bwd_total > self._max_candidates:
                 by_direction["backward"] = self._max_candidates
@@ -245,7 +368,9 @@ class Forager:
                 by_direction["backward"] = bwd_total
 
         if direction in ("forward", "both"):
-            fwd_total, fwd_local, _ = _estimate_forward_from_cited_by_detail(rows)
+            fwd_total, fwd_local, _ = _estimate_forward_from_cited_by_detail(
+                rows, origin_rows
+            )
             if fwd_local:
                 # cited_by_id disponible localmente: estimación sin red.
                 if (
@@ -301,6 +426,15 @@ class Forager:
         - ``ranking``: candidatos backward + forward rankeados por scent.
         - ``observed_refs``: IDs backward observados (no en corpus, tabla auxiliar).
 
+        Si el ``Forager`` se construyó con ``origin_ids`` (#309, unidad
+        escopada de ``chain --ids``/``--top``/``--scope``), solo esos papers
+        cuentan como origen: backward solo mira sus ``references_id``; forward
+        solo consulta citantes de esas semillas (menos llamadas HTTP).  Si el
+        ``Forager`` se construyó con ``call_budget`` (``chain --budget N``),
+        el forward chaining para limpio (sin reintentar) al agotarlo y
+        ``RankedCandidates.budget_stopped`` queda en ``True`` con lo
+        materializado hasta ese punto.
+
         NO muta el corpus de entrada.
 
         Args:
@@ -311,6 +445,7 @@ class Forager:
             ``RankedCandidates`` con candidatos, ranking y observed_refs.
         """
         rows = corpus.to_arrow().to_pylist()
+        origin_rows = _filter_rows_to_origin(rows, self._origin_ids)
         fetched_at = datetime.now(UTC).isoformat()
 
         combined_scent: dict[str, float] = {}
@@ -324,7 +459,7 @@ class Forager:
         seed_cited_by_updates: dict[str, dict[str, Any]] = {}
 
         if direction in ("backward", "both"):
-            bwd_scent = compute_backward_scent(rows)
+            bwd_scent = _compute_backward_scent_scoped(rows, origin_rows)
             for ref_id, scent_val in bwd_scent.items():
                 combined_scent[ref_id] = combined_scent.get(ref_id, 0.0) + scent_val
                 bwd_observed.add(ref_id)
@@ -387,6 +522,10 @@ class Forager:
             corpus=candidates_corpus,
             ranking=ranking,
             observed_refs=observed_refs,
+            budget_used=self._call_budget.used if self._call_budget else 0,
+            budget_stopped=(
+                self._call_budget.exhausted if self._call_budget else False
+            ),
         )
 
     # Helpers internos
@@ -429,6 +568,13 @@ class Forager:
         idempotente con la semilla ya persistida.  El ``CoCitationProjector``
         (ADR 0014, no se toca) consume ``cited_by_id`` como insumo.
 
+        Si ``self._origin_ids`` no es ``None`` (#309, ``chain --ids``/``--top``/
+        ``--scope``), solo se consultan citantes de esas semillas — menos
+        llamadas HTTP, no solo menos candidatos materializados.  Si
+        ``self._call_budget`` no es ``None`` y el source acepta el kwarg
+        ``call_budget`` (p. ej. ``OpenAlexSource``), se lo pasa para que el
+        fetch pare limpio (sin reintentar) al agotarse.
+
         Args:
             corpus_rows: Filas del corpus actual.
             fetched_at: Timestamp ISO del fetch.
@@ -451,9 +597,15 @@ class Forager:
                 "OpenAlexSource o un source con ese método."
             )
 
-        # Alcance: todas las semillas (is_seed=True); el chaining precede a la curación
-        seed_ids = _extract_seed_ids(corpus_rows)
+        # Alcance: todas las semillas (is_seed=True), o el subconjunto escopeado
+        # por --ids/--top/--scope (#309); el chaining precede a la curación.
+        seed_ids = _extract_seed_ids(corpus_rows, origin_ids=self._origin_ids)
         if not seed_ids:
+            return {}, {}, {}
+
+        # Guardia de budget agotado ANTES de la primera llamada (#309): si ya
+        # no queda presupuesto, no se hace ningún fetch adicional.
+        if self._call_budget is not None and self._call_budget.exhausted:
             return {}, {}, {}
 
         # Se incluye source_id porque los IDs de motor (W… de OpenAlex) aparecen
@@ -473,6 +625,25 @@ class Forager:
         citing_dict: dict[str, list[str]]
         works_map: dict[str, dict[str, Any]]
 
+        # kwargs opcionales, solo se agregan si tienen valor (#309: call_budget
+        # se pasa únicamente si el source lo soporta — inspect.signature evita
+        # romper mocks/sources de terceros que no conocen el parámetro).
+        import inspect
+
+        _extra_kw: dict[str, Any] = {}
+        if since is not None:
+            _extra_kw["since"] = since
+        _fetch_method = (
+            self._source.fetch_citing_batch_with_works
+            if use_with_works
+            else self._source.fetch_citing_batch
+        )
+        if (
+            self._call_budget is not None
+            and "call_budget" in inspect.signature(_fetch_method).parameters
+        ):
+            _extra_kw["call_budget"] = self._call_budget
+
         try:
             from tqdm import tqdm as _tqdm
 
@@ -482,26 +653,24 @@ class Forager:
                 unit="lote",
                 leave=False,
             ) as pbar:
-                _since_kw = {"since": since} if since is not None else {}
                 if use_with_works:
                     citing_dict, works_map = self._source.fetch_citing_batch_with_works(
-                        seed_ids, max_per_paper=self._max_citing_per_paper, **_since_kw
+                        seed_ids, max_per_paper=self._max_citing_per_paper, **_extra_kw
                     )
                 else:
                     citing_dict = self._source.fetch_citing_batch(
-                        seed_ids, max_per_paper=self._max_citing_per_paper, **_since_kw
+                        seed_ids, max_per_paper=self._max_citing_per_paper, **_extra_kw
                     )
                     works_map = {}
                 pbar.update(1)
         except ImportError:
-            _since_kw = {"since": since} if since is not None else {}
             if use_with_works:
                 citing_dict, works_map = self._source.fetch_citing_batch_with_works(
-                    seed_ids, max_per_paper=self._max_citing_per_paper, **_since_kw
+                    seed_ids, max_per_paper=self._max_citing_per_paper, **_extra_kw
                 )
             else:
                 citing_dict = self._source.fetch_citing_batch(
-                    seed_ids, max_per_paper=self._max_citing_per_paper, **_since_kw
+                    seed_ids, max_per_paper=self._max_citing_per_paper, **_extra_kw
                 )
                 works_map = {}
 

--- a/src/bib2graph/sources/openalex.py
+++ b/src/bib2graph/sources/openalex.py
@@ -34,6 +34,7 @@ import pyarrow as pa
 
 from bib2graph.constants import Col, CurationStatus
 from bib2graph.corpus import Corpus, EquationRef, _rows_with_ids
+from bib2graph.foraging.base import CallBudget
 from bib2graph.schemas import CORPUS_SCHEMA, ProvenanceEvent
 from bib2graph.service.errors import NetworkError
 
@@ -941,6 +942,7 @@ class OpenAlexSource:
         *,
         max_per_paper: int | None = None,
         since: date | None = None,
+        call_budget: CallBudget | None = None,
     ) -> tuple[dict[str, list[str]], dict[str, dict[str, Any]]]:
         """Núcleo compartido de paginación y atribución para los citantes en lote.
 
@@ -957,6 +959,11 @@ class OpenAlexSource:
             since: Filtrar citantes publicados desde esta fecha
                 (``from_publication_date:YYYY-MM-DD`` en OpenAlex).  ``None``
                 = sin filtro de fecha.
+            call_budget: Tope de llamadas HTTP (#309, ``chain --budget N``).
+                Antes de cada página se chequea ``call_budget.exhausted``: si
+                ya está agotado, se **para limpio, sin reintentar** (ni
+                siquiera se intenta la llamada) y se devuelve lo acumulado
+                hasta ese punto.  ``None`` = sin tope (comportamiento actual).
 
         Returns:
             Tupla ``(attribution, works_map)`` donde:
@@ -982,6 +989,10 @@ class OpenAlexSource:
                 filter_str += f",from_publication_date:{since.isoformat()}"
 
             cursor: str = "*"
+            # #309: bandera de corte por budget agotado — el volcado del lote
+            # (parcial hasta este punto) sigue ocurriendo abajo del ``with``;
+            # solo se detiene la iteración de MÁS lotes tras este.
+            budget_hit = False
             with self._client() as client:
                 while True:
                     if max_per_paper is not None and all(
@@ -989,9 +1000,31 @@ class OpenAlexSource:
                     ):
                         break
 
-                    page_works = self._fetch_page_with_retry(
-                        client, filter_str, cursor=cursor
-                    )
+                    # Guardarraíl anti-footgun: si el budget ya está agotado,
+                    # parar limpio ANTES de la llamada (ni siquiera se
+                    # intenta, y por ende nunca se reintenta ante 429).
+                    if call_budget is not None and call_budget.exhausted:
+                        budget_hit = True
+                        break
+
+                    try:
+                        page_works = self._fetch_page_with_retry(
+                            client,
+                            filter_str,
+                            cursor=cursor,
+                            call_budget=call_budget,
+                        )
+                    except httpx.HTTPStatusError:
+                        # #309: si el budget se agotó a mitad de un fallo
+                        # retryable (429/5xx), _fetch_page_with_retry deja de
+                        # reintentar y propaga — acá se traduce en "parar
+                        # limpio, reportar parcial" en vez de tumbar el
+                        # comando entero (el 429 "normal", con budget
+                        # disponible, sigue reintentando como siempre).
+                        if call_budget is not None and call_budget.exhausted:
+                            budget_hit = True
+                            break
+                        raise
                     if page_works is None:
                         break  # pragma: no cover
 
@@ -1018,6 +1051,9 @@ class OpenAlexSource:
 
                     if not next_cursor or not works_list:
                         break
+                    if call_budget is not None and call_budget.exhausted:
+                        budget_hit = True
+                        break
                     cursor = next_cursor
 
             for tid in lote:
@@ -1028,6 +1064,9 @@ class OpenAlexSource:
                 else:
                     result[tid] = sorted(merged)
 
+            if budget_hit:
+                break
+
         return result, works_map
 
     def fetch_citing_batch(
@@ -1036,6 +1075,7 @@ class OpenAlexSource:
         *,
         max_per_paper: int | None = None,
         since: date | None = None,
+        call_budget: CallBudget | None = None,
     ) -> dict[str, list[str]]:
         """Trae en lote los citantes de varios papers usando ``cites:W1|W2|...``.
 
@@ -1063,6 +1103,8 @@ class OpenAlexSource:
             max_per_paper: Presupuesto máximo de citantes a recolectar por semilla.
                 ``None`` = sin tope (pagina todo).  Acota el fetch: cuando todas
                 las semillas del lote alcanzan el tope, se detiene la paginación.
+            call_budget: Tope de llamadas HTTP (#309, ``chain --budget N``).
+                ``None`` = sin tope.
 
         Returns:
             Dict ``{seed_id: [citer_id, ...]}``.  Los citantes de cada semilla
@@ -1074,7 +1116,10 @@ class OpenAlexSource:
             return {}
         normalized = [_oa_id_short(i) or i for i in ids]
         attribution, _ = self._fetch_citing_pages(
-            normalized, max_per_paper=max_per_paper, since=since
+            normalized,
+            max_per_paper=max_per_paper,
+            since=since,
+            call_budget=call_budget,
         )
         return attribution
 
@@ -1084,6 +1129,7 @@ class OpenAlexSource:
         *,
         max_per_paper: int | None = None,
         since: date | None = None,
+        call_budget: CallBudget | None = None,
     ) -> tuple[dict[str, list[str]], dict[str, dict[str, Any]]]:
         """Como ``fetch_citing_batch`` pero conserva los objetos JSON completos.
 
@@ -1101,6 +1147,10 @@ class OpenAlexSource:
                 Se normalizan a ID corto internamente.
             max_per_paper: Presupuesto máximo de citantes por semilla.
                 ``None`` = sin tope.
+            call_budget: Tope de llamadas HTTP (#309, ``chain --budget N``).
+                Al agotarse, la paginación **para limpio sin reintentar** y
+                devuelve la atribución/works acumulados hasta ese punto.
+                ``None`` = sin tope (comportamiento actual).
 
         Returns:
             Tupla ``(attribution, works_map)``. ``attribution`` es
@@ -1115,7 +1165,10 @@ class OpenAlexSource:
             return {}, {}
         normalized = [_oa_id_short(i) or i for i in ids]
         return self._fetch_citing_pages(
-            normalized, max_per_paper=max_per_paper, since=since
+            normalized,
+            max_per_paper=max_per_paper,
+            since=since,
+            call_budget=call_budget,
         )
 
     def _fetch_page_with_retry(
@@ -1125,17 +1178,31 @@ class OpenAlexSource:
         *,
         cursor: str,
         per_page: int = 100,
+        call_budget: CallBudget | None = None,
     ) -> tuple[list[dict[str, Any]], str | None] | None:
         """Recupera una página de works con retry/backoff ante 429/5xx.
 
         Comparte la lógica de retry de ``_RETRY_MAX_ATTEMPTS`` y
         ``_RETRY_BACKOFF_BASE`` sin reimplementar el bucle de backoff.
 
+        **Guardarraíl de budget (#309):** cada llamada HTTP (incluidos los
+        reintentos) se registra en ``call_budget.record_call()`` si se pasa
+        uno.  Si tras un fallo retryable (429/5xx) el budget queda agotado,
+        **NO se reintenta** (ni se duerme el backoff): se propaga la
+        excepción inmediatamente para que el llamador la vea como "se acabó
+        el presupuesto a mitad de una página" en vez de seguir insistiendo.
+        La guardia principal (no llamar más allá del budget) vive en
+        ``_fetch_citing_pages``, que chequea ``call_budget.exhausted`` ANTES
+        de cada llamada a este método; esta guardia interna cubre el caso
+        borde de agotarse el budget en un reintento a mitad de una llamada
+        ya iniciada.
+
         Args:
             client: Cliente httpx ya abierto (reutilizado para conexión persistente).
             filter_str: Valor del parámetro ``filter`` de la API.
             cursor: Cursor de paginación (``"*"`` para la primera página).
             per_page: Tamaño de página (máx. 100 en OpenAlex).
+            call_budget: Tope de llamadas HTTP (#309).  ``None`` = sin tope.
 
         Returns:
             Tupla ``(works, next_cursor)`` si la página se obtuvo correctamente,
@@ -1143,11 +1210,14 @@ class OpenAlexSource:
             porque re-raise al agotar reintentos).
 
         Raises:
-            httpx.HTTPStatusError: Si se agotan los reintentos.
+            httpx.HTTPStatusError: Si se agotan los reintentos, o si el
+                budget se agota tras un fallo retryable (sin reintentar más).
         """
         last_exc: Exception | None = None
         for attempt in range(_RETRY_MAX_ATTEMPTS):
             try:
+                if call_budget is not None:
+                    call_budget.record_call()
                 resp = client.get(
                     "/works",
                     params={
@@ -1166,6 +1236,10 @@ class OpenAlexSource:
             except httpx.HTTPStatusError as exc:
                 if exc.response.status_code in _RETRY_STATUS_CODES:
                     last_exc = exc
+                    # #309: budget agotado a mitad de un fallo retryable →
+                    # parar limpio, SIN dormir el backoff ni reintentar.
+                    if call_budget is not None and call_budget.exhausted:
+                        raise
                     wait = _RETRY_BACKOFF_BASE * (2**attempt)
                     time.sleep(wait)
                 else:

--- a/tests/unit/test_chain_scoped.py
+++ b/tests/unit/test_chain_scoped.py
@@ -1,0 +1,620 @@
+"""Tests TDD — issue #309: forrajeo acotado (scoping, preview de fanout, budget).
+
+`chain` forrajea sobre TODAS las semillas por default; el costo es
+multiplicativo e invisible y puede agotar la cuota de OpenAlex (429
+account-wide).  Este módulo cubre los guardarraíles ADITIVOS:
+
+- ``--ids``/``--top``/``--scope``: acotan la unidad escopada del forrajeo
+  (mutuamente excluyentes).  Sin ninguno: comportamiento actual (todas las
+  semillas), sin cambios.
+- ``--preview``: dry-run que estima el fanout SIN red, reflejando el scoping.
+- ``--budget``: tope de llamadas HTTP; al alcanzarlo, para y reporta parcial,
+  SIN reintentar.  Ante un 429 mockeado, tampoco reintenta si el budget ya
+  se agotó.
+
+Marcador: ``unit`` (DuckDB en tmp_path + httpx.MockTransport, sin red real).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import httpx
+import pyarrow as pa
+import pytest
+
+from bib2graph.corpus import Corpus
+from bib2graph.schemas import CORPUS_SCHEMA
+
+pytestmark = pytest.mark.unit
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _row(
+    id: str,
+    *,
+    source_id: str | None = None,
+    is_seed: bool = True,
+    references_id: list[str] | None = None,
+    cited_by_id: list[str] | None = None,
+    curation_status: str = "candidate",
+) -> dict[str, Any]:
+    """Fila mínima con schema canónico completo."""
+    return {
+        "id": id,
+        "source_id": source_id,
+        "doi": None,
+        "title": f"Paper {id}",
+        "year": 2020,
+        "abstract": None,
+        "source": None,
+        "language": None,
+        "publisher": None,
+        "research_areas": None,
+        "is_seed": is_seed,
+        "curation_status": curation_status,
+        "provenance": None,
+        "authors_raw": None,
+        "authors_id": None,
+        "authors_affiliations": None,
+        "keywords_raw": None,
+        "keywords_id": None,
+        "institutions_raw": None,
+        "institutions_id": None,
+        "references_id": references_id,
+        "references_doi": None,
+        "cited_by_id": cited_by_id,
+    }
+
+
+def _seed_store_with_rows(store_path: Path, rows: list[dict[str, Any]]) -> None:
+    """Puebla un store DuckDB con las filas dadas."""
+    from bib2graph.stores.duckdb import DuckDBStore
+
+    table = pa.Table.from_pylist(rows, schema=CORPUS_SCHEMA)
+    corpus = Corpus.from_arrow(table)
+    store = DuckDBStore(store_path)
+    store.persist(corpus)
+    store.close()
+
+
+def _citing_work(
+    citer_id: str,
+    *,
+    cites_ids: list[str],
+    title: str = "Citing Paper",
+    year: int = 2022,
+) -> dict[str, Any]:
+    """Work JSON de OpenAlex que cita ``cites_ids`` (IDs cortos, sin prefijo)."""
+    return {
+        "id": f"https://openalex.org/{citer_id}",
+        "doi": None,
+        "title": title,
+        "display_name": title,
+        "publication_year": year,
+        "language": "en",
+        "abstract_inverted_index": None,
+        "authorships": [],
+        "keywords": [],
+        "referenced_works": [f"https://openalex.org/{cid}" for cid in cites_ids],
+        "primary_location": None,
+        "type": "article",
+    }
+
+
+def _make_recording_transport(
+    citing_by_seed: dict[str, list[dict[str, Any]]],
+    *,
+    calls: list[str],
+) -> httpx.MockTransport:
+    """Transport que responde a ``cites:`` según la semilla en el filtro y registra llamadas.
+
+    ``citing_by_seed``: ``{seed_short_id: [work_json, ...]}``.  El handler
+    determina qué semillas participan del filtro OR (``cites:W1|W2``) y
+    devuelve la unión de los works asociados — así un test puede verificar
+    que SOLO se consultó por las semillas esperadas (scoping, #309).
+    """
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        params = dict(request.url.params)
+        filter_val: str = params.get("filter", "")
+        calls.append(filter_val)
+        if "cites:" not in filter_val:
+            return httpx.Response(
+                200,
+                json={"results": [], "meta": {"count": 0, "next_cursor": None}},
+                headers={"x-openalex-api-version": "2026-05-01"},
+            )
+        # Extraer los seed ids del filtro cites:W1|W2,...
+        cites_segment = filter_val.split("cites:")[1].split(",")[0]
+        seed_ids_in_filter = cites_segment.split("|")
+        results: list[dict[str, Any]] = []
+        seen: set[str] = set()
+        for sid in seed_ids_in_filter:
+            for work in citing_by_seed.get(sid, []):
+                wid = work["id"]
+                if wid not in seen:
+                    seen.add(wid)
+                    results.append(work)
+        return httpx.Response(
+            200,
+            json={
+                "results": results,
+                "meta": {"count": len(results), "next_cursor": None},
+            },
+            headers={"x-openalex-api-version": "2026-05-01"},
+        )
+
+    return httpx.MockTransport(handler)
+
+
+# ---------------------------------------------------------------------------
+# --preview: no hace red, reporta origin_count
+# ---------------------------------------------------------------------------
+
+
+class TestChainPreviewNoRed:
+    def test_preview_no_llama_al_transport(self, tmp_path: Path) -> None:
+        """--preview no debe hacer ninguna llamada HTTP (dry-run puro)."""
+        from bib2graph.cli.commands.chain import run_chain
+
+        store_path = tmp_path / "lib.duckdb"
+        _seed_store_with_rows(
+            store_path,
+            [_row("P1", source_id="W1", references_id=["REF_A", "REF_B"])],
+        )
+
+        calls: list[str] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            calls.append(str(request.url))
+            raise AssertionError("preview no debe hacer llamadas HTTP")
+
+        transport = httpx.MockTransport(handler)
+
+        result = run_chain(
+            store_path,
+            direction="backward",
+            preview=True,
+            transport=transport,
+        )
+
+        assert calls == [], f"preview hizo llamadas HTTP: {calls}"
+        assert result["preview"] is True
+        assert result["estimated_candidates"] == 2
+
+    def test_preview_reporta_origin_count_todas_las_semillas_sin_scoping(
+        self, tmp_path: Path
+    ) -> None:
+        """Sin --ids/--top/--scope, origin_count = nº de semillas (comportamiento actual)."""
+        from bib2graph.cli.commands.chain import run_chain
+
+        store_path = tmp_path / "lib.duckdb"
+        _seed_store_with_rows(
+            store_path,
+            [
+                _row("P1", source_id="W1", references_id=["REF_A"]),
+                _row("P2", source_id="W2", references_id=["REF_B"]),
+            ],
+        )
+
+        result = run_chain(store_path, direction="backward", preview=True)
+
+        assert result["origin_count"] == 2
+
+    def test_preview_con_ids_acota_origin_count_y_estimacion(
+        self, tmp_path: Path
+    ) -> None:
+        """--preview --ids acota tanto origin_count como el fanout estimado."""
+        from bib2graph.cli.commands.chain import run_chain
+
+        store_path = tmp_path / "lib.duckdb"
+        _seed_store_with_rows(
+            store_path,
+            [
+                _row("P1", source_id="W1", references_id=["REF_A", "REF_B"]),
+                _row("P2", source_id="W2", references_id=["REF_C"]),
+            ],
+        )
+
+        result = run_chain(
+            store_path,
+            direction="backward",
+            preview=True,
+            ids=("P1",),
+        )
+
+        assert result["origin_count"] == 1
+        # Solo cuenta REF_A/REF_B (de P1), no REF_C (de P2)
+        assert result["estimated_candidates"] == 2
+        assert result["by_direction"]["backward"] == 2
+
+    def test_preview_con_scope_seeds_acota_origin_count(self, tmp_path: Path) -> None:
+        """--preview --scope acota origin_count al subconjunto resuelto."""
+        from bib2graph.cli.commands.chain import run_chain
+
+        store_path = tmp_path / "lib.duckdb"
+        _seed_store_with_rows(
+            store_path,
+            [
+                _row("P1", source_id="W1", references_id=["REF_A"], is_seed=True),
+                _row(
+                    "P2",
+                    source_id="W2",
+                    references_id=["REF_B"],
+                    is_seed=False,
+                    curation_status="candidate",
+                ),
+            ],
+        )
+
+        result = run_chain(
+            store_path,
+            direction="backward",
+            preview=True,
+            scope="seeds",
+        )
+
+        # scope=seeds sólo incluye P1 (is_seed=True)
+        assert result["origin_count"] == 1
+        assert result["estimated_candidates"] == 1
+
+    def test_preview_ids_y_top_juntos_es_usage_error(self, tmp_path: Path) -> None:
+        """Combinar --ids y --top es un UsageError claro (mutuamente excluyentes)."""
+        from bib2graph.cli._errors import UsageError
+        from bib2graph.cli.commands.chain import run_chain
+
+        store_path = tmp_path / "lib.duckdb"
+        _seed_store_with_rows(store_path, [_row("P1", source_id="W1")])
+
+        with pytest.raises(UsageError):
+            run_chain(
+                store_path,
+                direction="backward",
+                preview=True,
+                ids=("P1",),
+                top=1,
+            )
+
+    def test_preview_ids_inexistente_es_usage_error(self, tmp_path: Path) -> None:
+        """--ids con un id que no está en el corpus falla con UsageError."""
+        from bib2graph.cli._errors import UsageError
+        from bib2graph.cli.commands.chain import run_chain
+
+        store_path = tmp_path / "lib.duckdb"
+        _seed_store_with_rows(store_path, [_row("P1", source_id="W1")])
+
+        with pytest.raises(UsageError):
+            run_chain(
+                store_path,
+                direction="backward",
+                preview=True,
+                ids=("NO_EXISTE",),
+            )
+
+
+# ---------------------------------------------------------------------------
+# --ids / --top / --scope: forward chaining SOLO consulta el subconjunto
+# ---------------------------------------------------------------------------
+
+
+class TestChainForwardScopedFetch:
+    """Verifica con mock que sólo se forrajea desde el subconjunto pedido."""
+
+    def test_ids_acota_las_llamadas_a_esa_semilla(self, tmp_path: Path) -> None:
+        """--ids P1 sólo debe consultar citantes de P1, no de P2."""
+        from bib2graph.cli.commands.chain import run_chain
+
+        store_path = tmp_path / "lib.duckdb"
+        _seed_store_with_rows(
+            store_path,
+            [
+                _row("P1", source_id="W1", curation_status="accepted"),
+                _row("P2", source_id="W2", curation_status="accepted"),
+            ],
+        )
+
+        calls: list[str] = []
+        citing_by_seed = {
+            "W1": [_citing_work("W9001", cites_ids=["W1"])],
+            "W2": [_citing_work("W9002", cites_ids=["W2"])],
+        }
+        transport = _make_recording_transport(citing_by_seed, calls=calls)
+
+        result = run_chain(
+            store_path,
+            direction="forward",
+            ids=("P1",),
+            transport=transport,
+        )
+
+        cites_calls = [c for c in calls if "cites:" in c]
+        assert cites_calls, "debería haber al menos una llamada cites:"
+        for c in cites_calls:
+            assert "W2" not in c, f"--ids=P1 no debe consultar W2: {c}"
+            assert "W1" in c
+
+        # Solo el candidato de W1 se materializa
+        result_ids = {item["id"] for item in result["ranking_preview"]}
+        assert "W9002" not in result_ids
+
+    def test_scope_seeds_solo_forrajea_semillas(self, tmp_path: Path) -> None:
+        """--scope seeds excluye no-semillas del forward chaining."""
+        from bib2graph.cli.commands.chain import run_chain
+
+        store_path = tmp_path / "lib.duckdb"
+        _seed_store_with_rows(
+            store_path,
+            [
+                _row("P1", source_id="W1", is_seed=True, curation_status="accepted"),
+            ],
+        )
+
+        calls: list[str] = []
+        citing_by_seed = {"W1": [_citing_work("W9001", cites_ids=["W1"])]}
+        transport = _make_recording_transport(citing_by_seed, calls=calls)
+
+        run_chain(
+            store_path,
+            direction="forward",
+            scope="seeds",
+            transport=transport,
+        )
+
+        cites_calls = [c for c in calls if "cites:" in c]
+        assert cites_calls
+        assert "W1" in cites_calls[0]
+
+    def test_top_1_acota_a_la_semilla_con_mas_referencias(self, tmp_path: Path) -> None:
+        """--top 1 elige la semilla con más references_id (criterio documentado)."""
+        from bib2graph.cli.commands.chain import run_chain
+
+        store_path = tmp_path / "lib.duckdb"
+        _seed_store_with_rows(
+            store_path,
+            [
+                _row(
+                    "P1",
+                    source_id="W1",
+                    curation_status="accepted",
+                    references_id=["REF_A", "REF_B", "REF_C"],
+                ),
+                _row(
+                    "P2",
+                    source_id="W2",
+                    curation_status="accepted",
+                    references_id=["REF_D"],
+                ),
+            ],
+        )
+
+        calls: list[str] = []
+        citing_by_seed = {
+            "W1": [_citing_work("W9001", cites_ids=["W1"])],
+            "W2": [_citing_work("W9002", cites_ids=["W2"])],
+        }
+        transport = _make_recording_transport(citing_by_seed, calls=calls)
+
+        run_chain(
+            store_path,
+            direction="forward",
+            top=1,
+            transport=transport,
+        )
+
+        cites_calls = [c for c in calls if "cites:" in c]
+        assert cites_calls
+        # P1 tiene más referencias (3 vs 1) → debe ser la elegida
+        assert "W1" in cites_calls[0]
+        assert "W2" not in cites_calls[0]
+
+    def test_top_0_es_usage_error(self, tmp_path: Path) -> None:
+        from bib2graph.cli._errors import UsageError
+        from bib2graph.cli.commands.chain import run_chain
+
+        store_path = tmp_path / "lib.duckdb"
+        _seed_store_with_rows(store_path, [_row("P1", source_id="W1")])
+
+        with pytest.raises(UsageError):
+            run_chain(store_path, direction="backward", top=0)
+
+
+# ---------------------------------------------------------------------------
+# --budget: para al topar, reporta parcial, no reintenta ante 429
+# ---------------------------------------------------------------------------
+
+
+class TestChainBudget:
+    def test_budget_topa_llamadas_y_reporta_parcial(self, tmp_path: Path) -> None:
+        """--budget 1 detiene el forward chaining tras 1 llamada HTTP."""
+        from bib2graph.cli.commands.chain import run_chain
+
+        store_path = tmp_path / "lib.duckdb"
+        _seed_store_with_rows(
+            store_path,
+            [
+                _row("P1", source_id="W1", curation_status="accepted"),
+                _row("P2", source_id="W2", curation_status="accepted"),
+            ],
+        )
+
+        calls: list[str] = []
+        citing_by_seed = {
+            "W1": [_citing_work("W9001", cites_ids=["W1"])],
+            "W2": [_citing_work("W9002", cites_ids=["W2"])],
+        }
+        transport = _make_recording_transport(citing_by_seed, calls=calls)
+
+        result = run_chain(
+            store_path,
+            direction="forward",
+            budget=1,
+            transport=transport,
+        )
+
+        cites_calls = [c for c in calls if "cites:" in c]
+        assert len(cites_calls) <= 1, (
+            f"--budget=1 no debe hacer más de 1 llamada cites:; got {cites_calls}"
+        )
+        assert result["budget_used"] <= 1
+        assert result["budget_stopped"] is True
+
+    def test_sin_budget_no_marca_budget_stopped(self, tmp_path: Path) -> None:
+        """Sin --budget (comportamiento actual), budget_stopped queda False."""
+        from bib2graph.cli.commands.chain import run_chain
+
+        store_path = tmp_path / "lib.duckdb"
+        _seed_store_with_rows(
+            store_path,
+            [_row("P1", source_id="W1", curation_status="accepted")],
+        )
+
+        calls: list[str] = []
+        citing_by_seed = {"W1": [_citing_work("W9001", cites_ids=["W1"])]}
+        transport = _make_recording_transport(citing_by_seed, calls=calls)
+
+        result = run_chain(store_path, direction="forward", transport=transport)
+
+        assert result["budget_stopped"] is False
+        assert result["budget_used"] == 0
+
+    def test_budget_agotado_ante_429_no_reintenta_y_reporta_parcial(
+        self, tmp_path: Path
+    ) -> None:
+        """Con budget=1 y un 429 en la única llamada permitida, NO reintenta.
+
+        El comando NO debe fallar con excepción: para limpio y reporta
+        estado parcial (``budget_stopped=True``) — exactamente el DoD de
+        #309 ("ante un 429, no reintentar en loop: parar limpio y reportar").
+        Se verifica con ``time.sleep`` mockeado que NUNCA se llamó (no hubo
+        backoff) y que el mock recibió como máximo 1 request.
+        """
+        from bib2graph.cli.commands.chain import run_chain
+
+        store_path = tmp_path / "lib.duckdb"
+        _seed_store_with_rows(
+            store_path,
+            [_row("P1", source_id="W1", curation_status="accepted")],
+        )
+
+        calls: list[str] = []
+
+        def handler_429(request: httpx.Request) -> httpx.Response:
+            calls.append(str(request.url))
+            return httpx.Response(429, text="Rate limit exceeded")
+
+        transport = httpx.MockTransport(handler_429)
+
+        with patch("bib2graph.sources.openalex.time.sleep") as mock_sleep:
+            result = run_chain(
+                store_path,
+                direction="forward",
+                budget=1,
+                transport=transport,
+            )
+
+        assert len(calls) == 1, (
+            f"budget=1 debe hacer como máximo 1 llamada; got {calls}"
+        )
+        assert not mock_sleep.called, (
+            "Con budget agotado en la primera llamada, NO debe reintentar "
+            "(ni dormir el backoff)."
+        )
+        assert result["budget_stopped"] is True
+        assert result["budget_used"] == 1
+        # No crashea: el comando devuelve un resultado parcial pero consistente.
+        assert result["total_papers"] == 1  # solo P1, ningún candidato materializado
+
+    def test_budget_grande_no_para_forrajeo_normal(self, tmp_path: Path) -> None:
+        """Un --budget holgado no interfiere con un forward chaining normal."""
+        from bib2graph.cli.commands.chain import run_chain
+
+        store_path = tmp_path / "lib.duckdb"
+        _seed_store_with_rows(
+            store_path,
+            [_row("P1", source_id="W1", curation_status="accepted")],
+        )
+
+        citing_by_seed = {"W1": [_citing_work("W9001", cites_ids=["W1"])]}
+        transport = _make_recording_transport(citing_by_seed, calls=[])
+
+        result = run_chain(
+            store_path,
+            direction="forward",
+            budget=1000,
+            transport=transport,
+        )
+
+        assert result["budget_stopped"] is False
+        assert result["candidates_found"] >= 1
+
+
+# ---------------------------------------------------------------------------
+# Forager puro: CallBudget y origin_ids (sin pasar por el CLI)
+# ---------------------------------------------------------------------------
+
+
+class TestForagerCallBudgetUnit:
+    def test_call_budget_exhausted_property(self) -> None:
+        from bib2graph.foraging.base import CallBudget
+
+        budget = CallBudget(2)
+        assert budget.exhausted is False
+        budget.record_call()
+        assert budget.exhausted is False
+        budget.record_call()
+        assert budget.exhausted is True
+
+    def test_call_budget_none_nunca_agotado(self) -> None:
+        from bib2graph.foraging.base import CallBudget
+
+        budget = CallBudget(None)
+        for _ in range(100):
+            budget.record_call()
+        assert budget.exhausted is False
+
+    def test_forager_origin_ids_acota_backward_preview(self) -> None:
+        """Forager(origin_ids=...) acota el preview backward al subconjunto."""
+        from unittest.mock import MagicMock
+
+        from bib2graph.foraging.forager import Forager
+
+        rows = [
+            _row("P1", source_id="W1", references_id=["REF_A", "REF_B"]),
+            _row("P2", source_id="W2", references_id=["REF_C"]),
+        ]
+        table = pa.Table.from_pylist(rows, schema=CORPUS_SCHEMA)
+        corpus = Corpus.from_arrow(table)
+
+        forager = Forager(MagicMock(), depth=1, origin_ids={"P1"})
+        preview = forager.preview(corpus, direction="backward")
+
+        assert preview.by_direction["backward"] == 2  # solo REF_A, REF_B (de P1)
+
+
+# ---------------------------------------------------------------------------
+# Smoke test del wiring Click (barato, sin workspace — --help no lo requiere)
+# ---------------------------------------------------------------------------
+
+
+def test_chain_cmd_help_lista_los_flags_nuevos() -> None:
+    """--ids/--top/--scope/--budget están registrados en el comando Click.
+
+    Smoke test mínimo del wiring (no plumbing fino): confirma que Click no
+    tiene errores de definición (tipos, duplicados) al construir el comando.
+    """
+    from click.testing import CliRunner
+
+    from bib2graph.cli.commands.chain import chain_cmd
+
+    runner = CliRunner()
+    result = runner.invoke(chain_cmd, ["--help"])
+
+    assert result.exit_code == 0, result.output
+    for flag in ("--ids", "--top", "--scope", "--budget"):
+        assert flag in result.output, f"{flag} no aparece en --help"

--- a/tests/unit/test_r3_commands_domain.py
+++ b/tests/unit/test_r3_commands_domain.py
@@ -101,7 +101,8 @@ def _make_noop_transport() -> Any:
 def _make_empty_forage_result() -> Any:
     """Resultado de foraging vacío compatible con run_chain (Forager.chain mock).
 
-    Incluye ``observed_refs`` (campo #54) para que run_chain no falle al accederlo.
+    Incluye ``observed_refs`` (campo #54) y ``budget_used``/``budget_stopped``
+    (#309) para que run_chain no falle al accederlos.
     """
     from bib2graph.corpus import Corpus
 
@@ -116,6 +117,8 @@ def _make_empty_forage_result() -> Any:
         corpus = empty
         ranking: ClassVar[list[Any]] = []
         observed_refs: ClassVar[list[str]] = []
+        budget_used = 0
+        budget_stopped = False
 
     return _FakeResult()
 


### PR DESCRIPTION
Cierra #309 (MVP aditivo; el "flip de defaults" queda para la Discussion #310).

## Guardarraíles (aditivos, sin cambiar defaults)
- **`--ids`** (repetible), **`--top N`** (semillas más centrales; proxy: nº de `references_id`, degradación documentada), **`--scope seeds|accepted|all`**: acotan el conjunto ORIGEN antes de tocar la red → menos llamadas HTTP reales.
- **`--preview`:** refleja el scoping (`origin_count`), sin red.
- **`--budget N`** (`CallBudget`): tope de llamadas del forward chaining; al agotarse **para y reporta parcial** (`budget_used`/`budget_stopped`), no reintenta, no duerme backoff ante 429 con budget agotado.

18 tests nuevos (`test_chain_scoped.py`).

## ⚠️ Overlap con #306 (#311) — a resolver antes de merge
Ambos tocan `_fetch_page_with_retry`/`_fetch_citing_pages` en `sources/openalex.py` (#306 = 429→NetworkError; #309 = budget/no-retry). **Conflicto al mergear los dos.** Se resuelve rebasando #309 sobre #306 (combinan coherentes). Lo coordino en el pase de integración del milestone.

## Docs (architect)
`docs/API.md` §5 (Forager: `origin_ids`, `CallBudget`) + CLI reference de los flags nuevos.