### PR TITLE
feat(curate): curación masiva declarativa — accept/reject por predicado (#308)

### DIFF
--- a/src/bib2graph/cli/commands/curate.py
+++ b/src/bib2graph/cli/commands/curate.py
@@ -22,6 +22,15 @@ TRANSVERSAL (ADR 0016 enmendado, R3):
   el CycleState.  ``filter`` SÍ transiciona a FILTERED (el verbo define la
   transición, precedente D1 de #159).
 
+Curación masiva declarativa (#308):
+  ``accept`` y ``reject`` aceptan, además de ``--ids`` enumerados, un
+  SELECTOR declarativo: ``--query`` (substring de título, mismo criterio
+  que ``read list --query``) y/o metadata ``--year-gte/lte``,
+  ``--language``, ``--type``, ``--min-citations`` (misma semántica que
+  ``filter``). El conjunto afectado es la UNIÓN de ``--ids`` y lo que
+  matchea el selector — se pueden combinar libremente. Sin ``--ids`` ni
+  selector → error de uso (exit 1).
+
 Capa de servicios (#155):
   Toda la lógica vive en ``service.curate``; este módulo son shims delgados
   que inyectan el reloj (frontera CLI, R2/ADR 0017) y emiten el envelope.
@@ -40,6 +49,8 @@ Flujo canónico:
     b2g curate apply curacion.csv --by maria # con identificador de curador
     b2g curate accept --ids W1 --ids W2      # acepta por id
     b2g curate reject --ids W3               # rechaza por id
+    b2g curate accept --year-gte 2015        # acepta por selector (masivo)
+    b2g curate reject --query "erratum"      # rechaza por selector (masivo)
     b2g curate filter --year-gte 2018        # filtra y transiciona a FILTERED
 """
 
@@ -93,6 +104,8 @@ def curate_grp(ctx: click.Context) -> None:
         b2g curate apply curacion.csv
         b2g curate accept --ids W1 --ids W2
         b2g curate reject --ids W3
+        b2g curate accept --year-gte 2015
+        b2g curate reject --query "erratum"
         b2g curate filter --year-gte 2018 --year-lte 2024
     """
     ctx.ensure_object(dict)
@@ -237,9 +250,39 @@ def apply_cmd(
 @curate_grp.command("accept")
 @click.option(
     "--ids",
-    required=True,
     multiple=True,
     help="IDs de papers a aceptar (repetible: --ids ID1 --ids ID2).",
+)
+@click.option(
+    "--query",
+    default=None,
+    help=(
+        "Selector: texto a buscar en el título (substring, case-insensitive; "
+        "mismo criterio que 'read list --query')."
+    ),
+)
+@click.option(
+    "--year-gte", type=int, default=None, help="Selector: incluir años >= este valor."
+)
+@click.option(
+    "--year-lte", type=int, default=None, help="Selector: incluir años <= este valor."
+)
+@click.option(
+    "--language",
+    multiple=True,
+    help="Selector: códigos ISO 639-1 a incluir (repetible).",
+)
+@click.option(
+    "--type",
+    "type_in",
+    multiple=True,
+    help="Selector: áreas de investigación a incluir (repetible).",
+)
+@click.option(
+    "--min-citations",
+    type=int,
+    default=None,
+    help="Selector: mínimo de citantes en cited_by_id.",
 )
 @click.option(
     "--by",
@@ -253,10 +296,23 @@ def apply_cmd(
 def curate_accept_cmd(
     ctx: click.Context,
     ids: tuple[str, ...],
+    query: str | None,
+    year_gte: int | None,
+    year_lte: int | None,
+    language: tuple[str, ...],
+    type_in: tuple[str, ...],
+    min_citations: int | None,
     by: str,
     json_output: bool,
 ) -> None:
     """Marca papers como accepted en el corpus.
+
+    Acepta ``--ids`` enumerados y/o un SELECTOR declarativo (``--query``,
+    ``--year-gte/lte``, ``--language``, ``--type``, ``--min-citations`` —
+    misma semántica que ``curate filter``). El conjunto afectado es la
+    UNIÓN de ambos: si das solo ``--ids``, se comporta como antes; si das
+    solo selector, acepta todo lo que matchea; si das ambos, acepta la
+    unión (no hace falta que se solapen).
 
     Curación TRANSVERSAL: no transiciona el CycleState.  Disponible en
     cualquier estado del lazo (Nota 05 §4, ADR 0016 enmendado R3).
@@ -265,7 +321,18 @@ def curate_accept_cmd(
 
     ws = resolve_workspace(ctx.obj)
     now = datetime.now(UTC)
-    data = accept_papers(ws.library_path, list(ids), by=by, decided_at=now)
+    data = accept_papers(
+        ws.library_path,
+        list(ids),
+        by=by,
+        decided_at=now,
+        query=query,
+        year_gte=year_gte,
+        year_lte=year_lte,
+        language=list(language) if language else None,
+        type_in=list(type_in) if type_in else None,
+        min_citations=min_citations,
+    )
 
     # ADR 0045 (#259): eco de workspace + warning accionable en walk-up.
     data["workspace"] = workspace_echo(ws)
@@ -287,9 +354,39 @@ def curate_accept_cmd(
 @curate_grp.command("reject")
 @click.option(
     "--ids",
-    required=True,
     multiple=True,
     help="IDs de papers a rechazar (repetible: --ids ID1 --ids ID2).",
+)
+@click.option(
+    "--query",
+    default=None,
+    help=(
+        "Selector: texto a buscar en el título (substring, case-insensitive; "
+        "mismo criterio que 'read list --query')."
+    ),
+)
+@click.option(
+    "--year-gte", type=int, default=None, help="Selector: incluir años >= este valor."
+)
+@click.option(
+    "--year-lte", type=int, default=None, help="Selector: incluir años <= este valor."
+)
+@click.option(
+    "--language",
+    multiple=True,
+    help="Selector: códigos ISO 639-1 a incluir (repetible).",
+)
+@click.option(
+    "--type",
+    "type_in",
+    multiple=True,
+    help="Selector: áreas de investigación a incluir (repetible).",
+)
+@click.option(
+    "--min-citations",
+    type=int,
+    default=None,
+    help="Selector: mínimo de citantes en cited_by_id.",
 )
 @click.option(
     "--by",
@@ -303,10 +400,27 @@ def curate_accept_cmd(
 def curate_reject_cmd(
     ctx: click.Context,
     ids: tuple[str, ...],
+    query: str | None,
+    year_gte: int | None,
+    year_lte: int | None,
+    language: tuple[str, ...],
+    type_in: tuple[str, ...],
+    min_citations: int | None,
     by: str,
     json_output: bool,
 ) -> None:
     """Marca papers como rejected en el corpus.
+
+    Acepta ``--ids`` enumerados y/o un SELECTOR declarativo (``--query``,
+    ``--year-gte/lte``, ``--language``, ``--type``, ``--min-citations`` —
+    misma semántica que ``curate filter``). El conjunto afectado es la
+    UNIÓN de ambos: si das solo ``--ids``, se comporta como antes; si das
+    solo selector, rechaza todo lo que matchea; si das ambos, rechaza la
+    unión (no hace falta que se solapen).
+
+    A diferencia de ``curate filter``, este comando rechaza EXACTAMENTE lo
+    que matchea el selector/ids (sin excepción para ``accepted``) y NO
+    transiciona el CycleState (curación transversal, Nota 05 §4).
 
     Curación TRANSVERSAL: no transiciona el CycleState.  Disponible en
     cualquier estado del lazo (Nota 05 §4, ADR 0016 enmendado R3).
@@ -315,7 +429,18 @@ def curate_reject_cmd(
 
     ws = resolve_workspace(ctx.obj)
     now = datetime.now(UTC)
-    data = reject_papers(ws.library_path, list(ids), by=by, decided_at=now)
+    data = reject_papers(
+        ws.library_path,
+        list(ids),
+        by=by,
+        decided_at=now,
+        query=query,
+        year_gte=year_gte,
+        year_lte=year_lte,
+        language=list(language) if language else None,
+        type_in=list(type_in) if type_in else None,
+        min_citations=min_citations,
+    )
 
     # ADR 0045 (#259): eco de workspace + warning accionable en walk-up.
     data["workspace"] = workspace_echo(ws)

--- a/src/bib2graph/filters/prisma.py
+++ b/src/bib2graph/filters/prisma.py
@@ -137,6 +137,23 @@ def _passes(row: dict[str, object], criterion: FilterCriterion) -> bool:
     )
 
 
+def passes_all(row: dict[str, object], criteria: list[FilterCriterion]) -> bool:
+    """Devuelve ``True`` si ``row`` cumple TODOS los criterios (AND lógico).
+
+    Wrapper público de ``_passes`` para reuso fuera de este módulo (p. ej.
+    ``service.curate`` en la curación masiva declarativa, #308), evitando
+    reimplementar la semántica de cada campo/operador.
+
+    Args:
+        row: Fila del corpus como dict.
+        criteria: Lista de criterios; lista vacía → ``True`` (sin filtro).
+
+    Returns:
+        ``True`` si la fila cumple todos los criterios.
+    """
+    return all(_passes(row, criterion) for criterion in criteria)
+
+
 def _count_not_rejected(corpus: Corpus) -> int:
     """Cuenta los papers que NO están rechazados (candidate + accepted).
 

--- a/src/bib2graph/service/curate.py
+++ b/src/bib2graph/service/curate.py
@@ -10,6 +10,17 @@ Operaciones de curación paper-a-paper (G3 original):
   - ``reject_papers`` — marca ids como ``rejected``.
   - ``curate_paper`` — wrapper de un solo paper.
 
+Selector declarativo (#308 — curación masiva sin enumerar ids):
+  - ``select_ids_by_predicate`` — resuelve un subconjunto del corpus por
+    ``query`` (mismo criterio que ``read list --query``, título substring
+    case-insensitive) y/o metadata (``year_gte/lte``, ``language``,
+    ``type_in``, ``min_citations`` — misma semántica que ``curate filter``,
+    reusando ``filters.prisma.FilterCriterion``/``passes_all``).
+    ``accept_papers``/``reject_papers`` aceptan estos mismos parámetros: el
+    conjunto afectado es la UNIÓN de ``ids`` explícitos y los que matchean
+    el selector (si no se da ningún criterio de selector, se usa solo
+    ``ids``, comportamiento previo sin cambios).
+
 Operaciones en lote (subidas desde cli/ en #155):
   - ``run_curate_dump`` — exporta corpus a CSV para revisión offline.
   - ``run_curate_from_csv`` — reimporta decisiones desde CSV.
@@ -491,32 +502,150 @@ def filter_corpus(
     }
 
 
+def select_ids_by_predicate(
+    rows: list[dict[str, Any]],
+    *,
+    query: str | None = None,
+    year_gte: int | None = None,
+    year_lte: int | None = None,
+    language: list[str] | None = None,
+    type_in: list[str] | None = None,
+    min_citations: int | None = None,
+) -> list[str]:
+    """Resuelve los ids del corpus que matchean un selector declarativo (#308).
+
+    Selector = ``query`` (substring case-insensitive en título, mismo
+    criterio que ``service.reads.list_papers``/``read list --query``) Y/O
+    criterios de metadata (misma semántica que ``curate filter``, reusando
+    ``filters.prisma.FilterCriterion``/``passes_all``). Todos los criterios
+    presentes se combinan con AND lógico.
+
+    Args:
+        rows: Filas del corpus (``corpus.to_arrow().to_pylist()``).
+        query: Substring a buscar en el título, case-insensitive.
+        year_gte: Año >= este valor.
+        year_lte: Año <= este valor.
+        language: Códigos de idioma a incluir.
+        type_in: Áreas de investigación a incluir.
+        min_citations: Mínimo de citantes (``len(cited_by_id) >= valor``).
+
+    Returns:
+        Lista de ``Col.ID`` (como str) de las filas que matchean TODOS los
+        criterios dados. Si no se da ningún criterio, devuelve ``[]`` (un
+        selector vacío no selecciona todo el corpus implícitamente).
+    """
+    from bib2graph.filters.prisma import FilterCriterion, passes_all
+
+    criteria: list[FilterCriterion] = []
+    if year_gte is not None:
+        criteria.append(FilterCriterion(field="year", op="gte", value=year_gte))
+    if year_lte is not None:
+        criteria.append(FilterCriterion(field="year", op="lte", value=year_lte))
+    if language:
+        criteria.append(FilterCriterion(field="language", op="in", value=language))
+    if type_in:
+        criteria.append(FilterCriterion(field="type", op="in", value=type_in))
+    if min_citations is not None:
+        criteria.append(
+            FilterCriterion(field="min_citations", op="gte", value=min_citations)
+        )
+
+    if query is None and not criteria:
+        return []
+
+    matched: list[str] = []
+    for row in rows:
+        if query is not None:
+            title_val = str(row.get(Col.TITLE) or "")
+            if query.lower() not in title_val.lower():
+                continue
+        if not passes_all(row, criteria):
+            continue
+        matched.append(str(row.get(Col.ID)))
+
+    return matched
+
+
+def _has_selector(
+    *,
+    query: str | None,
+    year_gte: int | None,
+    year_lte: int | None,
+    language: list[str] | None,
+    type_in: list[str] | None,
+    min_citations: int | None,
+) -> bool:
+    """``True`` si al menos un criterio de selector fue provisto."""
+    return not (
+        query is None
+        and year_gte is None
+        and year_lte is None
+        and not language
+        and not type_in
+        and min_citations is None
+    )
+
+
 def accept_papers(
     store_path: str | Path,
     ids: list[str],
     *,
     by: str = "api",
     decided_at: datetime | None = None,
+    query: str | None = None,
+    year_gte: int | None = None,
+    year_lte: int | None = None,
+    language: list[str] | None = None,
+    type_in: list[str] | None = None,
+    min_citations: int | None = None,
 ) -> dict[str, Any]:
     """Marca los papers dados como ``accepted`` y persiste.
 
-    Verifica que todos los ids existan en el corpus antes de operar.
+    El conjunto afectado es la UNIÓN de ``ids`` explícitos (resueltos por id
+    interno, DOI o source_id) y los ids que matchean el selector declarativo
+    (``query``/``year_gte``/``year_lte``/``language``/``type_in``/
+    ``min_citations`` — #308). Si no se especifica ningún criterio de
+    selector, el comportamiento es idéntico al previo (solo ``ids``).
+
+    Verifica que todos los ``ids`` explícitos existan en el corpus antes de
+    operar; los ids resueltos por selector nunca fallan por "no encontrado"
+    (se derivan del corpus mismo).
 
     Args:
         store_path: Ruta al archivo ``.duckdb``.
-        ids: Lista de ids a aceptar.
+        ids: Lista de ids a aceptar (puede ser vacía si se usa selector).
         by: Identificador de quien decide (default: ``"api"``).
         decided_at: Timestamp inyectado por el llamador (R2/ADR 0017).
+        query: Substring de título (selector, ver ``select_ids_by_predicate``).
+        year_gte: Selector — año >= valor.
+        year_lte: Selector — año <= valor.
+        language: Selector — códigos de idioma a incluir.
+        type_in: Selector — áreas de investigación a incluir.
+        min_citations: Selector — mínimo de citantes.
 
     Returns:
-        Dict con ``accepted_count``, ``ids``.
+        Dict con ``accepted_count``, ``ids`` (todos los ids afectados,
+        ordenados) y ``selector_matched_count`` (cuántos vinieron del
+        selector, 0 si no se usó).
 
     Raises:
-        DataError: Si la lista está vacía o algún id no existe.
+        DataError: Si no hay ``ids`` ni selector, o algún id explícito no existe.
         StoreError: Si el store está bloqueado.
     """
-    if not ids:
-        raise DataError("Debés especificar al menos un ID.")
+    selector_active = _has_selector(
+        query=query,
+        year_gte=year_gte,
+        year_lte=year_lte,
+        language=language,
+        type_in=type_in,
+        min_citations=min_citations,
+    )
+    if not ids and not selector_active:
+        raise DataError(
+            "Debés especificar al menos un ID (--ids) o un criterio de "
+            "selector (--query, --year-gte, --year-lte, --language, --type, "
+            "--min-citations)."
+        )
 
     path = Path(store_path)
     updated_backend_close = None
@@ -525,15 +654,32 @@ def accept_papers(
         corpus = store.load()
 
         rows = corpus.to_arrow().to_pylist()
-        resolved_ids, missing = resolve_idents(rows, ids)
-        if missing:
-            raise DataError(
-                f"IDs no encontrados en el corpus: {missing}. "
-                "Verificá los ids con 'b2g read list' o 'b2g status'. "
-                "curate acepta id interno, DOI o source_id (igual que 'read show')."
+
+        resolved_ids: list[str] = []
+        if ids:
+            resolved_ids, missing = resolve_idents(rows, ids)
+            if missing:
+                raise DataError(
+                    f"IDs no encontrados en el corpus: {missing}. "
+                    "Verificá los ids con 'b2g read list' o 'b2g status'. "
+                    "curate acepta id interno, DOI o source_id (igual que 'read show')."
+                )
+
+        selector_ids: list[str] = []
+        if selector_active:
+            selector_ids = select_ids_by_predicate(
+                rows,
+                query=query,
+                year_gte=year_gte,
+                year_lte=year_lte,
+                language=language,
+                type_in=type_in,
+                min_citations=min_citations,
             )
 
-        updated = corpus.accept(resolved_ids, by=by, decided_at=decided_at)
+        all_ids = sorted(set(resolved_ids) | set(selector_ids))
+
+        updated = corpus.accept(all_ids, by=by, decided_at=decided_at)
         updated_backend_close = getattr(updated._backend, "close", None)
         store.persist(updated)
     finally:
@@ -542,8 +688,9 @@ def accept_papers(
         store.close()
 
     return {
-        "accepted_count": len(resolved_ids),
-        "ids": resolved_ids,
+        "accepted_count": len(all_ids),
+        "ids": all_ids,
+        "selector_matched_count": len(selector_ids),
     }
 
 
@@ -553,24 +700,56 @@ def reject_papers(
     *,
     by: str = "api",
     decided_at: datetime | None = None,
+    query: str | None = None,
+    year_gte: int | None = None,
+    year_lte: int | None = None,
+    language: list[str] | None = None,
+    type_in: list[str] | None = None,
+    min_citations: int | None = None,
 ) -> dict[str, Any]:
     """Marca los papers dados como ``rejected`` y persiste.
 
+    El conjunto afectado es la UNIÓN de ``ids`` explícitos (resueltos por id
+    interno, DOI o source_id) y los ids que matchean el selector declarativo
+    (``query``/``year_gte``/``year_lte``/``language``/``type_in``/
+    ``min_citations`` — #308). Si no se especifica ningún criterio de
+    selector, el comportamiento es idéntico al previo (solo ``ids``).
+
     Args:
         store_path: Ruta al archivo ``.duckdb``.
-        ids: Lista de ids a rechazar.
+        ids: Lista de ids a rechazar (puede ser vacía si se usa selector).
         by: Identificador de quien decide (default: ``"api"``).
         decided_at: Timestamp inyectado por el llamador (R2/ADR 0017).
+        query: Substring de título (selector, ver ``select_ids_by_predicate``).
+        year_gte: Selector — año >= valor.
+        year_lte: Selector — año <= valor.
+        language: Selector — códigos de idioma a incluir.
+        type_in: Selector — áreas de investigación a incluir.
+        min_citations: Selector — mínimo de citantes.
 
     Returns:
-        Dict con ``rejected_count``, ``ids``.
+        Dict con ``rejected_count``, ``ids`` (todos los ids afectados,
+        ordenados) y ``selector_matched_count`` (cuántos vinieron del
+        selector, 0 si no se usó).
 
     Raises:
-        DataError: Si la lista está vacía o algún id no existe.
+        DataError: Si no hay ``ids`` ni selector, o algún id explícito no existe.
         StoreError: Si el store está bloqueado.
     """
-    if not ids:
-        raise DataError("Debés especificar al menos un ID.")
+    selector_active = _has_selector(
+        query=query,
+        year_gte=year_gte,
+        year_lte=year_lte,
+        language=language,
+        type_in=type_in,
+        min_citations=min_citations,
+    )
+    if not ids and not selector_active:
+        raise DataError(
+            "Debés especificar al menos un ID (--ids) o un criterio de "
+            "selector (--query, --year-gte, --year-lte, --language, --type, "
+            "--min-citations)."
+        )
 
     path = Path(store_path)
     updated_backend_close = None
@@ -579,15 +758,32 @@ def reject_papers(
         corpus = store.load()
 
         rows = corpus.to_arrow().to_pylist()
-        resolved_ids, missing = resolve_idents(rows, ids)
-        if missing:
-            raise DataError(
-                f"IDs no encontrados en el corpus: {missing}. "
-                "Verificá los ids con 'b2g read list' o 'b2g status'. "
-                "curate acepta id interno, DOI o source_id (igual que 'read show')."
+
+        resolved_ids: list[str] = []
+        if ids:
+            resolved_ids, missing = resolve_idents(rows, ids)
+            if missing:
+                raise DataError(
+                    f"IDs no encontrados en el corpus: {missing}. "
+                    "Verificá los ids con 'b2g read list' o 'b2g status'. "
+                    "curate acepta id interno, DOI o source_id (igual que 'read show')."
+                )
+
+        selector_ids: list[str] = []
+        if selector_active:
+            selector_ids = select_ids_by_predicate(
+                rows,
+                query=query,
+                year_gte=year_gte,
+                year_lte=year_lte,
+                language=language,
+                type_in=type_in,
+                min_citations=min_citations,
             )
 
-        updated = corpus.reject(resolved_ids, by=by, decided_at=decided_at)
+        all_ids = sorted(set(resolved_ids) | set(selector_ids))
+
+        updated = corpus.reject(all_ids, by=by, decided_at=decided_at)
         updated_backend_close = getattr(updated._backend, "close", None)
         store.persist(updated)
     finally:
@@ -596,8 +792,9 @@ def reject_papers(
         store.close()
 
     return {
-        "rejected_count": len(resolved_ids),
-        "ids": resolved_ids,
+        "rejected_count": len(all_ids),
+        "ids": all_ids,
+        "selector_matched_count": len(selector_ids),
     }
 
 

--- a/tests/unit/test_curate_selector.py
+++ b/tests/unit/test_curate_selector.py
@@ -1,0 +1,545 @@
+"""Tests de curación masiva declarativa (#308).
+
+``curate accept``/``curate reject`` aceptan, además de ``--ids`` enumerados,
+un SELECTOR declarativo: ``--query`` (substring de título, mismo criterio
+que ``read list --query``) y/o metadata ``--year-gte/lte``, ``--language``,
+``--type``, ``--min-citations`` (misma semántica que ``curate filter``).
+
+Cubre:
+  1. ``select_ids_by_predicate`` (núcleo del selector, service.curate).
+  2. ``accept_papers``/``reject_papers`` con selector (service layer).
+  3. ``curate accept``/``curate reject`` --year-gte/--query (CLI).
+  4. Combinación ``--ids`` + selector → unión.
+  5. ``--ids`` solo sigue funcionando (regresión, ya cubierto en
+     test_curate_grp.py, pero se repite acá el caso límite sin selector).
+  6. Envelope ``--json`` con conteos correctos.
+  7. Sin ``--ids`` ni selector → error de uso (exit 1).
+
+Marcador: ``unit`` (DuckDB en tmp_path, sin red real).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pyarrow as pa
+import pytest
+from click.testing import CliRunner
+
+from bib2graph.cli import b2g
+from bib2graph.schemas import CORPUS_SCHEMA
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Helpers compartidos (mismo molde que test_curate_grp.py)
+# ---------------------------------------------------------------------------
+
+
+def _row(
+    *,
+    id: str,
+    title: str = "Título de prueba",
+    year: int = 2020,
+    is_seed: bool = False,
+    curation_status: str = "candidate",
+    language: str = "en",
+    cited_by_id: list[str] | None = None,
+) -> dict[str, Any]:
+    """Fila mínima con schema completo para tests, con año/status variados."""
+    return {
+        "id": id,
+        "source_id": None,
+        "doi": None,
+        "title": title,
+        "year": year,
+        "abstract": None,
+        "source": None,
+        "language": language,
+        "publisher": None,
+        "research_areas": None,
+        "is_seed": is_seed,
+        "curation_status": curation_status,
+        "provenance": None,
+        "authors_raw": None,
+        "authors_id": None,
+        "authors_affiliations": None,
+        "keywords_raw": None,
+        "keywords_id": None,
+        "institutions_raw": None,
+        "institutions_id": None,
+        "references_id": None,
+        "references_doi": None,
+        "cited_by_id": cited_by_id,
+    }
+
+
+def _init_workspace(tmp_path: Path, name: str = "test-ws") -> Any:
+    """Crea y devuelve un Workspace inicializado en tmp_path."""
+    from bib2graph.workspace import Workspace
+
+    ws_dir = tmp_path / name
+    return Workspace.init(ws_dir, name)
+
+
+def _seed_store(ws: Any, rows: list[dict[str, Any]]) -> None:
+    """Persiste filas en el store del workspace."""
+    from bib2graph.corpus import Corpus
+    from bib2graph.stores.duckdb import DuckDBStore
+
+    table = pa.Table.from_pylist(rows, schema=CORPUS_SCHEMA)
+    corpus = Corpus.from_arrow(table)
+    store = DuckDBStore(ws.library_path)
+    store.persist(corpus)
+    store.close()
+
+
+def _status_by_id(ws: Any) -> dict[str, str]:
+    """Lee curation_status por id desde el store."""
+    from bib2graph.stores.duckdb import DuckDBStore
+
+    store = DuckDBStore(ws.library_path)
+    corpus = store.load()
+    by_id = {
+        str(r["id"]): str(r["curation_status"]) for r in corpus.to_arrow().to_pylist()
+    }
+    store.close()
+    return by_id
+
+
+# Corpus de prueba con años/status/títulos variados (fixture compartida).
+def _mixed_corpus_rows() -> list[dict[str, Any]]:
+    return [
+        _row(id="P2010", title="Old paper on unrelated topic", year=2010),
+        _row(id="P2015", title="Erratum: correction notice", year=2015),
+        _row(id="P2018", title="A study on unequal exchange", year=2018),
+        _row(id="P2020", title="Recent advances in ecology", year=2020),
+        _row(
+            id="P2022ACC",
+            title="Already accepted paper",
+            year=2022,
+            curation_status="accepted",
+        ),
+        _row(
+            id="P2023REJ",
+            title="Already rejected paper",
+            year=2023,
+            curation_status="rejected",
+        ),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# 1. select_ids_by_predicate — núcleo del selector (service layer, sin CLI)
+# ---------------------------------------------------------------------------
+
+
+def test_select_ids_by_predicate_year_gte() -> None:
+    """select_ids_by_predicate con year_gte devuelve solo los ids >= el año."""
+    from bib2graph.service.curate import select_ids_by_predicate
+
+    rows = _mixed_corpus_rows()
+    matched = select_ids_by_predicate(rows, year_gte=2018)
+
+    assert set(matched) == {"P2018", "P2020", "P2022ACC", "P2023REJ"}
+
+
+def test_select_ids_by_predicate_query() -> None:
+    """select_ids_by_predicate con query matchea substring case-insensitive en título."""
+    from bib2graph.service.curate import select_ids_by_predicate
+
+    rows = _mixed_corpus_rows()
+    matched = select_ids_by_predicate(rows, query="ERRATUM")
+
+    assert matched == ["P2015"]
+
+
+def test_select_ids_by_predicate_query_y_year_and_logico() -> None:
+    """query + year_gte se combinan con AND lógico."""
+    from bib2graph.service.curate import select_ids_by_predicate
+
+    rows = _mixed_corpus_rows()
+    matched = select_ids_by_predicate(rows, query="paper", year_gte=2020)
+
+    # "paper" está en "Old paper..." (2010, excluido por year), "Already accepted
+    # paper" (2022) y "Already rejected paper" (2023).
+    assert set(matched) == {"P2022ACC", "P2023REJ"}
+
+
+def test_select_ids_by_predicate_sin_criterios_devuelve_vacio() -> None:
+    """Sin ningún criterio, select_ids_by_predicate no selecciona nada implícito."""
+    from bib2graph.service.curate import select_ids_by_predicate
+
+    rows = _mixed_corpus_rows()
+    matched = select_ids_by_predicate(rows)
+
+    assert matched == []
+
+
+def test_select_ids_by_predicate_min_citations() -> None:
+    """select_ids_by_predicate con min_citations usa len(cited_by_id) (misma semántica que filter)."""
+    from bib2graph.service.curate import select_ids_by_predicate
+
+    rows = [
+        _row(id="LOW", cited_by_id=["A"]),
+        _row(id="HIGH", cited_by_id=["A", "B", "C"]),
+    ]
+    matched = select_ids_by_predicate(rows, min_citations=2)
+
+    assert matched == ["HIGH"]
+
+
+# ---------------------------------------------------------------------------
+# 2. accept_papers/reject_papers con selector (service layer)
+# ---------------------------------------------------------------------------
+
+
+def test_accept_papers_con_selector_year_gte(tmp_path: Path) -> None:
+    """accept_papers con year_gte marca accepted solo los papers >= el año."""
+    from bib2graph.service.curate import accept_papers
+
+    ws = _init_workspace(tmp_path)
+    _seed_store(ws, _mixed_corpus_rows())
+
+    data = accept_papers(ws.library_path, [], year_gte=2018)
+
+    assert data["accepted_count"] == 4  # P2018, P2020, P2022ACC (ya accepted), P2023REJ
+    statuses = _status_by_id(ws)
+    assert statuses["P2010"] == "candidate"
+    assert statuses["P2015"] == "candidate"
+    assert statuses["P2018"] == "accepted"
+    assert statuses["P2020"] == "accepted"
+    assert statuses["P2022ACC"] == "accepted"
+    assert (
+        statuses["P2023REJ"] == "accepted"
+    )  # accept por selector SÍ puede revertir reject
+
+
+def test_reject_papers_con_selector_query(tmp_path: Path) -> None:
+    """reject_papers con query marca rejected los papers que matchean el título."""
+    from bib2graph.service.curate import reject_papers
+
+    ws = _init_workspace(tmp_path)
+    _seed_store(ws, _mixed_corpus_rows())
+
+    data = reject_papers(ws.library_path, [], query="erratum")
+
+    assert data["rejected_count"] == 1
+    statuses = _status_by_id(ws)
+    assert statuses["P2015"] == "rejected"
+    assert statuses["P2010"] == "candidate"
+
+
+def test_accept_papers_combina_ids_y_selector_union(tmp_path: Path) -> None:
+    """accept_papers con --ids + selector afecta la UNIÓN (no intersección)."""
+    from bib2graph.service.curate import accept_papers
+
+    ws = _init_workspace(tmp_path)
+    _seed_store(ws, _mixed_corpus_rows())
+
+    # --ids P2010 (no matchea selector) + selector year_gte=2020 (P2020, P2022ACC, P2023REJ)
+    data = accept_papers(ws.library_path, ["P2010"], year_gte=2020)
+
+    statuses = _status_by_id(ws)
+    assert statuses["P2010"] == "accepted"  # vino de --ids
+    assert statuses["P2020"] == "accepted"  # vino del selector
+    assert statuses["P2022ACC"] == "accepted"
+    assert statuses["P2023REJ"] == "accepted"
+    assert statuses["P2015"] == "candidate"  # no matchea ninguno de los dos
+    assert data["accepted_count"] == 4
+    assert data["selector_matched_count"] == 3
+
+
+def test_accept_papers_solo_ids_sin_selector_comportamiento_previo(
+    tmp_path: Path,
+) -> None:
+    """accept_papers sin ningún criterio de selector se comporta como antes (solo --ids)."""
+    from bib2graph.service.curate import accept_papers
+
+    ws = _init_workspace(tmp_path)
+    _seed_store(ws, [_row(id="P1"), _row(id="P2")])
+
+    data = accept_papers(ws.library_path, ["P1"])
+
+    assert data["accepted_count"] == 1
+    assert data["selector_matched_count"] == 0
+    statuses = _status_by_id(ws)
+    assert statuses["P1"] == "accepted"
+    assert statuses["P2"] == "candidate"
+
+
+def test_accept_papers_sin_ids_ni_selector_lanza_data_error(tmp_path: Path) -> None:
+    """accept_papers sin --ids ni selector lanza DataError (exit 1 vía UsageError en CLI)."""
+    from bib2graph.service.curate import accept_papers
+    from bib2graph.service.errors import DataError
+
+    ws = _init_workspace(tmp_path)
+    _seed_store(ws, [_row(id="P1")])
+
+    with pytest.raises(DataError):
+        accept_papers(ws.library_path, [])
+
+
+def test_reject_papers_sin_ids_ni_selector_lanza_data_error(tmp_path: Path) -> None:
+    """reject_papers sin --ids ni selector lanza DataError."""
+    from bib2graph.service.curate import reject_papers
+    from bib2graph.service.errors import DataError
+
+    ws = _init_workspace(tmp_path)
+    _seed_store(ws, [_row(id="P1")])
+
+    with pytest.raises(DataError):
+        reject_papers(ws.library_path, [])
+
+
+# ---------------------------------------------------------------------------
+# 3. curate accept/reject --year-gte / --query (CLI, exit 0)
+# ---------------------------------------------------------------------------
+
+
+def test_cli_curate_accept_year_gte(tmp_path: Path) -> None:
+    """b2g curate accept --year-gte 2015 marca accepted solo los >= 2015."""
+    ws = _init_workspace(tmp_path)
+    _seed_store(ws, _mixed_corpus_rows())
+
+    runner = CliRunner()
+    result = runner.invoke(
+        b2g,
+        ["--workspace", str(ws.root), "curate", "accept", "--year-gte", "2015"],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
+
+    statuses = _status_by_id(ws)
+    assert statuses["P2010"] == "candidate"
+    assert statuses["P2015"] == "accepted"
+    assert statuses["P2018"] == "accepted"
+    assert statuses["P2020"] == "accepted"
+
+
+def test_cli_curate_reject_query(tmp_path: Path) -> None:
+    """b2g curate reject --query "erratum" rechaza los que matchean el título."""
+    ws = _init_workspace(tmp_path)
+    _seed_store(ws, _mixed_corpus_rows())
+
+    runner = CliRunner()
+    result = runner.invoke(
+        b2g,
+        ["--workspace", str(ws.root), "curate", "reject", "--query", "erratum"],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
+
+    statuses = _status_by_id(ws)
+    assert statuses["P2015"] == "rejected"
+    assert statuses["P2010"] == "candidate"
+
+
+def test_cli_curate_accept_combina_ids_y_year_lte(tmp_path: Path) -> None:
+    """b2g curate accept --ids + --year-lte combina ids explícitos y selector."""
+    ws = _init_workspace(tmp_path)
+    _seed_store(ws, _mixed_corpus_rows())
+
+    runner = CliRunner()
+    result = runner.invoke(
+        b2g,
+        [
+            "--workspace",
+            str(ws.root),
+            "curate",
+            "accept",
+            "--ids",
+            "P2020",
+            "--year-lte",
+            "2010",
+        ],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
+
+    statuses = _status_by_id(ws)
+    assert statuses["P2010"] == "accepted"  # selector year_lte=2010
+    assert statuses["P2020"] == "accepted"  # --ids explícito
+
+
+def test_cli_curate_accept_min_citations_y_type_y_language(tmp_path: Path) -> None:
+    """b2g curate accept combina --min-citations, --language y --type (repetibles)."""
+    ws = _init_workspace(tmp_path)
+    rows = [
+        _row(id="EN_HIGH", language="en", cited_by_id=["A", "B", "C"]),
+        _row(id="EN_LOW", language="en", cited_by_id=["A"]),
+        _row(id="ES_HIGH", language="es", cited_by_id=["A", "B", "C"]),
+    ]
+    _seed_store(ws, rows)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        b2g,
+        [
+            "--workspace",
+            str(ws.root),
+            "curate",
+            "accept",
+            "--language",
+            "en",
+            "--min-citations",
+            "2",
+        ],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
+
+    statuses = _status_by_id(ws)
+    assert statuses["EN_HIGH"] == "accepted"
+    assert statuses["EN_LOW"] == "candidate"
+    assert statuses["ES_HIGH"] == "candidate"
+
+
+# ---------------------------------------------------------------------------
+# 4. Sin --ids ni selector → error de uso (exit != 0)
+# ---------------------------------------------------------------------------
+
+
+def test_cli_curate_accept_sin_ids_ni_selector_falla(tmp_path: Path) -> None:
+    """b2g curate accept sin --ids ni selector falla con exit != 0."""
+    ws = _init_workspace(tmp_path)
+    _seed_store(ws, [_row(id="P1")])
+
+    runner = CliRunner()
+    result = runner.invoke(
+        b2g,
+        ["--workspace", str(ws.root), "curate", "accept"],
+    )
+    assert result.exit_code != 0
+
+
+def test_cli_curate_reject_sin_ids_ni_selector_falla(tmp_path: Path) -> None:
+    """b2g curate reject sin --ids ni selector falla con exit != 0."""
+    ws = _init_workspace(tmp_path)
+    _seed_store(ws, [_row(id="P1")])
+
+    runner = CliRunner()
+    result = runner.invoke(
+        b2g,
+        ["--workspace", str(ws.root), "curate", "reject"],
+    )
+    assert result.exit_code != 0
+
+
+# ---------------------------------------------------------------------------
+# 5. --ids solo sigue funcionando (regresión explícita del selector nuevo)
+# ---------------------------------------------------------------------------
+
+
+def test_cli_curate_accept_solo_ids_sigue_funcionando(tmp_path: Path) -> None:
+    """b2g curate accept --ids (sin ningún flag de selector) sigue funcionando igual."""
+    ws = _init_workspace(tmp_path)
+    _seed_store(ws, [_row(id="P1"), _row(id="P2")])
+
+    runner = CliRunner()
+    result = runner.invoke(
+        b2g,
+        ["--workspace", str(ws.root), "curate", "accept", "--ids", "P1", "--json"],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+    data = json.loads(result.stdout.strip())
+    assert data["data"]["accepted_count"] == 1
+    assert data["data"]["selector_matched_count"] == 0
+
+    statuses = _status_by_id(ws)
+    assert statuses["P1"] == "accepted"
+    assert statuses["P2"] == "candidate"
+
+
+# ---------------------------------------------------------------------------
+# 6. Envelope --json con conteos correctos
+# ---------------------------------------------------------------------------
+
+
+def test_cli_curate_accept_json_envelope_conteos(tmp_path: Path) -> None:
+    """curate accept --year-gte --json reporta accepted_count y selector_matched_count."""
+    ws = _init_workspace(tmp_path)
+    _seed_store(ws, _mixed_corpus_rows())
+
+    runner = CliRunner()
+    result = runner.invoke(
+        b2g,
+        [
+            "--workspace",
+            str(ws.root),
+            "curate",
+            "accept",
+            "--year-gte",
+            "2020",
+            "--json",
+        ],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
+    lines = [ln for ln in result.stdout.splitlines() if ln.strip()]
+    assert len(lines) == 1
+    data = json.loads(lines[0])
+    assert data["ok"] is True
+    assert data["command"] == "curate accept"
+    assert data["data"]["accepted_count"] == 3  # P2020, P2022ACC, P2023REJ
+    assert data["data"]["selector_matched_count"] == 3
+    assert sorted(data["data"]["ids"]) == ["P2020", "P2022ACC", "P2023REJ"]
+
+
+def test_cli_curate_reject_json_envelope_conteos(tmp_path: Path) -> None:
+    """curate reject --query --json reporta rejected_count correcto."""
+    ws = _init_workspace(tmp_path)
+    _seed_store(ws, _mixed_corpus_rows())
+
+    runner = CliRunner()
+    result = runner.invoke(
+        b2g,
+        [
+            "--workspace",
+            str(ws.root),
+            "curate",
+            "reject",
+            "--query",
+            "unequal exchange",
+            "--json",
+        ],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.stdout.strip())
+    assert data["data"]["rejected_count"] == 1
+    assert data["data"]["ids"] == ["P2018"]
+
+
+# ---------------------------------------------------------------------------
+# 7. curate accept/reject por selector NO transiciona el CycleState
+# ---------------------------------------------------------------------------
+
+
+def test_cli_curate_accept_selector_no_transiciona_fsm(tmp_path: Path) -> None:
+    """curate accept por selector es transversal: no transiciona el CycleState."""
+    from bib2graph.stores.duckdb import DuckDBStore
+
+    ws = _init_workspace(tmp_path)
+    _seed_store(ws, _mixed_corpus_rows())
+
+    store = DuckDBStore(ws.library_path)
+    estado_previo = store.backend.loop_state()
+    store.close()
+
+    runner = CliRunner()
+    runner.invoke(
+        b2g,
+        ["--workspace", str(ws.root), "curate", "accept", "--year-gte", "2018"],
+        catch_exceptions=False,
+    )
+
+    store = DuckDBStore(ws.library_path)
+    estado_post = store.backend.loop_state()
+    store.close()
+
+    assert estado_post == estado_previo


### PR DESCRIPTION
Cierra #308 (opción (a) del DoD).

## Qué
`curate accept`/`curate reject` aceptan, además de `--ids`, un **selector declarativo**:
`--query` (título, como `read list`), `--year-gte/--year-lte`, `--language` (repetible), `--type` (repetible), `--min-citations` (semántica de `curate filter`). Todos los criterios se combinan en AND.

- Conjunto afectado = **UNIÓN** de `--ids` + los que matchean el selector. `--ids` solo → sin regresión; selector solo → masivo. Sin nada → error de uso.
- `curate accept` por selector **puede revertir un `rejected`** (semántica natural de "aceptar lo que matchea"; distinto de `filter` que nunca toca `accepted`, ADR 0044) — documentado.
- Envelope gana `selector_matched_count`. NO transiciona FSM.
- DRY: reusa `read list --query` y `filters.prisma` (nueva `passes_all`).

21 tests nuevos (`test_curate_selector.py`).

## Docs (architect)
`docs/API.md`: flags nuevos de `curate accept/reject`, `--ids` ya no `required`, `selector_matched_count`. Nota de la semántica accept-revierte-rejected.